### PR TITLE
feat: redesign remaining auth pages with design system primitives (Phase 3.3)

### DIFF
--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -54,7 +54,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 
 - [x] 3.1 — Auth layout (gradient background, branded Card container)
 - [x] 3.2 — Login page (use Button, Input, Label, Card primitives)
-- [ ] 3.3 — Signup, forgot-password, reset-password, waiting-for-approval pages
+- [x] 3.3 — Signup, forgot-password, reset-password, waiting-for-approval pages
 - [ ] 3-CP — **Checkpoint**: full suite green
 - [ ] 3-PUSH — **Push**: `/push` to PR
 

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -3,6 +3,9 @@
 import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
@@ -36,13 +39,13 @@ export default function ForgotPasswordPage() {
 
   if (success) {
     return (
-      <div className="rounded-lg bg-white p-8 text-center shadow">
-        <h1 className="mb-4 text-2xl font-bold">Check Your Email</h1>
-        <p className="mb-6 text-gray-600">
-          We&apos;ve sent a password reset link to <strong>{email}</strong>. Check your inbox and
-          follow the link to reset your password.
+      <div className="text-center">
+        <h1 className="text-fg mb-4 text-2xl font-bold">Check Your Email</h1>
+        <p className="text-fg-muted mb-6">
+          We&apos;ve sent a password reset link to <strong className="text-fg">{email}</strong>.
+          Check your inbox and follow the link to reset your password.
         </p>
-        <Link href="/login" className="text-blue-600 hover:underline">
+        <Link href="/login" className="text-primary-600 hover:underline">
           Back to login
         </Link>
       </div>
@@ -50,45 +53,39 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <div className="rounded-lg bg-white p-8 shadow">
-      <h1 className="mb-6 text-center text-2xl font-bold">Forgot Password</h1>
+    <>
+      <h1 className="text-fg mb-6 text-center text-2xl font-bold">Forgot Password</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-            Email
-          </label>
-          <input
+          <Label htmlFor="email">Email</Label>
+          <Input
             id="email"
             type="email"
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             placeholder="you@example.com"
+            className="mt-1"
           />
         </div>
 
         {error && (
-          <div role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          <div role="alert" className="text-error bg-error-bg rounded-md p-3 text-sm">
             {error}
           </div>
         )}
 
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50"
-        >
+        <Button type="submit" loading={loading} className="w-full">
           {loading ? "Sending..." : "Send reset link"}
-        </button>
+        </Button>
       </form>
 
-      <p className="mt-4 text-center text-sm text-gray-600">
-        <Link href="/login" className="text-blue-600 hover:underline">
+      <p className="text-fg-muted mt-4 text-center text-sm">
+        <Link href="/login" className="text-primary-600 hover:underline">
           Back to login
         </Link>
       </p>
-    </div>
+    </>
   );
 }

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export default function ResetPasswordPage() {
   const [password, setPassword] = useState("");
@@ -38,61 +41,53 @@ export default function ResetPasswordPage() {
   }
 
   return (
-    <div className="rounded-lg bg-white p-8 shadow">
-      <h1 className="mb-6 text-center text-2xl font-bold">Reset Password</h1>
+    <>
+      <h1 className="text-fg mb-6 text-center text-2xl font-bold">Reset Password</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-            New Password
-          </label>
-          <input
+          <Label htmlFor="password">New Password</Label>
+          <Input
             id="password"
             type="password"
             required
             minLength={6}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             placeholder="Min. 6 characters"
+            className="mt-1"
           />
         </div>
 
         <div>
-          <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">
-            Confirm Password
-          </label>
-          <input
+          <Label htmlFor="confirmPassword">Confirm Password</Label>
+          <Input
             id="confirmPassword"
             type="password"
             required
             minLength={6}
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            className="mt-1"
           />
         </div>
 
         {error && (
-          <div role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          <div role="alert" className="text-error bg-error-bg rounded-md p-3 text-sm">
             {error}
           </div>
         )}
 
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50"
-        >
+        <Button type="submit" loading={loading} className="w-full">
           {loading ? "Resetting..." : "Reset password"}
-        </button>
+        </Button>
       </form>
 
-      <p className="mt-4 text-center text-sm text-gray-600">
-        <Link href="/login" className="text-blue-600 hover:underline">
+      <p className="text-fg-muted mt-4 text-center text-sm">
+        <Link href="/login" className="text-primary-600 hover:underline">
           Back to login
         </Link>
       </p>
-    </div>
+    </>
   );
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export default function SignupPage() {
   const [email, setEmail] = useState("");
@@ -39,62 +42,54 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="rounded-lg bg-white p-8 shadow">
-      <h1 className="mb-6 text-center text-2xl font-bold">Create Account</h1>
+    <>
+      <h1 className="text-fg mb-6 text-center text-2xl font-bold">Create Account</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-            Email
-          </label>
-          <input
+          <Label htmlFor="email">Email</Label>
+          <Input
             id="email"
             type="email"
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             placeholder="you@example.com"
+            className="mt-1"
           />
         </div>
 
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-            Password
-          </label>
-          <input
+          <Label htmlFor="password">Password</Label>
+          <Input
             id="password"
             type="password"
             required
             minLength={6}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
             placeholder="Min. 6 characters"
+            className="mt-1"
           />
         </div>
 
         {error && (
-          <div role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          <div role="alert" className="text-error bg-error-bg rounded-md p-3 text-sm">
             {error}
           </div>
         )}
 
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50"
-        >
+        <Button type="submit" loading={loading} className="w-full">
           {loading ? "Creating account..." : "Sign up"}
-        </button>
+        </Button>
       </form>
 
-      <p className="mt-4 text-center text-sm text-gray-600">
+      <p className="text-fg-muted mt-4 text-center text-sm">
         Already have an account?{" "}
-        <Link href="/login" className="text-blue-600 hover:underline">
+        <Link href="/login" className="text-primary-600 hover:underline">
           Log in
         </Link>
       </p>
-    </div>
+    </>
   );
 }

--- a/src/app/(auth)/waiting-for-approval/page.tsx
+++ b/src/app/(auth)/waiting-for-approval/page.tsx
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
 
 export default function WaitingForApprovalPage() {
   const router = useRouter();
@@ -16,19 +17,15 @@ export default function WaitingForApprovalPage() {
   }
 
   return (
-    <div className="rounded-lg bg-white p-8 text-center shadow">
-      <h1 className="mb-4 text-2xl font-bold">Waiting for Approval</h1>
-      <p className="mb-6 text-gray-600">
+    <div className="text-center">
+      <h1 className="text-fg mb-4 text-2xl font-bold">Waiting for Approval</h1>
+      <p className="text-fg-muted mb-6">
         Your account is pending approval. You&apos;ll be able to access Drafto once an admin
         approves your account.
       </p>
-      <button
-        type="button"
-        onClick={handleLogout}
-        className="rounded-md bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
-      >
+      <Button variant="secondary" onClick={handleLogout}>
         Log out
-      </button>
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace raw Tailwind classes with Button, Input, Label primitives and semantic design tokens across signup, forgot-password, reset-password, and waiting-for-approval pages
- Remove redundant Card wrapper divs (auth layout already provides the Card container)
- Consistent error styling using `text-error bg-error-bg` tokens
- Links use `text-primary-600` instead of raw `text-blue-600`

## Pages updated
- `src/app/(auth)/signup/page.tsx`
- `src/app/(auth)/forgot-password/page.tsx`
- `src/app/(auth)/reset-password/page.tsx`
- `src/app/(auth)/waiting-for-approval/page.tsx`

## Test plan
- [x] All 414 unit + integration tests pass
- [x] All 43 E2E tests pass (13 skipped — device-specific responsive tests)
- [x] ESLint: 0 errors
- [x] TypeScript: compiles with no errors
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)