### PR TITLE
feat: redesign login page with UI primitives (Phase 3.2)

### DIFF
--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -53,7 +53,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 ### Phase 3: Auth Pages Redesign
 
 - [x] 3.1 — Auth layout (gradient background, branded Card container)
-- [ ] 3.2 — Login page (use Button, Input, Label, Card primitives)
+- [x] 3.2 — Login page (use Button, Input, Label, Card primitives)
 - [ ] 3.3 — Signup, forgot-password, reset-password, waiting-for-approval pages
 - [ ] 3-CP — **Checkpoint**: full suite green
 - [ ] 3-PUSH — **Push**: `/push` to PR

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -33,67 +36,59 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="rounded-lg bg-white p-8 shadow">
-      <h1 className="mb-6 text-center text-2xl font-bold">Log In</h1>
+    <>
+      <h1 className="text-fg mb-6 text-center text-2xl font-bold">Log In</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-            Email
-          </label>
-          <input
+          <Label htmlFor="email">Email</Label>
+          <Input
             id="email"
             type="email"
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             placeholder="you@example.com"
+            className="mt-1"
           />
         </div>
 
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-            Password
-          </label>
-          <input
+          <Label htmlFor="password">Password</Label>
+          <Input
             id="password"
             type="password"
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            className="mt-1"
           />
         </div>
 
         {error && (
-          <div role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          <div role="alert" className="text-error rounded-md bg-red-50 p-3 text-sm">
             {error}
           </div>
         )}
 
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50"
-        >
+        <Button type="submit" loading={loading} className="w-full">
           {loading ? "Logging in..." : "Log in"}
-        </button>
+        </Button>
       </form>
 
-      <div className="mt-4 text-center text-sm text-gray-600">
+      <div className="text-fg-muted mt-4 text-center text-sm">
         <p>
           Don&apos;t have an account?{" "}
-          <Link href="/signup" className="text-blue-600 hover:underline">
+          <Link href="/signup" className="text-primary-600 hover:underline">
             Sign up
           </Link>
         </p>
         <p className="mt-2">
-          <Link href="/forgot-password" className="text-blue-600 hover:underline">
+          <Link href="/forgot-password" className="text-primary-600 hover:underline">
             Forgot your password?
           </Link>
         </p>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Replace raw HTML `<label>`, `<input>`, `<button>` in login page with design system `Label`, `Input`, `Button` primitives
- Remove page-level card wrapper (auth layout already provides `Card` + `CardBody`)
- Replace raw Tailwind color classes (`text-gray-700`, `bg-blue-600`, `text-blue-600`) with semantic design tokens (`text-fg`, `text-primary-600`, `text-error`)

## Test plan
- [x] All 414 unit/integration tests pass (including 6 login-specific tests)
- [x] 43 E2E tests pass (pre-existing auth redirect test excluded)
- [x] ESLint: 0 errors
- [x] TypeScript: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)