### PR TITLE
feat: enhance Phase 8.1 transitions — opacity fades and auth link transitions

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -45,7 +45,10 @@ export default function ForgotPasswordPage() {
           We&apos;ve sent a password reset link to <strong className="text-fg">{email}</strong>.
           Check your inbox and follow the link to reset your password.
         </p>
-        <Link href="/login" className="text-primary-600 hover:underline">
+        <Link
+          href="/login"
+          className="text-primary-600 hover:text-primary-700 transition-colors duration-[var(--transition-fast)] hover:underline"
+        >
           Back to login
         </Link>
       </div>
@@ -82,7 +85,10 @@ export default function ForgotPasswordPage() {
       </form>
 
       <p className="text-fg-muted mt-4 text-center text-sm">
-        <Link href="/login" className="text-primary-600 hover:underline">
+        <Link
+          href="/login"
+          className="text-primary-600 hover:text-primary-700 transition-colors duration-[var(--transition-fast)] hover:underline"
+        >
           Back to login
         </Link>
       </p>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -79,12 +79,18 @@ export default function LoginPage() {
       <div className="text-fg-muted mt-4 text-center text-sm">
         <p>
           Don&apos;t have an account?{" "}
-          <Link href="/signup" className="text-primary-600 hover:underline">
+          <Link
+            href="/signup"
+            className="text-primary-600 hover:text-primary-700 transition-colors duration-[var(--transition-fast)] hover:underline"
+          >
             Sign up
           </Link>
         </p>
         <p className="mt-2">
-          <Link href="/forgot-password" className="text-primary-600 hover:underline">
+          <Link
+            href="/forgot-password"
+            className="text-primary-600 hover:text-primary-700 transition-colors duration-[var(--transition-fast)] hover:underline"
+          >
             Forgot your password?
           </Link>
         </p>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -84,7 +84,10 @@ export default function ResetPasswordPage() {
       </form>
 
       <p className="text-fg-muted mt-4 text-center text-sm">
-        <Link href="/login" className="text-primary-600 hover:underline">
+        <Link
+          href="/login"
+          className="text-primary-600 hover:text-primary-700 transition-colors duration-[var(--transition-fast)] hover:underline"
+        >
           Back to login
         </Link>
       </p>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -86,7 +86,10 @@ export default function SignupPage() {
 
       <p className="text-fg-muted mt-4 text-center text-sm">
         Already have an account?{" "}
-        <Link href="/login" className="text-primary-600 hover:underline">
+        <Link
+          href="/login"
+          className="text-primary-600 hover:text-primary-700 transition-colors duration-[var(--transition-fast)] hover:underline"
+        >
           Log in
         </Link>
       </p>

--- a/src/components/notebooks/notebooks-sidebar.tsx
+++ b/src/components/notebooks/notebooks-sidebar.tsx
@@ -263,7 +263,7 @@ export function NotebooksSidebar({
                       e.stopPropagation();
                       requestDelete(notebook.id);
                     }}
-                    className="text-fg-subtle hover:text-error hidden rounded p-0.5 transition-colors duration-[var(--transition-fast)] group-focus-within:block group-hover:block"
+                    className="text-fg-subtle hover:text-error rounded p-0.5 opacity-0 transition-all duration-[var(--transition-fast)] group-focus-within:opacity-100 group-hover:opacity-100"
                     aria-label={`Delete ${notebook.name}`}
                   >
                     <svg

--- a/src/components/notes/note-list.tsx
+++ b/src/components/notes/note-list.tsx
@@ -179,7 +179,7 @@ export function NoteList({
                       e.stopPropagation();
                       setMenuOpenForNote(menuOpenForNote === note.id ? null : note.id);
                     }}
-                    className="absolute top-2 right-2 hidden group-focus-within:block group-hover:block"
+                    className="absolute top-2 right-2 opacity-0 transition-opacity duration-[var(--transition-fast)] group-focus-within:opacity-100 group-hover:opacity-100"
                     aria-label={`Actions for ${note.title}`}
                   >
                     <svg


### PR DESCRIPTION
## Summary
- **Sidebar delete button**: smooth opacity fade-in on hover instead of abrupt hidden/block toggle
- **Note list action button**: smooth opacity fade-in on hover instead of abrupt hidden/block toggle  
- **Auth page links**: add `transition-colors` with design token duration and hover color darkening (primary-600 → primary-700)

Completes the remaining Phase 8.1 work — all interactive elements now have smooth CSS transitions.

## Test plan
- [x] Unit + integration tests pass (437/437)
- [x] E2E tests pass (43 passed, 13 skipped)
- [x] ESLint passes (0 errors)
- [x] TypeScript type check passes
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)