### PR TITLE
feat: dev/prod environment separation — Sentry environment tagging

### DIFF
--- a/docs/Dev-Prod Environment Separation-ralph.md
+++ b/docs/Dev-Prod Environment Separation-ralph.md
@@ -39,7 +39,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 
 ### Phase 1: Environment Tagging (Sentry + PostHog)
 
-- [ ] 1.1 — Add `NEXT_PUBLIC_SENTRY_ENVIRONMENT` to env schema + all Sentry init files
+- [x] 1.1 — Add `NEXT_PUBLIC_SENTRY_ENVIRONMENT` to env schema + all Sentry init files
 - [ ] 1.2 — Add PostHog environment super property
 - [ ] 1-CP — **Checkpoint**: full suite green
 - [ ] 1-PUSH — **Push**: `/push` to PR

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,6 +2,9 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment:
+    process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ??
+    (process.env.NODE_ENV === "production" ? "production" : "development"),
   tracesSampleRate: 1,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -2,6 +2,9 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment:
+    process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ??
+    (process.env.NODE_ENV === "production" ? "production" : "development"),
   tracesSampleRate: 1,
   debug: false,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -2,6 +2,9 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment:
+    process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ??
+    (process.env.NODE_ENV === "production" ? "production" : "development"),
   tracesSampleRate: 1,
   debug: false,
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -12,6 +12,7 @@ export const env = createEnv({
     NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
     NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),
     NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
+    NEXT_PUBLIC_SENTRY_ENVIRONMENT: z.string().optional(),
   },
   runtimeEnv: {
     CRON_SECRET: process.env.CRON_SECRET,
@@ -21,6 +22,7 @@ export const env = createEnv({
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
     NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    NEXT_PUBLIC_SENTRY_ENVIRONMENT: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
   },
   skipValidation: process.env.SKIP_ENV_VALIDATION === "true",
 });


### PR DESCRIPTION
## Summary
- Add `NEXT_PUBLIC_SENTRY_ENVIRONMENT` optional env var to t3-env schema
- Add `environment` config to all three Sentry init files (client, server, edge) with fallback to `NODE_ENV`-based detection
- Mark task 1.1 complete in the ralph planning doc

Part of the dev/prod environment separation effort.

## Test plan
- [x] Unit + integration tests pass (456 tests)
- [x] ESLint clean (no errors)
- [x] TypeScript compiles with no errors
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Sentry error tracking configuration to properly identify and categorize errors across development and production environments, enabling better error context and monitoring visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->