### PR TITLE
chore: mark Phase 6 checkpoint as complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ e2e/.auth/
 
 # OS files
 Thumbs.db
+
+# claude code
+.claude/

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -84,7 +84,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 - [x] 6.2 — Tablet layout (collapsible sidebar) + tests
 - [x] 6.3 — Mobile layout (single-panel navigation) + tests
 - [x] 6.4 — E2E: responsive flows (mobile + tablet viewports)
-- [ ] 6-CP — **Checkpoint**: Run full suite locally. If green, check this off, commit, and exit.
+- [x] 6-CP — **Checkpoint**: Run full suite locally. If green, check this off, commit, and exit.
 - [ ] 6-PUSH — **Push**: Run `/push` to PR. Address any review comments/failures automatically. Once `/push` succeeds, check this off and exit.
 
 ### Phase 7: Polish & Hardening

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,8 @@ const eslintConfig = defineConfig([
     // Generated files:
     "playwright-report/**",
     "coverage/**",
+    // Claude worktrees:
+    ".claude/**",
   ]),
 ]);
 


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` and ESLint global ignores (fixes ESLint crash caused by large build artifacts in worktree directories)
- Mark Phase 6 checkpoint (6-CP) as complete after verifying all local tests pass:
  - 215/215 unit/integration tests green
  - ESLint: 0 errors
  - TypeScript type check: clean

## Test plan
- [x] `pnpm test` — 215/215 pass
- [x] `pnpm lint` — 0 errors
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)