### PR TITLE
feat: redesign admin page with design tokens and UI primitives (Phase 6.2)

### DIFF
--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -76,7 +76,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 ### Phase 6: Trash & Admin Redesign
 
 - [x] 6.1 — Trash list (tokens, Button primitives, styled empty state)
-- [ ] 6.2 — Admin page (Card, Button primitives, styled list)
+- [x] 6.2 — Admin page (Card, Button primitives, styled list)
 - [ ] 6-CP — **Checkpoint**: full suite green
 - [ ] 6-PUSH — **Push**: `/push` to PR
 

--- a/src/app/(app)/admin/admin-user-list.tsx
+++ b/src/app/(app)/admin/admin-user-list.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { Card, CardBody } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 
 interface PendingUser {
   id: string;
@@ -31,27 +33,50 @@ export function AdminUserList({ initialUsers }: { initialUsers: PendingUser[] })
   }
 
   if (pendingUsers.length === 0) {
-    return <p className="text-gray-500">No pending users to approve.</p>;
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <svg
+          className="text-fg-subtle mb-3 h-12 w-12"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"
+          />
+        </svg>
+        <p className="text-fg-muted text-sm">No pending users to approve.</p>
+      </div>
+    );
   }
 
   return (
     <ul className="space-y-3">
       {pendingUsers.map((user) => (
-        <li key={user.id} className="flex items-center justify-between rounded-lg border p-4">
-          <div>
-            <p className="font-medium">{user.display_name ?? user.id}</p>
-            <p className="text-sm text-gray-500">
-              Signed up {new Date(user.created_at).toLocaleDateString()}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => handleApprove(user.id)}
-            disabled={approvingId === user.id}
-            className="rounded-md bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700 disabled:opacity-50"
-          >
-            {approvingId === user.id ? "Approving..." : "Approve"}
-          </button>
+        <li key={user.id}>
+          <Card shadow="sm">
+            <CardBody className="flex items-center justify-between">
+              <div>
+                <p className="text-fg font-medium">{user.display_name ?? user.id}</p>
+                <p className="text-fg-muted text-sm">
+                  Signed up {new Date(user.created_at).toLocaleDateString()}
+                </p>
+              </div>
+              <Button
+                variant="primary"
+                size="sm"
+                loading={approvingId === user.id}
+                onClick={() => handleApprove(user.id)}
+                className="bg-success hover:bg-green-600 focus-visible:ring-green-500"
+              >
+                {approvingId === user.id ? "Approving..." : "Approve"}
+              </Button>
+            </CardBody>
+          </Card>
         </li>
       ))}
     </ul>

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -44,7 +44,7 @@ export default async function AdminPage() {
 
   return (
     <div className="mx-auto max-w-2xl p-8">
-      <h1 className="mb-6 text-2xl font-bold">Admin — User Approval</h1>
+      <h1 className="text-fg mb-6 text-2xl font-bold">Admin — User Approval</h1>
       <AdminUserList initialUsers={pendingUsers ?? []} />
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace raw Tailwind classes in admin page with Card, Button UI primitives and design tokens
- Add styled empty state with user group SVG icon for "no pending users" view
- Use green-tinted Button primary variant for approve action
- Apply `text-fg` and `text-fg-muted` design tokens for text styling

## Test plan
- [x] All 421 unit/integration tests pass
- [x] E2E tests pass (42 passed, 1 pre-existing flaky)
- [x] ESLint: 0 errors
- [x] TypeScript: compiles with no errors
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)