### PR TITLE
feat: synchronize BlockNote editor theme with design tokens (Phase 5.3)

### DIFF
--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -69,7 +69,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 
 - [x] 5.1 — Note list (tokens, DropdownMenu, styled selection/hover, empty state)
 - [x] 5.2 — Note editor panel (title styling, Badge save status, timestamp icons)
-- [ ] 5.3 — BlockNote editor theme synchronization
+- [x] 5.3 — BlockNote editor theme synchronization
 - [ ] 5-CP — **Checkpoint**: full suite green
 - [ ] 5-PUSH — **Push**: `/push` to PR
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,3 +103,25 @@ body {
   color: var(--fg);
   font-family: var(--font-sans, Arial, Helvetica, sans-serif);
 }
+
+/* ── BlockNote Theme Synchronization ─────────────────────── */
+
+.bn-container {
+  --bn-colors-editor-text: var(--fg);
+  --bn-colors-editor-background: var(--bg);
+  --bn-colors-menu-text: var(--fg);
+  --bn-colors-menu-background: var(--bg);
+  --bn-colors-tooltip-text: var(--fg);
+  --bn-colors-tooltip-background: var(--bg-muted);
+  --bn-colors-hovered-text: var(--fg);
+  --bn-colors-hovered-background: var(--bg-muted);
+  --bn-colors-selected-text: #ffffff;
+  --bn-colors-selected-background: var(--ring);
+  --bn-colors-disabled-text: var(--fg-subtle);
+  --bn-colors-disabled-background: var(--bg-muted);
+  --bn-colors-shadow: var(--border);
+  --bn-colors-border: var(--border);
+  --bn-colors-side-menu: var(--fg-subtle);
+  --bn-font-family: var(--font-sans, Arial, Helvetica, sans-serif);
+  --bn-border-radius: 6px;
+}


### PR DESCRIPTION
## Summary
- Add CSS custom property overrides for BlockNote's `.bn-container` in `globals.css`, mapping editor colors (text, background, menus, tooltips, hover/selection states, borders, shadows) to the app's design token system
- Uses the same semantic CSS variables (`--fg`, `--bg`, `--bg-muted`, `--border`, `--ring`, etc.) so BlockNote will automatically adapt when dark mode tokens are added in Phase 7
- Mark task 5.3 complete in the UI redesign plan

## Test plan
- [x] All 420 unit/integration tests pass
- [x] All 43 E2E tests pass (13 skipped — device-specific)
- [x] ESLint: 0 errors
- [x] TypeScript: no type errors
- [ ] Visual verification: BlockNote editor text, backgrounds, menus, and selection colors match the app's design system

🤖 Generated with [Claude Code](https://claude.com/claude-code)