### PR TITLE
feat: Phase 8 push — body transition and duration token fix

### DIFF
--- a/docs/ui-redesign-plan.md
+++ b/docs/ui-redesign-plan.md
@@ -96,7 +96,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 - [x] 8.2 — Loading skeletons in component Suspense fallbacks (replace "Loading..." text)
 - [x] 8.3 — Improved empty states with SVG icons and descriptive text
 - [x] 8-CP — **Checkpoint**: full suite green
-- [ ] 8-PUSH — **Push**: `/push` to PR
+- [x] 8-PUSH — **Push**: `/push` to PR
 
 ### Phase 9: Polish & Verification
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -124,6 +124,9 @@ body {
   background: var(--bg);
   color: var(--fg);
   font-family: var(--font-sans, Arial, Helvetica, sans-serif);
+  transition:
+    background-color var(--transition-slow),
+    color var(--transition-slow);
 }
 
 /* ── Micro-interaction Animations ────────────────────────── */

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -300,7 +300,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
       <aside
         className={`${
           mobileView === "notebooks" ? "flex" : "hidden"
-        } bg-sidebar-bg sm:border-border w-full flex-col overflow-hidden sm:fixed sm:inset-y-0 sm:left-0 sm:z-30 sm:flex sm:w-60 sm:shrink-0 sm:border-r sm:transition-transform sm:duration-200 sm:ease-in-out lg:static lg:translate-x-0 ${
+        } bg-sidebar-bg sm:border-border w-full flex-col overflow-hidden sm:fixed sm:inset-y-0 sm:left-0 sm:z-30 sm:flex sm:w-60 sm:shrink-0 sm:border-r sm:transition-transform sm:duration-[var(--transition-normal)] sm:ease-in-out lg:static lg:translate-x-0 ${
           sidebarOpen ? "sm:translate-x-0" : "sm:-translate-x-full"
         }`}
       >


### PR DESCRIPTION
## Summary
- Adds CSS transition on `body` for smooth background/text color animation during dark mode toggle (uses `--transition-slow` token)
- Replaces hardcoded `sm:duration-200` with `sm:duration-[var(--transition-normal)]` on app shell sidebar transform for design token consistency
- Marks 8-PUSH complete in the UI redesign progress tracker

## Test plan
- [x] All 437 unit/integration tests pass
- [x] All 43 E2E tests pass (13 skipped)
- [x] ESLint passes (0 errors)
- [x] TypeScript type check passes
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)