### PR TITLE
chore: Phase 7 checkpoint — full suite green, build passes

### DIFF
--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -87,7 +87,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 - [x] 7.3 — Integrate toggle into app shell sidebar and auth layout
 - [x] 7.4 — BlockNote dynamic theme prop (light/dark)
 - [x] 7.5 — Create ADR-0005 (dark mode implementation)
-- [ ] 7-CP — **Checkpoint**: full suite green, `pnpm build` passes
+- [x] 7-CP — **Checkpoint**: full suite green, `pnpm build` passes
 - [ ] 7-PUSH — **Push**: `/push` to PR
 
 ### Phase 8: Animations & Micro-interactions


### PR DESCRIPTION
## Summary
- Verified all tests pass after Phase 7 (dark mode) implementation
- Unit/Integration: 437 tests passed (42 files)
- E2E: 43 passed, 13 skipped (responsive device variations)
- Lint: 0 errors, TypeScript: clean, Production build: clean
- Marks 7-CP task as complete in ui-redesign-plan.md

## Test plan
- [x] Unit and integration tests pass (`CI=true pnpm test -- --run`)
- [x] E2E tests pass (`CI=true pnpm test:e2e`)
- [x] Lint passes (`pnpm lint`)
- [x] TypeScript type check passes (`pnpm exec tsc --noEmit`)
- [x] Production build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)