### PR TITLE
fix: complete sentry integration with instrumentation and error boundary

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,13 @@
+import * as Sentry from "@sentry/nextjs";
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config");
+  }
+
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("./sentry.edge.config");
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError;

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -6,5 +6,5 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   integrations: [Sentry.replayIntegration()],
-  debug: false,
+  debug: process.env.NODE_ENV === "development",
 });

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <h2>Something went wrong!</h2>
+        <button type="button" onClick={() => reset()}>
+          Try again
+        </button>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `instrumentation.ts` to register Sentry server/edge configs at Next.js startup and export `onRequestError` for server component error capture
- Add `src/app/global-error.tsx` as an App Router error boundary that reports unhandled client errors to Sentry
- Enable Sentry debug logging in development for easier verification

Without these files, Sentry was initialized on the client but never on the server/edge, and unhandled errors had no boundary to catch and report them.

## Test plan
- [ ] Create `.env.local` with valid `NEXT_PUBLIC_SENTRY_DSN`
- [ ] Run `pnpm dev` and visit `/sentry-example-page`
- [ ] Click "Throw Client Error" — verify error appears in Sentry dashboard
- [ ] Click "Throw API Error" — verify server error appears in Sentry dashboard
- [ ] Check browser console for Sentry debug logs in development

🤖 Generated with [Claude Code](https://claude.com/claude-code)