### PR TITLE
feat: add useTheme hook, ThemeToggle, and flash-prevention (Phase 7.2)

### DIFF
--- a/__tests__/integration/ui/theme-toggle.test.tsx
+++ b/__tests__/integration/ui/theme-toggle.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock localStorage for jsdom
+const localStorageStore: Record<string, string> = {};
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageStore[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete localStorageStore[key];
+  }),
+};
+Object.defineProperty(window, "localStorage", { value: localStorageMock, writable: true });
+
+let ThemeToggle: typeof import("@/components/ui/theme-toggle").ThemeToggle;
+
+describe("ThemeToggle", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    delete localStorageStore["theme"];
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+    document.documentElement.classList.remove("dark");
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+
+    const mod = await import("@/components/ui/theme-toggle");
+    ThemeToggle = mod.ThemeToggle;
+  });
+
+  it("renders with an accessible label", () => {
+    render(<ThemeToggle />);
+    const button = screen.getByTestId("theme-toggle");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-label");
+  });
+
+  it("shows sun icon in light mode", () => {
+    render(<ThemeToggle />);
+    const button = screen.getByTestId("theme-toggle");
+    const svg = button.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    // Sun icon has a circle element
+    expect(svg?.querySelector("circle")).toBeInTheDocument();
+  });
+
+  it("cycles to dark mode on click", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    const button = screen.getByTestId("theme-toggle");
+
+    // Default is system (light), first click goes to light, then dark
+    // cycle: light -> dark -> system
+    // But default is "system", so first click goes to "light" (next after system in cycle)
+    // Wait — cycle is [light, dark, system]. system is index 2, next is index 0 = light
+    await user.click(button);
+    // Should now be "light" — still shows sun icon
+    expect(button).toHaveAttribute("aria-label", "Light mode");
+
+    await user.click(button);
+    // Should now be "dark" — shows moon icon
+    expect(button).toHaveAttribute("aria-label", "Dark mode");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("cycles back to system after dark", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    const button = screen.getByTestId("theme-toggle");
+
+    // system -> light -> dark -> system
+    await user.click(button); // light
+    await user.click(button); // dark
+    await user.click(button); // system
+    expect(button.getAttribute("aria-label")).toContain("System theme");
+  });
+
+  it("persists theme to localStorage", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    const button = screen.getByTestId("theme-toggle");
+    // system -> light
+    await user.click(button);
+    expect(localStorage.getItem("theme")).toBe("light");
+
+    // light -> dark
+    await user.click(button);
+    expect(localStorage.getItem("theme")).toBe("dark");
+  });
+
+  it("applies custom className", () => {
+    render(<ThemeToggle className="custom-class" />);
+    const button = screen.getByTestId("theme-toggle");
+    expect(button.className).toContain("custom-class");
+  });
+});

--- a/__tests__/unit/use-theme.test.ts
+++ b/__tests__/unit/use-theme.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// Mock localStorage for jsdom
+const localStorageStore: Record<string, string> = {};
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageStore[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete localStorageStore[key];
+  }),
+};
+Object.defineProperty(window, "localStorage", { value: localStorageMock, writable: true });
+
+// Reset module state between tests
+let useTheme: typeof import("@/hooks/use-theme").useTheme;
+
+describe("useTheme", () => {
+  let matchMediaListeners: Array<(e: { matches: boolean }) => void>;
+  let darkMatches: boolean;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    matchMediaListeners = [];
+    darkMatches = false;
+
+    // Clear theme from localStorage
+    delete localStorageStore["theme"];
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+
+    // Mock matchMedia
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-color-scheme: dark)" ? darkMatches : false,
+        media: query,
+        addEventListener: vi.fn((_event: string, handler: (e: { matches: boolean }) => void) => {
+          matchMediaListeners.push(handler);
+        }),
+        removeEventListener: vi.fn((_event: string, handler: (e: { matches: boolean }) => void) => {
+          matchMediaListeners = matchMediaListeners.filter((l) => l !== handler);
+        }),
+      })),
+    });
+
+    // Remove dark class
+    document.documentElement.classList.remove("dark");
+
+    const mod = await import("@/hooks/use-theme");
+    useTheme = mod.useTheme;
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("defaults to system theme when no localStorage value", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("system");
+  });
+
+  it("resolves system theme to light when prefers-color-scheme is light", () => {
+    darkMatches = false;
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.resolvedTheme).toBe("light");
+  });
+
+  it("reads stored theme from localStorage", async () => {
+    localStorage.setItem("theme", "dark");
+    vi.resetModules();
+    const mod = await import("@/hooks/use-theme");
+    const { result } = renderHook(() => mod.useTheme());
+    expect(result.current.theme).toBe("dark");
+    expect(result.current.resolvedTheme).toBe("dark");
+  });
+
+  it("applies dark class to html element when theme is dark", async () => {
+    localStorage.setItem("theme", "dark");
+    vi.resetModules();
+    const mod = await import("@/hooks/use-theme");
+    renderHook(() => mod.useTheme());
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("does not apply dark class when theme is light", () => {
+    renderHook(() => useTheme());
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("setTheme updates the theme and persists to localStorage", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme("dark");
+    });
+
+    expect(result.current.theme).toBe("dark");
+    expect(result.current.resolvedTheme).toBe("dark");
+    expect(localStorage.getItem("theme")).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("setTheme to light removes dark class", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme("dark");
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    act(() => {
+      result.current.setTheme("light");
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(result.current.theme).toBe("light");
+  });
+
+  it("setTheme to system resolves based on media query", async () => {
+    darkMatches = true;
+    vi.resetModules();
+    const mod = await import("@/hooks/use-theme");
+
+    const { result } = renderHook(() => mod.useTheme());
+
+    act(() => {
+      result.current.setTheme("system");
+    });
+
+    expect(result.current.theme).toBe("system");
+    expect(result.current.resolvedTheme).toBe("dark");
+  });
+
+  it("cycles through themes correctly", () => {
+    const { result } = renderHook(() => useTheme());
+
+    // default is system
+    expect(result.current.theme).toBe("system");
+
+    act(() => {
+      result.current.setTheme("light");
+    });
+    expect(result.current.theme).toBe("light");
+
+    act(() => {
+      result.current.setTheme("dark");
+    });
+    expect(result.current.theme).toBe("dark");
+
+    act(() => {
+      result.current.setTheme("system");
+    });
+    expect(result.current.theme).toBe("system");
+  });
+
+  it("ignores invalid localStorage values", async () => {
+    localStorage.setItem("theme", "invalid");
+    vi.resetModules();
+    const mod = await import("@/hooks/use-theme");
+    const { result } = renderHook(() => mod.useTheme());
+    expect(result.current.theme).toBe("system");
+  });
+});

--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -83,7 +83,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 ### Phase 7: Dark Mode
 
 - [x] 7.1 — Dark mode token overrides in globals.css (.dark class)
-- [ ] 7.2 — useTheme hook + ThemeToggle component + flash-prevention script
+- [x] 7.2 — useTheme hook + ThemeToggle component + flash-prevention script
 - [ ] 7.3 — Integrate toggle into app shell sidebar and auth layout
 - [ ] 7.4 — BlockNote dynamic theme prop (light/dark)
 - [ ] 7.5 — Create ADR-0005 (dark mode implementation)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("theme");var d=t==="dark"||(t!=="light"&&matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")}catch(e){}})()`,
+          }}
+        />
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <PostHogProvider>{children}</PostHogProvider>
       </body>

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useTheme } from "@/hooks/use-theme";
+import { IconButton } from "@/components/ui/icon-button";
+import type { Theme } from "@/hooks/use-theme";
+
+const CYCLE_ORDER: Theme[] = ["light", "dark", "system"];
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+
+  const handleClick = () => {
+    const currentIndex = CYCLE_ORDER.indexOf(theme);
+    const nextTheme = CYCLE_ORDER[(currentIndex + 1) % CYCLE_ORDER.length];
+    setTheme(nextTheme);
+  };
+
+  const label =
+    theme === "system"
+      ? `System theme (${resolvedTheme})`
+      : theme === "dark"
+        ? "Dark mode"
+        : "Light mode";
+
+  return (
+    <IconButton
+      aria-label={label}
+      onClick={handleClick}
+      size="sm"
+      className={className}
+      data-testid="theme-toggle"
+    >
+      {resolvedTheme === "dark" ? <MoonIcon /> : <SunIcon />}
+    </IconButton>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" />
+      <path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" />
+      <path d="m19.07 4.93-1.41 1.41" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  );
+}

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+
+export type Theme = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+const STORAGE_KEY = "theme";
+
+function getStoredTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark" || stored === "system") return stored;
+  return "system";
+}
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function resolveTheme(theme: Theme): ResolvedTheme {
+  return theme === "system" ? getSystemTheme() : theme;
+}
+
+function applyTheme(resolved: ResolvedTheme) {
+  if (typeof document === "undefined") return;
+  document.documentElement.classList.toggle("dark", resolved === "dark");
+}
+
+// External store for theme preference
+let listeners: Array<() => void> = [];
+let currentTheme: Theme = typeof window !== "undefined" ? getStoredTheme() : "system";
+
+function subscribe(listener: () => void): () => void {
+  listeners = [...listeners, listener];
+  return () => {
+    listeners = listeners.filter((l) => l !== listener);
+  };
+}
+
+function getSnapshot(): Theme {
+  return currentTheme;
+}
+
+function getServerSnapshot(): Theme {
+  return "system";
+}
+
+function setThemeInternal(theme: Theme) {
+  currentTheme = theme;
+  const resolved = resolveTheme(theme);
+  applyTheme(resolved);
+  if (typeof window !== "undefined") {
+    localStorage.setItem(STORAGE_KEY, theme);
+  }
+  listeners.forEach((l) => l());
+}
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const resolvedTheme = resolveTheme(theme);
+
+  // Listen for system preference changes when theme is "system"
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      if (currentTheme === "system") {
+        applyTheme(getSystemTheme());
+        listeners.forEach((l) => l());
+      }
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // Apply theme on mount
+  useEffect(() => {
+    applyTheme(resolveTheme(currentTheme));
+  }, []);
+
+  const setTheme = useCallback((newTheme: Theme) => {
+    setThemeInternal(newTheme);
+  }, []);
+
+  return { theme, resolvedTheme, setTheme } as const;
+}


### PR DESCRIPTION
## Summary
- Add `useTheme` hook that reads/writes `localStorage("theme")`, listens to `prefers-color-scheme` media query, and toggles `.dark` class on `<html>`
- Add `ThemeToggle` component with sun/moon icon button that cycles through light → dark → system
- Add flash-prevention inline `<script>` in root layout to read localStorage before first paint (prevents FOUC)
- Add `suppressHydrationWarning` to `<html>` for SSR compatibility

## Test plan
- [x] Unit tests for `useTheme` hook (10 tests passing)
- [x] Integration tests for `ThemeToggle` component (6 tests passing)
- [x] All 437 existing tests remain green
- [x] ESLint passes (no new warnings)
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)