### PR TITLE
fix: replace raw bg-red-50 with semantic error-bg token (Phase 3.2)

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -66,7 +66,7 @@ export default function LoginPage() {
         </div>
 
         {error && (
-          <div role="alert" className="text-error rounded-md bg-red-50 p-3 text-sm">
+          <div role="alert" className="text-error bg-error-bg rounded-md p-3 text-sm">
             {error}
           </div>
         )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,6 +58,7 @@
   --color-warning: #f59e0b;
   --color-error: #ef4444;
   --color-info: #3b82f6;
+  --color-error-bg: #fef2f2;
 
   /* Semantic surface tokens (dark-mode-ready via CSS vars) */
   --color-bg: var(--bg);


### PR DESCRIPTION
## Summary
- Added `--color-error-bg` design token (`#fef2f2`) to `globals.css`
- Replaced raw `bg-red-50` Tailwind class with semantic `bg-error-bg` token in login page error alert
- Ensures all login page styling uses design system tokens (no raw Tailwind color classes)

## Test plan
- [x] All 414 unit/integration tests pass
- [x] All 43 E2E tests pass (13 skipped by config)
- [x] ESLint: 0 errors
- [x] TypeScript: no type errors
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual styling of error alert messages on the login page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->