### PR TITLE
feat: add collapsible sidebar for tablet layout (Phase 6.2)

### DIFF
--- a/__tests__/integration/app-shell.test.tsx
+++ b/__tests__/integration/app-shell.test.tsx
@@ -908,4 +908,187 @@ describe("AppShell", () => {
 
     vi.restoreAllMocks();
   });
+
+  describe("tablet layout — collapsible sidebar", () => {
+    it("renders a sidebar toggle button", async () => {
+      await act(async () => {
+        render(<AppShell />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Notebooks")).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText("Toggle sidebar")).toBeInTheDocument();
+    });
+
+    it("shows backdrop when sidebar toggle is clicked", async () => {
+      const user = userEvent.setup();
+
+      const { container } = await act(async () => {
+        return render(<AppShell />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Notebooks")).toBeInTheDocument();
+      });
+
+      // Backdrop should not be visible initially
+      expect(container.querySelector("[data-testid='sidebar-backdrop']")).not.toBeInTheDocument();
+
+      // Click the toggle button to open sidebar
+      await act(async () => {
+        await user.click(screen.getByLabelText("Toggle sidebar"));
+      });
+
+      // Backdrop should now be visible
+      expect(screen.getByTestId("sidebar-backdrop")).toBeInTheDocument();
+    });
+
+    it("closes sidebar when backdrop is clicked", async () => {
+      const user = userEvent.setup();
+
+      await act(async () => {
+        render(<AppShell />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Notebooks")).toBeInTheDocument();
+      });
+
+      // Open sidebar
+      await act(async () => {
+        await user.click(screen.getByLabelText("Toggle sidebar"));
+      });
+
+      expect(screen.getByTestId("sidebar-backdrop")).toBeInTheDocument();
+
+      // Click backdrop to close
+      await act(async () => {
+        await user.click(screen.getByTestId("sidebar-backdrop"));
+      });
+
+      // Backdrop should disappear
+      expect(screen.queryByTestId("sidebar-backdrop")).not.toBeInTheDocument();
+    });
+
+    it("closes sidebar when a notebook is selected", async () => {
+      const user = userEvent.setup();
+
+      await act(async () => {
+        render(<AppShell />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Personal")).toBeInTheDocument();
+      });
+
+      // Open sidebar
+      await act(async () => {
+        await user.click(screen.getByLabelText("Toggle sidebar"));
+      });
+
+      expect(screen.getByTestId("sidebar-backdrop")).toBeInTheDocument();
+
+      // Click a notebook — sidebar should close
+      await act(async () => {
+        await user.click(screen.getByText("Work"));
+      });
+
+      expect(screen.queryByTestId("sidebar-backdrop")).not.toBeInTheDocument();
+    });
+
+    it("closes sidebar when trash is selected", async () => {
+      const user = userEvent.setup();
+      const mockTrashedNotes = [
+        {
+          id: "t-1",
+          title: "Trashed Note",
+          notebook_id: "nb-1",
+          trashed_at: new Date().toISOString(),
+        },
+      ];
+
+      mockFetch.mockImplementation((url: string) => {
+        if (url === "/api/notebooks") {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockNotebooks) });
+        }
+        if (url === "/api/notes/trash") {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTrashedNotes) });
+        }
+        if (typeof url === "string" && url.match(/\/api\/notebooks\/[^/]+\/notes$/)) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockNotes) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      });
+
+      await act(async () => {
+        render(<AppShell />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /Trash/i })).toBeInTheDocument();
+      });
+
+      // Open sidebar
+      await act(async () => {
+        await user.click(screen.getByLabelText("Toggle sidebar"));
+      });
+
+      expect(screen.getByTestId("sidebar-backdrop")).toBeInTheDocument();
+
+      // Click Trash — sidebar should close
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /Trash/i }));
+      });
+
+      expect(screen.queryByTestId("sidebar-backdrop")).not.toBeInTheDocument();
+    });
+
+    it("sidebar has responsive CSS classes for tablet overlay", async () => {
+      const { container } = await act(async () => {
+        return render(<AppShell />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Notebooks")).toBeInTheDocument();
+      });
+
+      const aside = container.querySelector("aside");
+      expect(aside).toBeInTheDocument();
+
+      // Sidebar should have fixed positioning (overlay on tablet) and lg:static (inline on desktop)
+      expect(aside?.className).toContain("fixed");
+      expect(aside?.className).toContain("lg:static");
+      expect(aside?.className).toContain("lg:translate-x-0");
+      expect(aside?.className).toContain("transition-transform");
+    });
+
+    it("toggles sidebar translate class when opened and closed", async () => {
+      const user = userEvent.setup();
+
+      const { container } = await act(async () => {
+        return render(<AppShell />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Notebooks")).toBeInTheDocument();
+      });
+
+      const aside = container.querySelector("aside");
+
+      // Initially closed — should have -translate-x-full
+      expect(aside?.className).toContain("-translate-x-full");
+      expect(aside?.className).not.toContain(" translate-x-0");
+
+      // Open sidebar
+      await act(async () => {
+        await user.click(screen.getByLabelText("Toggle sidebar"));
+      });
+
+      // Now open — should have translate-x-0 (not the -translate-x-full)
+      expect(aside?.className).toContain("translate-x-0");
+      expect(aside?.className).not.toContain("-translate-x-full");
+    });
+  });
 });

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -81,7 +81,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 ### Phase 6: Responsive Design
 
 - [x] 6.1 — Desktop layout refinement
-- [ ] 6.2 — Tablet layout (collapsible sidebar) + tests
+- [x] 6.2 — Tablet layout (collapsible sidebar) + tests
 - [ ] 6.3 — Mobile layout (single-panel navigation) + tests
 - [ ] 6.4 — E2E: responsive flows (mobile + tablet viewports)
 - [ ] 6-CP — **Checkpoint**: Run full suite locally. If green, check this off, commit, and exit.

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -17,6 +17,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [notebooks, setNotebooks] = useState<NotebookInfo[]>([]);
   const [viewingTrash, setViewingTrash] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const handleCreateNote = useCallback(async () => {
     if (!selectedNotebookId) return;
@@ -43,12 +44,14 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
     setSelectedNotebookId(id);
     setSelectedNoteId(null);
     setViewingTrash(false);
+    setSidebarOpen(false);
   }, []);
 
   const handleSelectTrash = useCallback(() => {
     setViewingTrash(true);
     setSelectedNotebookId(null);
     setSelectedNoteId(null);
+    setSidebarOpen(false);
   }, []);
 
   const handleDeleteNote = useCallback(
@@ -146,8 +149,22 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
 
   return (
     <div className="flex h-screen overflow-hidden">
+      {/* Sidebar backdrop — visible on tablet when sidebar is open */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-20 bg-black/20 lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+          aria-hidden="true"
+          data-testid="sidebar-backdrop"
+        />
+      )}
+
       {/* Sidebar — notebooks (~240px fixed) */}
-      <aside className="flex w-60 shrink-0 flex-col overflow-hidden border-r bg-gray-50">
+      <aside
+        className={`fixed inset-y-0 left-0 z-30 flex w-60 shrink-0 flex-col overflow-hidden border-r bg-gray-50 transition-transform duration-200 ease-in-out lg:static lg:translate-x-0 ${
+          sidebarOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
         <NotebooksSidebar
           selectedNotebookId={selectedNotebookId}
           onSelectNotebook={handleSelectNotebook}
@@ -159,6 +176,25 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
 
       {/* Middle panel — note list or trash (~300px fixed) */}
       <section className="flex w-[300px] shrink-0 flex-col overflow-hidden border-r">
+        {/* Sidebar toggle — visible on tablet only */}
+        <div className="flex items-center border-b p-2 lg:hidden">
+          <button
+            type="button"
+            onClick={() => setSidebarOpen((prev) => !prev)}
+            className="rounded p-1 text-gray-500 hover:bg-gray-200 hover:text-gray-700"
+            aria-label="Toggle sidebar"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </button>
+        </div>
+
         {viewingTrash ? (
           <Suspense
             fallback={<div className="p-4 text-center text-sm text-gray-400">Loading trash...</div>}


### PR DESCRIPTION
## Summary
- Adds collapsible sidebar for tablet breakpoint (`< 1024px`): sidebar slides in/out as an overlay with backdrop
- Hamburger toggle button in the middle panel header, visible only on tablet
- Sidebar auto-closes when a notebook or trash is selected
- 7 new integration tests covering toggle, backdrop dismiss, notebook/trash selection auto-close, CSS class assertions

## Test plan
- [x] All 206 unit/integration tests pass
- [x] ESLint: 0 errors
- [x] TypeScript: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)