### PR TITLE
feat: redesign trash list with design tokens (Phase 6.1)

### DIFF
--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -75,7 +75,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 
 ### Phase 6: Trash & Admin Redesign
 
-- [ ] 6.1 — Trash list (tokens, Button primitives, styled empty state)
+- [x] 6.1 — Trash list (tokens, Button primitives, styled empty state)
 - [ ] 6.2 — Admin page (Card, Button primitives, styled list)
 - [ ] 6-CP — **Checkpoint**: full suite green
 - [ ] 6-PUSH — **Push**: `/push` to PR

--- a/src/components/notes/trash-list.tsx
+++ b/src/components/notes/trash-list.tsx
@@ -3,6 +3,8 @@
 import { use, useState, useCallback } from "react";
 import { formatRelativeTime } from "@/lib/format-utils";
 import { handleAuthError } from "@/lib/handle-auth-error";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 
 interface TrashedNote {
   id: string;
@@ -97,36 +99,64 @@ export function TrashList({
 
   return (
     <div className="flex flex-1 flex-col">
-      <div className="flex items-center justify-between border-b p-3">
-        <h2 className="text-sm font-semibold text-gray-700">Trash</h2>
+      <div className="border-border flex items-center justify-between border-b p-3">
+        <h2 className="text-fg text-sm font-semibold">Trash</h2>
       </div>
 
       {notes.length === 0 ? (
-        <div className="p-4 text-center text-sm text-gray-400">Trash is empty.</div>
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+          <svg
+            className="text-fg-subtle h-10 w-10"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+            />
+          </svg>
+          <p className="text-fg-subtle text-sm">Trash is empty.</p>
+        </div>
       ) : (
         <nav className="flex-1 overflow-y-auto">
-          <ul className="space-y-0.5 p-2">
+          <ul className="space-y-1.5 p-2">
             {notes.map((note) => (
-              <li key={note.id} className="group rounded px-3 py-2 hover:bg-gray-50">
-                <p className="truncate text-sm font-medium text-gray-700">{note.title}</p>
-                <p className="text-xs text-gray-400">
-                  {getNotebookName(note.notebook_id)} &middot; {formatRelativeTime(note.trashed_at)}
-                </p>
-                <div className="mt-1 flex gap-2">
-                  <button
-                    type="button"
-                    onClick={() => handleRestore(note.id)}
-                    className="rounded px-2 py-0.5 text-xs text-blue-600 hover:bg-blue-50"
-                  >
+              <li
+                key={note.id}
+                className="bg-bg-muted hover:bg-bg-subtle rounded-lg px-3 py-2.5 transition-colors duration-[var(--transition-fast)]"
+              >
+                <p className="text-fg truncate text-sm font-medium">{note.title}</p>
+                <div className="text-fg-muted mt-1 flex items-center gap-2 text-xs">
+                  <Badge>{getNotebookName(note.notebook_id)}</Badge>
+                  <span>
+                    <svg
+                      className="mr-0.5 inline-block h-3 w-3"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+                      />
+                    </svg>
+                    {formatRelativeTime(note.trashed_at)}
+                  </span>
+                </div>
+                <div className="mt-2 flex gap-2">
+                  <Button variant="secondary" size="sm" onClick={() => handleRestore(note.id)}>
                     Restore
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handlePermanentDelete(note.id)}
-                    className="rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50"
-                  >
+                  </Button>
+                  <Button variant="danger" size="sm" onClick={() => handlePermanentDelete(note.id)}>
                     Delete forever
-                  </button>
+                  </Button>
                 </div>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- Redesign trash list component with design system tokens and UI primitives
- Replace raw Tailwind `gray-*`, `blue-*`, `red-*` classes with semantic token classes (`text-fg`, `bg-bg-muted`, `border-border`, etc.)
- Use `Button` primitive (secondary for Restore, danger for Delete forever) instead of raw styled buttons
- Use `Badge` primitive for notebook origin display
- Add trash SVG icon to empty state with `text-fg-subtle` styling
- Apply `rounded-lg`, `bg-bg-muted` item styling with `transition-colors` hover effects
- Add clock icon next to relative timestamp

## Test plan
- [x] All 421 unit/integration tests pass
- [x] All 42 E2E tests pass (1 flaky due to pre-existing timing issue)
- [x] ESLint: 0 errors (warnings are pre-existing)
- [x] TypeScript: no type errors
- [x] Existing test assertions still find "Trash", "Restore", "Delete forever", and "Trash is empty." text

🤖 Generated with [Claude Code](https://claude.com/claude-code)