### PR TITLE
feat: add CSS transitions to interactive elements (Phase 8.1)

### DIFF
--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -92,7 +92,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 
 ### Phase 8: Animations & Micro-interactions
 
-- [ ] 8.1 — CSS transitions on interactive elements (buttons, inputs, sidebar items, note items)
+- [x] 8.1 — CSS transitions on interactive elements (buttons, inputs, sidebar items, note items)
 - [ ] 8.2 — Loading skeletons in component Suspense fallbacks (replace "Loading..." text)
 - [ ] 8.3 — Improved empty states with SVG icons and descriptive text
 - [ ] 8-CP — **Checkpoint**: full suite green

--- a/src/components/notebooks/notebooks-sidebar.tsx
+++ b/src/components/notebooks/notebooks-sidebar.tsx
@@ -230,7 +230,7 @@ export function NotebooksSidebar({
                     if (e.key === "Escape") setEditingId(null);
                   }}
                   maxLength={MAX_NOTEBOOK_NAME_LENGTH}
-                  className="border-border text-fg focus:ring-ring w-full rounded-md border bg-transparent px-2 py-1.5 text-sm focus:ring-1 focus:outline-none"
+                  className="border-border text-fg focus:ring-ring w-full rounded-md border bg-transparent px-2 py-1.5 text-sm transition-colors duration-[var(--transition-fast)] focus:ring-1 focus:outline-none"
                 />
               ) : (
                 <div
@@ -263,7 +263,7 @@ export function NotebooksSidebar({
                       e.stopPropagation();
                       requestDelete(notebook.id);
                     }}
-                    className="text-fg-subtle hover:text-error hidden rounded p-0.5 transition-colors group-focus-within:block group-hover:block"
+                    className="text-fg-subtle hover:text-error hidden rounded p-0.5 transition-colors duration-[var(--transition-fast)] group-focus-within:block group-hover:block"
                     aria-label={`Delete ${notebook.name}`}
                   >
                     <svg
@@ -299,7 +299,7 @@ export function NotebooksSidebar({
                 }}
                 maxLength={MAX_NOTEBOOK_NAME_LENGTH}
                 placeholder="Notebook name"
-                className="border-border text-fg focus:ring-ring w-full rounded-md border bg-transparent px-2 py-1.5 text-sm focus:ring-1 focus:outline-none"
+                className="border-border text-fg focus:ring-ring w-full rounded-md border bg-transparent px-2 py-1.5 text-sm transition-colors duration-[var(--transition-fast)] focus:ring-1 focus:outline-none"
               />
             </li>
           )}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ export function Badge({ variant = "default", className, children, ...props }: Ba
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors duration-[var(--transition-fast)]",
         variantStyles[variant],
         className,
       )}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -22,7 +22,11 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
   return (
     <div
       ref={ref}
-      className={cn("border-border bg-bg rounded-xl border", shadowStyles[shadow], className)}
+      className={cn(
+        "border-border bg-bg rounded-xl border transition-shadow duration-[var(--transition-normal)]",
+        shadowStyles[shadow],
+        className,
+      )}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- Add `transition-colors` with `--transition-fast` duration token to sidebar inline edit/create inputs and delete buttons in notebooks-sidebar
- Add `transition-colors` with `--transition-fast` to Badge component for smooth variant transitions (e.g., save status badge)
- Add `transition-shadow` with `--transition-normal` to Card component for shadow transitions
- Mark Phase 8.1 complete in ui-redesign-plan

## Test plan
- [x] All 437 unit + integration tests pass
- [x] All 42 E2E tests pass (1 pre-existing flaky test)
- [x] ESLint: 0 errors (pre-existing warnings only)
- [x] TypeScript: no errors
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added smooth transitions to interactive UI components for enhanced visual polish when colors and shadows change.

* **Documentation**
  * Updated UI redesign progress tracker with completed milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->