### PR TITLE
feat: BlockNote dynamic theme prop for light/dark mode (Phase 7.4)

### DIFF
--- a/__tests__/integration/note-editor.test.tsx
+++ b/__tests__/integration/note-editor.test.tsx
@@ -23,6 +23,15 @@ vi.mock("@blocknote/mantine", () => ({
 
 vi.mock("@blocknote/mantine/style.css", () => ({}));
 
+const mockSetTheme = vi.fn();
+vi.mock("@/hooks/use-theme", () => ({
+  useTheme: () => ({
+    theme: "light" as const,
+    resolvedTheme: "light" as const,
+    setTheme: mockSetTheme,
+  }),
+}));
+
 const mockFetch = vi.fn();
 
 const { NoteEditor } = await import("@/components/editor/note-editor");
@@ -79,7 +88,7 @@ describe("NoteEditor", () => {
     expect(screen.getByTestId("blocknote-editor")).toBeInTheDocument();
   });
 
-  it("passes custom theme with CSS variable colors to BlockNoteView", async () => {
+  it("passes resolved theme to BlockNoteView for dynamic light/dark mode", async () => {
     const { BlockNoteView } = await import("@blocknote/mantine");
     const mockBlockNoteView = vi.mocked(BlockNoteView);
     mockBlockNoteView.mockClear();
@@ -91,29 +100,7 @@ describe("NoteEditor", () => {
     expect(mockBlockNoteView).toHaveBeenCalled();
 
     const props = mockBlockNoteView.mock.calls[0]?.[0] as Record<string, unknown>;
-    const theme = props?.theme as {
-      colors: Record<string, unknown>;
-      borderRadius: number;
-      fontFamily: string;
-    };
-
-    expect(theme.colors.editor).toEqual({ text: "var(--fg)", background: "var(--bg)" });
-    expect(theme.colors.menu).toEqual({ text: "var(--fg)", background: "var(--bg)" });
-    expect(theme.colors.tooltip).toEqual({ text: "var(--fg)", background: "var(--bg-muted)" });
-    expect(theme.colors.hovered).toEqual({ text: "var(--fg)", background: "var(--bg-muted)" });
-    expect(theme.colors.selected).toEqual({
-      text: "var(--fg-on-primary)",
-      background: "var(--ring)",
-    });
-    expect(theme.colors.disabled).toEqual({
-      text: "var(--fg-subtle)",
-      background: "var(--bg-muted)",
-    });
-    expect(theme.colors.shadow).toBe("var(--border)");
-    expect(theme.colors.border).toBe("var(--border)");
-    expect(theme.colors.sideMenu).toBe("var(--fg-subtle)");
-    expect(theme.borderRadius).toBe(6);
-    expect(theme.fontFamily).toBe("var(--font-sans, Arial, Helvetica, sans-serif)");
+    expect(props?.theme).toBe("light");
   });
 
   it("wraps the editor in a scrollable container", async () => {

--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -85,7 +85,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 - [x] 7.1 — Dark mode token overrides in globals.css (.dark class)
 - [x] 7.2 — useTheme hook + ThemeToggle component + flash-prevention script
 - [x] 7.3 — Integrate toggle into app shell sidebar and auth layout
-- [ ] 7.4 — BlockNote dynamic theme prop (light/dark)
+- [x] 7.4 — BlockNote dynamic theme prop (light/dark)
 - [ ] 7.5 — Create ADR-0005 (dark mode implementation)
 - [ ] 7-CP — **Checkpoint**: full suite green, `pnpm build` passes
 - [ ] 7-PUSH — **Push**: `/push` to PR

--- a/src/components/editor/note-editor.tsx
+++ b/src/components/editor/note-editor.tsx
@@ -4,24 +4,8 @@ import { useCallback } from "react";
 import { useCreateBlockNote } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import type { Block } from "@blocknote/core";
-import type { Theme } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
-
-const draftoTheme: Theme = {
-  colors: {
-    editor: { text: "var(--fg)", background: "var(--bg)" },
-    menu: { text: "var(--fg)", background: "var(--bg)" },
-    tooltip: { text: "var(--fg)", background: "var(--bg-muted)" },
-    hovered: { text: "var(--fg)", background: "var(--bg-muted)" },
-    selected: { text: "var(--fg-on-primary)", background: "var(--ring)" },
-    disabled: { text: "var(--fg-subtle)", background: "var(--bg-muted)" },
-    shadow: "var(--border)",
-    border: "var(--border)",
-    sideMenu: "var(--fg-subtle)",
-  },
-  borderRadius: 6,
-  fontFamily: "var(--font-sans, Arial, Helvetica, sans-serif)",
-};
+import { useTheme } from "@/hooks/use-theme";
 
 interface NoteEditorProps {
   noteId: string;
@@ -30,6 +14,7 @@ interface NoteEditorProps {
 }
 
 export function NoteEditor({ noteId, initialContent, onChange }: NoteEditorProps) {
+  const { resolvedTheme } = useTheme();
   const uploadFile = useCallback(
     async (file: File): Promise<string> => {
       const formData = new FormData();
@@ -66,7 +51,7 @@ export function NoteEditor({ noteId, initialContent, onChange }: NoteEditorProps
         onChange={() => {
           onChange?.(editor.document);
         }}
-        theme={draftoTheme}
+        theme={resolvedTheme}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace static `draftoTheme` object with `useTheme` hook's `resolvedTheme` string in `BlockNoteView`
- BlockNote's internal Mantine styling now correctly reflects the app's current light/dark mode
- CSS variable overrides in `globals.css` `.bn-container` continue to handle color synchronization

## Test plan
- [x] Unit/integration tests pass (437/437)
- [x] E2E tests pass (43/43)
- [x] ESLint: 0 errors
- [x] TypeScript: clean
- [x] `pnpm build` passes
- [x] Updated test assertion to verify resolved theme string is passed to BlockNoteView

🤖 Generated with [Claude Code](https://claude.com/claude-code)