### PR TITLE
feat: input and label components (Phase 2.2)

### DIFF
--- a/__tests__/integration/ui/input.test.tsx
+++ b/__tests__/integration/ui/input.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+describe("Input", () => {
+  it("renders an input element", () => {
+    render(<Input aria-label="test input" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("applies default md size styles", () => {
+    render(<Input aria-label="test" />);
+    const input = screen.getByRole("textbox");
+    expect(input.className).toContain("py-2");
+    expect(input.className).toContain("rounded-lg");
+  });
+
+  it("applies sm size styles", () => {
+    render(<Input inputSize="sm" aria-label="test" />);
+    const input = screen.getByRole("textbox");
+    expect(input.className).toContain("py-1");
+    expect(input.className).toContain("rounded-md");
+  });
+
+  it("applies lg size styles", () => {
+    render(<Input inputSize="lg" aria-label="test" />);
+    const input = screen.getByRole("textbox");
+    expect(input.className).toContain("py-2.5");
+  });
+
+  it("applies error border when error is true", () => {
+    render(<Input error aria-label="test" />);
+    const input = screen.getByRole("textbox");
+    expect(input.className).toContain("border-error");
+  });
+
+  it("applies normal border when error is false", () => {
+    render(<Input aria-label="test" />);
+    const input = screen.getByRole("textbox");
+    expect(input.className).toContain("border-border");
+  });
+
+  it("disables input when disabled prop is true", () => {
+    render(<Input disabled aria-label="test" />);
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+
+  it("accepts user input", async () => {
+    const user = userEvent.setup();
+    render(<Input aria-label="test" />);
+    const input = screen.getByRole("textbox");
+    await user.type(input, "hello");
+    expect(input).toHaveValue("hello");
+  });
+
+  it("calls onChange when typing", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Input aria-label="test" onChange={onChange} />);
+    await user.type(screen.getByRole("textbox"), "a");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("merges custom className", () => {
+    render(<Input className="custom-class" aria-label="test" />);
+    const input = screen.getByRole("textbox");
+    expect(input.className).toContain("custom-class");
+  });
+
+  it("forwards ref to input element", () => {
+    const ref = { current: null } as React.RefObject<HTMLInputElement | null>;
+    render(<Input ref={ref} aria-label="test" />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it("passes through placeholder", () => {
+    render(<Input placeholder="Enter text..." aria-label="test" />);
+    expect(screen.getByPlaceholderText("Enter text...")).toBeInTheDocument();
+  });
+
+  it("supports type prop", () => {
+    render(<Input type="password" aria-label="password" />);
+    const input = document.querySelector('input[type="password"]');
+    expect(input).toBeInTheDocument();
+  });
+});
+
+describe("Label", () => {
+  it("renders label text", () => {
+    render(<Label>Email</Label>);
+    expect(screen.getByText("Email")).toBeInTheDocument();
+  });
+
+  it("renders as a label element", () => {
+    render(<Label htmlFor="email">Email</Label>);
+    const label = screen.getByText("Email");
+    expect(label.tagName).toBe("LABEL");
+    expect(label).toHaveAttribute("for", "email");
+  });
+
+  it("applies muted text styling", () => {
+    render(<Label>Email</Label>);
+    const label = screen.getByText("Email");
+    expect(label.className).toContain("text-fg-muted");
+  });
+
+  it("shows required indicator when required is true", () => {
+    render(<Label required>Email</Label>);
+    const asterisk = screen.getByText("*");
+    expect(asterisk).toBeInTheDocument();
+    expect(asterisk.className).toContain("text-error");
+  });
+
+  it("does not show required indicator by default", () => {
+    render(<Label>Email</Label>);
+    expect(screen.queryByText("*")).not.toBeInTheDocument();
+  });
+
+  it("merges custom className", () => {
+    render(<Label className="custom-class">Email</Label>);
+    const label = screen.getByText("Email");
+    expect(label.className).toContain("custom-class");
+  });
+
+  it("forwards ref to label element", () => {
+    const ref = { current: null } as React.RefObject<HTMLLabelElement | null>;
+    render(<Label ref={ref}>Email</Label>);
+    expect(ref.current).toBeInstanceOf(HTMLLabelElement);
+  });
+
+  it("associates with input via htmlFor", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <Label htmlFor="test-input">Click me</Label>
+        <input id="test-input" />
+      </>,
+    );
+    await user.click(screen.getByText("Click me"));
+    expect(document.getElementById("test-input")).toHaveFocus();
+  });
+});

--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -42,7 +42,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 ### Phase 2: Reusable UI Primitives
 
 - [x] 2.1 — cn() utility + Button component (variants: primary, secondary, ghost, danger; sizes: sm, md, lg; loading state)
-- [ ] 2.2 — Input and Label components
+- [x] 2.2 — Input and Label components
 - [ ] 2.3 — Card component (with header/body/footer slots)
 - [ ] 2.4 — Badge, IconButton, and Skeleton components
 - [ ] 2.5 — ConfirmDialog component

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export type InputSize = "sm" | "md" | "lg";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  inputSize?: InputSize;
+  error?: boolean;
+}
+
+const sizeStyles: Record<InputSize, string> = {
+  sm: "px-2.5 py-1 text-sm rounded-md",
+  md: "px-3 py-2 text-sm rounded-lg",
+  lg: "px-4 py-2.5 text-base rounded-lg",
+};
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { inputSize = "md", error = false, className, ...props },
+  ref,
+) {
+  return (
+    <input
+      ref={ref}
+      className={cn(
+        "bg-bg text-fg placeholder:text-fg-subtle w-full border transition-colors duration-[var(--transition-fast)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
+        error ? "border-error focus-visible:ring-error" : "border-border focus-visible:ring-ring",
+        sizeStyles[inputSize],
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { forwardRef, type LabelHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+  required?: boolean;
+}
+
+export const Label = forwardRef<HTMLLabelElement, LabelProps>(function Label(
+  { required, className, children, ...props },
+  ref,
+) {
+  return (
+    <label ref={ref} className={cn("text-fg-muted text-sm font-medium", className)} {...props}>
+      {children}
+      {required && <span className="text-error ml-0.5">*</span>}
+    </label>
+  );
+});


### PR DESCRIPTION
## Summary
- Add reusable `Input` component with focus ring, error state (red border), three sizes (sm/md/lg), and disabled state
- Add reusable `Label` component with muted text styling and optional required indicator (`*`)
- Add 21 integration tests covering both components (sizes, error state, disabled, ref forwarding, label association)
- Mark task 2.2 complete in `ui-redesign-plan.md`

## Test plan
- [x] All 303 unit + integration tests pass
- [x] ESLint: 0 errors
- [x] TypeScript: no type errors
- [x] E2E: only pre-existing env credential issue (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)