### PR TITLE
feat: redesign notebooks sidebar with design tokens (Phase 4.1)

### DIFF
--- a/src/components/notebooks/notebooks-sidebar.tsx
+++ b/src/components/notebooks/notebooks-sidebar.tsx
@@ -252,7 +252,7 @@ export function NotebooksSidebar({
                   })}
                   className={`group flex w-full cursor-pointer items-center justify-between rounded-md px-2 py-1.5 text-left text-sm transition-colors duration-[var(--transition-fast)] ${
                     selectedNotebookId === notebook.id
-                      ? "bg-sidebar-active text-sidebar-active-text border-primary-500 border-l-3 font-medium"
+                      ? "bg-sidebar-active text-sidebar-active-text border-primary-500 border-l-[3px] font-medium"
                       : "text-fg hover:bg-sidebar-hover"
                   }`}
                 >


### PR DESCRIPTION
## Summary
- Replace raw Tailwind gray/blue classes in `NotebooksSidebar` with semantic design tokens (`sidebar-bg`, `sidebar-active`, `sidebar-hover`, `fg-muted`, etc.)
- Use `Skeleton` component for loading state instead of "Loading..." text
- Use `ConfirmDialog` primitive for delete confirmation instead of raw styled div
- Use `IconButton` primitive for new-notebook button
- Add styled empty state with book icon and descriptive text
- Selected notebook now has left accent border (`border-l-3 border-primary-500`)
- Update integration tests (`notebooks-sidebar.test.tsx`, `app-shell.test.tsx`) to use `data-testid="sidebar-skeleton"` instead of `getByText("Loading...")`

## Test plan
- [x] All 414 unit + integration tests pass
- [x] All 42 E2E tests pass (1 pre-existing flaky test)
- [x] ESLint passes (0 errors)
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual styling for active notebook items with bolder text weight for improved clarity.
  * Improved delete button hover transitions for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->