### PR TITLE
feat: confirm-dialog component (Phase 2.5)

### DIFF
--- a/__tests__/integration/ui/confirm-dialog.test.tsx
+++ b/__tests__/integration/ui/confirm-dialog.test.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+describe("ConfirmDialog", () => {
+  const defaultProps = {
+    title: "Delete this item?",
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it("renders title", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByText("Delete this item?")).toBeInTheDocument();
+  });
+
+  it("has alertdialog role", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+  });
+
+  it("uses title as aria-label", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByRole("alertdialog")).toHaveAttribute("aria-label", "Delete this item?");
+  });
+
+  it("renders default confirm and cancel labels", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("renders custom confirm and cancel labels", () => {
+    render(<ConfirmDialog {...defaultProps} confirmLabel="Delete" cancelLabel="Keep" />);
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Keep" })).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when confirm button is clicked", async () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+    await userEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when cancel button is clicked", async () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("renders children as description", () => {
+    render(<ConfirmDialog {...defaultProps}>This action cannot be undone.</ConfirmDialog>);
+    expect(screen.getByText("This action cannot be undone.")).toBeInTheDocument();
+  });
+
+  it("renders error message with alert role", () => {
+    render(<ConfirmDialog {...defaultProps} error="Something went wrong" />);
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Something went wrong");
+  });
+
+  it("does not render error when error is null", () => {
+    render(<ConfirmDialog {...defaultProps} error={null} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not render error when error is not provided", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows loading state on confirm button", () => {
+    render(<ConfirmDialog {...defaultProps} loading confirmLabel="Delete" />);
+    const confirmBtn = screen.getByRole("button", { name: "Delete" });
+    expect(confirmBtn).toBeDisabled();
+  });
+
+  it("does not disable cancel button when loading", () => {
+    render(<ConfirmDialog {...defaultProps} loading />);
+    const cancelBtn = screen.getByRole("button", { name: "Cancel" });
+    expect(cancelBtn).not.toBeDisabled();
+  });
+
+  it("merges custom className", () => {
+    render(<ConfirmDialog {...defaultProps} className="custom-class" />);
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog.className).toContain("custom-class");
+  });
+
+  it("forwards ref", () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    render(<ConfirmDialog {...defaultProps} ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("passes through HTML attributes", () => {
+    render(<ConfirmDialog {...defaultProps} data-testid="confirm-dialog" />);
+    expect(screen.getByTestId("confirm-dialog")).toBeInTheDocument();
+  });
+
+  it("applies danger variant by default", () => {
+    render(<ConfirmDialog {...defaultProps} confirmLabel="Delete" />);
+    const confirmBtn = screen.getByRole("button", { name: "Delete" });
+    expect(confirmBtn.className).toContain("bg-error");
+  });
+
+  it("applies primary variant for warning", () => {
+    render(<ConfirmDialog {...defaultProps} variant="warning" confirmLabel="Proceed" />);
+    const confirmBtn = screen.getByRole("button", { name: "Proceed" });
+    expect(confirmBtn.className).toContain("bg-primary-600");
+  });
+});

--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -45,7 +45,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 - [x] 2.2 — Input and Label components
 - [x] 2.3 — Card component (with header/body/footer slots)
 - [x] 2.4 — Badge, IconButton, and Skeleton components
-- [ ] 2.5 — ConfirmDialog component
+- [x] 2.5 — ConfirmDialog component
 - [ ] 2.6 — DropdownMenu component
 - [ ] 2-CP — **Checkpoint**: full suite green
 - [ ] 2-PUSH — **Push**: `/push` to PR

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { forwardRef, type HTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+import { Button } from "@/components/ui/button";
+
+export interface ConfirmDialogProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  variant?: "danger" | "warning";
+  error?: string | null;
+  loading?: boolean;
+}
+
+export const ConfirmDialog = forwardRef<HTMLDivElement, ConfirmDialogProps>(function ConfirmDialog(
+  {
+    title,
+    confirmLabel = "Confirm",
+    cancelLabel = "Cancel",
+    onConfirm,
+    onCancel,
+    variant = "danger",
+    error,
+    loading = false,
+    className,
+    children,
+    ...props
+  },
+  ref,
+) {
+  const confirmVariant = variant === "danger" ? "danger" : "primary";
+
+  return (
+    <div
+      ref={ref}
+      role="alertdialog"
+      aria-label={title}
+      className={cn("border-border bg-bg-subtle border-t p-3", className)}
+      {...props}
+    >
+      <p className="text-fg mb-2 text-xs font-medium">{title}</p>
+      {children && <div className="text-fg-muted mb-2 text-xs">{children}</div>}
+      {error && (
+        <p className="text-error mb-2 text-xs" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="flex gap-2">
+        <Button size="sm" variant={confirmVariant} onClick={onConfirm} loading={loading}>
+          {confirmLabel}
+        </Button>
+        <Button size="sm" variant="secondary" onClick={onCancel}>
+          {cancelLabel}
+        </Button>
+      </div>
+    </div>
+  );
+});


### PR DESCRIPTION
## Summary
- Add reusable `ConfirmDialog` inline confirmation panel component (`src/components/ui/confirm-dialog.tsx`)
- Supports title, message (children), confirm/cancel buttons, `danger`/`warning` variants, error display, and loading state
- Uses `Button` primitive internally with proper design token styling
- 18 integration tests covering all props, interactions, accessibility (alertdialog role), and ref forwarding
- Marks task 2.5 complete in ui-redesign-plan.md

## Test plan
- [x] All 387 unit + integration tests pass (`CI=true pnpm test -- --run`)
- [x] ESLint: 0 errors (only pre-existing warnings)
- [x] TypeScript: clean (`pnpm exec tsc --noEmit`)
- [x] Build succeeds (`pnpm build`)
- [ ] E2E tests pass on CI (blocked locally by missing E2E credentials — pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)