### PR TITLE
feat: refine desktop layout proportions (Phase 6.1)

### DIFF
--- a/src/components/notes/note-editor-panel.tsx
+++ b/src/components/notes/note-editor-panel.tsx
@@ -55,11 +55,11 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
           type="text"
           value={title}
           onChange={(e) => handleTitleChange(e.target.value)}
-          className="flex-1 text-lg font-semibold outline-none"
+          className="min-w-0 flex-1 text-lg font-semibold outline-none"
           placeholder="Untitled"
           aria-label="Note title"
         />
-        <span className="text-xs text-gray-400">
+        <span className="shrink-0 text-xs text-gray-400">
           {saveStatus === "saving" && "Saving..."}
           {saveStatus === "saved" && "Saved"}
           {saveStatus === "error" && "Error saving"}


### PR DESCRIPTION
## Summary
- Refine the three-panel desktop layout to match spec proportions: sidebar ~240px, note list ~300px, editor fills remaining
- Note list panel width updated from `w-72` (288px) to `w-[300px]` (300px)
- Added `min-w-0` on editor main panel and note title input to prevent flex overflow with long content
- Added `shrink-0` on save status indicator to prevent text compression

## Test plan
- [x] Unit + integration tests pass (199/199)
- [x] ESLint: 0 errors
- [x] TypeScript: clean
- [ ] CI pipeline passes
- [ ] Visual verification of layout proportions on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)