### PR TITLE
feat: add attachment management — list, delete, cascade (Phase 5.3)

### DIFF
--- a/__tests__/unit/attachments-delete-api.test.ts
+++ b/__tests__/unit/attachments-delete-api.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-key",
+  },
+}));
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+const mockStorageFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+    storage: { from: mockStorageFrom },
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({
+    getAll: () => [],
+    set: vi.fn(),
+  }),
+}));
+
+function authenticateAs(userId: string) {
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: userId, email: "test@test.com" } },
+    error: null,
+  });
+}
+
+const params = Promise.resolve({ id: "att-1" });
+
+describe("DELETE /api/attachments/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: "Not auth" },
+    });
+
+    const { DELETE } = await import("@/app/api/attachments/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/attachments/att-1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, { params });
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when attachment does not exist", async () => {
+    authenticateAs("user-1");
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: null, error: { message: "Not found" } }),
+          }),
+        }),
+      }),
+    });
+
+    const { DELETE } = await import("@/app/api/attachments/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/attachments/att-1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, { params });
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Attachment not found");
+  });
+
+  it("deletes attachment from storage and database", async () => {
+    authenticateAs("user-1");
+    const mockRemove = vi.fn().mockResolvedValue({ error: null });
+    const mockDeleteEq = vi.fn().mockResolvedValue({ error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "attachments") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: { id: "att-1", file_path: "user-1/note-1/image.png" },
+                    error: null,
+                  }),
+              }),
+            }),
+          }),
+          delete: () => ({
+            eq: mockDeleteEq,
+          }),
+        };
+      }
+      return {};
+    });
+
+    mockStorageFrom.mockReturnValue({
+      remove: mockRemove,
+    });
+
+    const { DELETE } = await import("@/app/api/attachments/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/attachments/att-1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, { params });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(mockRemove).toHaveBeenCalledWith(["user-1/note-1/image.png"]);
+    expect(mockDeleteEq).toHaveBeenCalledWith("id", "att-1");
+  });
+
+  it("returns 500 when storage deletion fails", async () => {
+    authenticateAs("user-1");
+
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            single: () =>
+              Promise.resolve({
+                data: { id: "att-1", file_path: "user-1/note-1/image.png" },
+                error: null,
+              }),
+          }),
+        }),
+      }),
+    });
+
+    mockStorageFrom.mockReturnValue({
+      remove: vi.fn().mockResolvedValue({ error: { message: "Storage error" } }),
+    });
+
+    const { DELETE } = await import("@/app/api/attachments/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/attachments/att-1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, { params });
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe("Failed to delete file from storage");
+  });
+
+  it("returns 500 when database deletion fails", async () => {
+    authenticateAs("user-1");
+    const mockDeleteEq = vi.fn().mockResolvedValue({ error: { message: "DB error" } });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "attachments") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: { id: "att-1", file_path: "user-1/note-1/image.png" },
+                    error: null,
+                  }),
+              }),
+            }),
+          }),
+          delete: () => ({
+            eq: mockDeleteEq,
+          }),
+        };
+      }
+      return {};
+    });
+
+    mockStorageFrom.mockReturnValue({
+      remove: vi.fn().mockResolvedValue({ error: null }),
+    });
+
+    const { DELETE } = await import("@/app/api/attachments/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/attachments/att-1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, { params });
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe("Failed to delete attachment record");
+  });
+});

--- a/__tests__/unit/attachments-list-api.test.ts
+++ b/__tests__/unit/attachments-list-api.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-key",
+  },
+}));
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({
+    getAll: () => [],
+    set: vi.fn(),
+  }),
+}));
+
+function authenticateAs(userId: string) {
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: userId, email: "test@test.com" } },
+    error: null,
+  });
+}
+
+const params = Promise.resolve({ id: "note-1" });
+
+describe("GET /api/notes/[id]/attachments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: "Not auth" },
+    });
+
+    const { GET } = await import("@/app/api/notes/[id]/attachments/route");
+    const request = new NextRequest("http://localhost:3000/api/notes/note-1/attachments");
+    const response = await GET(request, { params });
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when note does not exist", async () => {
+    authenticateAs("user-1");
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: null, error: { message: "Not found" } }),
+          }),
+        }),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/notes/[id]/attachments/route");
+    const request = new NextRequest("http://localhost:3000/api/notes/note-1/attachments");
+    const response = await GET(request, { params });
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Note not found");
+  });
+
+  it("returns attachments for a note", async () => {
+    authenticateAs("user-1");
+    const attachmentList = [
+      {
+        id: "att-1",
+        note_id: "note-1",
+        user_id: "user-1",
+        file_name: "image.png",
+        file_path: "user-1/note-1/image.png",
+        file_size: 1024,
+        mime_type: "image/png",
+        created_at: "2026-03-02T00:00:00Z",
+      },
+      {
+        id: "att-2",
+        note_id: "note-1",
+        user_id: "user-1",
+        file_name: "doc.pdf",
+        file_path: "user-1/note-1/doc.pdf",
+        file_size: 2048,
+        mime_type: "application/pdf",
+        created_at: "2026-03-01T00:00:00Z",
+      },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "notes") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: { id: "note-1" }, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "attachments") {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => Promise.resolve({ data: attachmentList, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const { GET } = await import("@/app/api/notes/[id]/attachments/route");
+    const request = new NextRequest("http://localhost:3000/api/notes/note-1/attachments");
+    const response = await GET(request, { params });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(2);
+    expect(body[0].file_name).toBe("image.png");
+    expect(body[1].file_name).toBe("doc.pdf");
+  });
+
+  it("returns empty array when note has no attachments", async () => {
+    authenticateAs("user-1");
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "notes") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: { id: "note-1" }, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "attachments") {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => Promise.resolve({ data: [], error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const { GET } = await import("@/app/api/notes/[id]/attachments/route");
+    const request = new NextRequest("http://localhost:3000/api/notes/note-1/attachments");
+    const response = await GET(request, { params });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(0);
+  });
+
+  it("returns 500 on database error", async () => {
+    authenticateAs("user-1");
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "notes") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: { id: "note-1" }, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "attachments") {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => Promise.resolve({ data: null, error: { message: "DB error" } }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const { GET } = await import("@/app/api/notes/[id]/attachments/route");
+    const request = new NextRequest("http://localhost:3000/api/notes/note-1/attachments");
+    const response = await GET(request, { params });
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe("Failed to fetch attachments");
+  });
+});

--- a/__tests__/unit/trash-api.test.ts
+++ b/__tests__/unit/trash-api.test.ts
@@ -10,11 +10,13 @@ vi.mock("@/env", () => ({
 
 const mockGetUser = vi.fn();
 const mockFrom = vi.fn();
+const mockStorageFrom = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: () => ({
     auth: { getUser: mockGetUser },
     from: mockFrom,
+    storage: { from: mockStorageFrom },
   }),
 }));
 
@@ -103,18 +105,33 @@ describe("Trash API", () => {
 
     it("returns 404 when note not found or not trashed", async () => {
       authenticateAs("user-1");
-      mockFrom.mockReturnValue({
-        delete: () => ({
-          eq: () => ({
-            eq: () => ({
+      mockFrom.mockImplementation((table: string) => {
+        if (table === "attachments") {
+          return {
+            select: () => ({
               eq: () => ({
-                select: () => ({
-                  single: () => Promise.resolve({ data: null, error: { message: "Not found" } }),
+                eq: () => Promise.resolve({ data: [], error: null }),
+              }),
+            }),
+          };
+        }
+        if (table === "notes") {
+          return {
+            delete: () => ({
+              eq: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    select: () => ({
+                      single: () =>
+                        Promise.resolve({ data: null, error: { message: "Not found" } }),
+                    }),
+                  }),
                 }),
               }),
             }),
-          }),
-        }),
+          };
+        }
+        return {};
       });
 
       const { DELETE } = await import("@/app/api/notes/[id]/permanent/route");
@@ -125,20 +142,44 @@ describe("Trash API", () => {
       expect(response.status).toBe(404);
     });
 
-    it("permanently deletes a trashed note atomically", async () => {
+    it("permanently deletes a trashed note and cleans up storage", async () => {
       authenticateAs("user-1");
-      mockFrom.mockReturnValue({
-        delete: () => ({
-          eq: () => ({
-            eq: () => ({
+      const mockRemove = vi.fn().mockResolvedValue({ error: null });
+      mockStorageFrom.mockReturnValue({ remove: mockRemove });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === "attachments") {
+          return {
+            select: () => ({
               eq: () => ({
-                select: () => ({
-                  single: () => Promise.resolve({ data: { id: "note-1" }, error: null }),
+                eq: () =>
+                  Promise.resolve({
+                    data: [
+                      { file_path: "user-1/note-1/image.png" },
+                      { file_path: "user-1/note-1/doc.pdf" },
+                    ],
+                    error: null,
+                  }),
+              }),
+            }),
+          };
+        }
+        if (table === "notes") {
+          return {
+            delete: () => ({
+              eq: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    select: () => ({
+                      single: () => Promise.resolve({ data: { id: "note-1" }, error: null }),
+                    }),
+                  }),
                 }),
               }),
             }),
-          }),
-        }),
+          };
+        }
+        return {};
       });
 
       const { DELETE } = await import("@/app/api/notes/[id]/permanent/route");
@@ -147,6 +188,49 @@ describe("Trash API", () => {
       });
       const response = await DELETE(request, { params });
       expect(response.status).toBe(200);
+      expect(mockRemove).toHaveBeenCalledWith(["user-1/note-1/image.png", "user-1/note-1/doc.pdf"]);
+    });
+
+    it("permanently deletes a trashed note with no attachments", async () => {
+      authenticateAs("user-1");
+      const mockRemove = vi.fn();
+      mockStorageFrom.mockReturnValue({ remove: mockRemove });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === "attachments") {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => Promise.resolve({ data: [], error: null }),
+              }),
+            }),
+          };
+        }
+        if (table === "notes") {
+          return {
+            delete: () => ({
+              eq: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    select: () => ({
+                      single: () => Promise.resolve({ data: { id: "note-1" }, error: null }),
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        return {};
+      });
+
+      const { DELETE } = await import("@/app/api/notes/[id]/permanent/route");
+      const request = new NextRequest("http://localhost:3000/api/notes/note-1/permanent", {
+        method: "DELETE",
+      });
+      const response = await DELETE(request, { params });
+      expect(response.status).toBe(200);
+      expect(mockRemove).not.toHaveBeenCalled();
     });
   });
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -74,7 +74,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 - [x] 5.1 — Supabase Storage bucket + policies
 - [x] 5.2a — Upload API route (25MB limit, auth) + unit tests
 - [x] 5.2b — Editor file integration (inline images, download links) + tests
-- [ ] 5.3 — Attachment management (list, delete, cascade) + tests
+- [x] 5.3 — Attachment management (list, delete, cascade) + tests
 - [ ] 5-CP — **Checkpoint**: Run full suite locally. If green, check this off, commit, and exit.
 - [ ] 5-PUSH — **Push**: Run `/push` to PR. Address any review comments/failures automatically. Once `/push` succeeds, check this off and exit.
 

--- a/src/app/api/attachments/[id]/route.ts
+++ b/src/app/api/attachments/[id]/route.ts
@@ -1,0 +1,46 @@
+import type { NextRequest } from "next/server";
+import { getAuthenticatedUser, errorResponse, successResponse } from "@/lib/api/utils";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+const BUCKET_NAME = "attachments";
+
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const { data: auth, error: authError } = await getAuthenticatedUser();
+  if (authError) return authError;
+
+  const { supabase, user } = auth;
+  const { id: attachmentId } = await params;
+
+  // Fetch the attachment to get the file path (and verify ownership)
+  const { data: attachment, error: fetchError } = await supabase
+    .from("attachments")
+    .select("id, file_path")
+    .eq("id", attachmentId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (fetchError || !attachment) {
+    return errorResponse("Attachment not found", 404);
+  }
+
+  // Remove from storage
+  const { error: storageError } = await supabase.storage
+    .from(BUCKET_NAME)
+    .remove([attachment.file_path]);
+
+  if (storageError) {
+    return errorResponse("Failed to delete file from storage", 500);
+  }
+
+  // Delete the database record
+  const { error: dbError } = await supabase.from("attachments").delete().eq("id", attachmentId);
+
+  if (dbError) {
+    return errorResponse("Failed to delete attachment record", 500);
+  }
+
+  return successResponse({ success: true });
+}

--- a/src/app/api/notes/[id]/attachments/route.ts
+++ b/src/app/api/notes/[id]/attachments/route.ts
@@ -8,6 +8,38 @@ interface RouteParams {
 const MAX_FILE_SIZE = 26214400; // 25MB in bytes
 const BUCKET_NAME = "attachments";
 
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const { data: auth, error: authError } = await getAuthenticatedUser();
+  if (authError) return authError;
+
+  const { supabase, user } = auth;
+  const { id: noteId } = await params;
+
+  // Verify the note exists and belongs to the user
+  const { data: note, error: noteError } = await supabase
+    .from("notes")
+    .select("id")
+    .eq("id", noteId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (noteError || !note) {
+    return errorResponse("Note not found", 404);
+  }
+
+  const { data: attachments, error } = await supabase
+    .from("attachments")
+    .select("id, note_id, user_id, file_name, file_path, file_size, mime_type, created_at")
+    .eq("note_id", noteId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return errorResponse("Failed to fetch attachments", 500);
+  }
+
+  return successResponse(attachments);
+}
+
 export async function POST(request: NextRequest, { params }: RouteParams) {
   const { data: auth, error: authError } = await getAuthenticatedUser();
   if (authError) return authError;

--- a/src/app/api/notes/[id]/permanent/route.ts
+++ b/src/app/api/notes/[id]/permanent/route.ts
@@ -5,6 +5,8 @@ interface RouteParams {
   params: Promise<{ id: string }>;
 }
 
+const BUCKET_NAME = "attachments";
+
 export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   const { data: auth, error: authError } = await getAuthenticatedUser();
   if (authError) return authError;
@@ -12,7 +14,15 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   const { supabase, user } = auth;
   const { id } = await params;
 
+  // Fetch attachment file paths before deleting the note (cascade will remove DB rows)
+  const { data: attachments } = await supabase
+    .from("attachments")
+    .select("file_path")
+    .eq("note_id", id)
+    .eq("user_id", user.id);
+
   // Atomic delete: only deletes if note exists, belongs to user, AND is trashed
+  // CASCADE will automatically delete attachment DB records
   const { data, error } = await supabase
     .from("notes")
     .delete()
@@ -24,6 +34,12 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
 
   if (error || !data) {
     return errorResponse("Note not found or not in trash", 404);
+  }
+
+  // Clean up storage files (best-effort — DB records already cascaded)
+  if (attachments && attachments.length > 0) {
+    const filePaths = attachments.map((a) => a.file_path);
+    await supabase.storage.from(BUCKET_NAME).remove(filePaths);
   }
 
   return successResponse({ success: true });


### PR DESCRIPTION
## Summary
- Add `GET /api/notes/[id]/attachments` endpoint to list attachments for a note
- Add `DELETE /api/attachments/[id]` endpoint to delete an attachment (removes from both Supabase Storage and database)
- Update `DELETE /api/notes/[id]/permanent` to cascade-delete storage files when permanently deleting a trashed note
- Add comprehensive unit tests for all new/modified endpoints

## Test plan
- [x] Unit tests for list attachments API (5 tests: auth, not found, success, empty, DB error)
- [x] Unit tests for delete attachment API (5 tests: auth, not found, success, storage error, DB error)
- [x] Updated permanent delete tests (cascade cleanup with attachments, without attachments, not found)
- [x] All 199 unit/integration tests passing
- [x] Lint: 0 errors
- [x] TypeScript: clean (tsc --noEmit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)