### PR TITLE
feat: add sentry example page for error verification

### DIFF
--- a/src/app/api/sentry-example-api/route.ts
+++ b/src/app/api/sentry-example-api/route.ts
@@ -1,6 +1,3 @@
-import { NextResponse } from "next/server";
-
 export function GET() {
   throw new Error("Sentry Example API Route Error");
-  return NextResponse.json({ data: "Testing Sentry Error..." });
 }

--- a/src/app/sentry-example-page/page.tsx
+++ b/src/app/sentry-example-page/page.tsx
@@ -22,12 +22,16 @@ export default function SentryExamplePage() {
         type="button"
         className="rounded bg-orange-600 px-4 py-2 text-white hover:bg-orange-700"
         onClick={async () => {
-          await Sentry.startSpan({ name: "Example Frontend Span", op: "test" }, async () => {
-            const response = await fetch("/api/sentry-example-api");
-            if (!response.ok) {
-              throw new Error("Sentry Example API Route Error");
-            }
-          });
+          try {
+            await Sentry.startSpan({ name: "Example Frontend Span", op: "test" }, async () => {
+              const response = await fetch("/api/sentry-example-api");
+              if (!response.ok) {
+                throw new Error("Sentry Example API Response Error");
+              }
+            });
+          } catch (err) {
+            Sentry.captureException(err);
+          }
         }}
       >
         Throw API Error


### PR DESCRIPTION
## Summary
- Add `/sentry-example-page` with buttons to trigger client-side and API route errors
- Add `/api/sentry-example-api` route that throws a test error
- Enables quick verification that Sentry is capturing errors correctly

## Test plan
- [ ] Visit `/sentry-example-page` and confirm it loads
- [ ] Click "Throw Client Error" and verify the error appears in Sentry dashboard
- [ ] Click "Throw API Error" and verify the server-side error appears in Sentry dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added an example page for testing error monitoring and tracking functionality
- Included interactive buttons to trigger client-side and API error scenarios for testing purposes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->