### PR TITLE
chore: mark Phase 6 push as complete

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -85,7 +85,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 - [x] 6.3 — Mobile layout (single-panel navigation) + tests
 - [x] 6.4 — E2E: responsive flows (mobile + tablet viewports)
 - [x] 6-CP — **Checkpoint**: Run full suite locally. If green, check this off, commit, and exit.
-- [ ] 6-PUSH — **Push**: Run `/push` to PR. Address any review comments/failures automatically. Once `/push` succeeds, check this off and exit.
+- [x] 6-PUSH — **Push**: Run `/push` to PR. Address any review comments/failures automatically. Once `/push` succeeds, check this off and exit.
 
 ### Phase 7: Polish & Hardening
 


### PR DESCRIPTION
## Summary
- Marks Phase 6-PUSH as complete in the implementation plan progress tracker
- All Phase 6 responsive design tasks (6.1-6.4) and checkpoint (6-CP) were already merged

## Test plan
- [x] Unit + integration tests pass (215/215)
- [x] Lint passes (0 errors)
- [x] TypeScript type check passes
- [x] E2E tests verified at checkpoint (6-CP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)