### PR TITLE
feat: add dark mode token overrides (Phase 7.1)

### DIFF
--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -82,7 +82,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 
 ### Phase 7: Dark Mode
 
-- [ ] 7.1 — Dark mode token overrides in globals.css (.dark class)
+- [x] 7.1 — Dark mode token overrides in globals.css (.dark class)
 - [ ] 7.2 — useTheme hook + ThemeToggle component + flash-prevention script
 - [ ] 7.3 — Integrate toggle into app shell sidebar and auth layout
 - [ ] 7.4 — BlockNote dynamic theme prop (light/dark)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,7 @@
 /* ── Design Tokens ────────────────────────────────────────── */
 
 :root {
-  /* Semantic surface tokens (overridden by .dark in Phase 7) */
+  /* Semantic surface tokens — light mode (overridden by .dark below) */
   --bg: #ffffff;
   --bg-subtle: #fafaf9;
   --bg-muted: #f5f5f4;
@@ -18,6 +18,27 @@
   --sidebar-active: #eef2ff;
   --sidebar-active-text: #4338ca;
   --fg-on-primary: #ffffff;
+  --error-bg: #fef2f2;
+}
+
+/* ── Dark Mode Token Overrides ───────────────────────────── */
+
+.dark {
+  --bg: #0f0f0f;
+  --bg-subtle: #141414;
+  --bg-muted: #1c1c1c;
+  --fg: #ededed;
+  --fg-muted: #a1a1a1;
+  --fg-subtle: #6b6b6b;
+  --border: #2a2a2a;
+  --border-strong: #3a3a3a;
+  --ring: #818cf8;
+  --sidebar-bg: #141414;
+  --sidebar-hover: #1c1c1c;
+  --sidebar-active: #1e1b4b;
+  --sidebar-active-text: #a5b4fc;
+  --fg-on-primary: #ffffff;
+  --error-bg: #2d1414;
 }
 
 @theme inline {
@@ -59,7 +80,7 @@
   --color-warning: #f59e0b;
   --color-error: #ef4444;
   --color-info: #3b82f6;
-  --color-error-bg: #fef2f2;
+  --color-error-bg: var(--error-bg);
 
   /* Semantic surface tokens (dark-mode-ready via CSS vars) */
   --color-bg: var(--bg);


### PR DESCRIPTION
## Summary
- Add `.dark` class in `globals.css` with complete dark mode overrides for all semantic surface tokens (backgrounds, foregrounds, borders, sidebar, ring, error states)
- Make `--color-error-bg` dark-mode-ready by routing through a `--error-bg` CSS variable
- When `.dark` is applied to `<html>`, all UI surfaces automatically switch to dark palette via CSS variable inheritance
- No component changes needed — the existing token architecture supports this cleanly

## Test plan
- [x] All 421 unit/integration tests pass
- [x] All 43 E2E tests pass
- [x] ESLint passes (0 errors)
- [x] TypeScript type check passes
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)