### PR TITLE
feat: add PostHog environment super property

### DIFF
--- a/docs/Dev-Prod Environment Separation-ralph.md
+++ b/docs/Dev-Prod Environment Separation-ralph.md
@@ -40,7 +40,7 @@ You are running in an autonomous, unattended loop. On every single execution, yo
 ### Phase 1: Environment Tagging (Sentry + PostHog)
 
 - [x] 1.1 — Add `NEXT_PUBLIC_SENTRY_ENVIRONMENT` to env schema + all Sentry init files
-- [ ] 1.2 — Add PostHog environment super property
+- [x] 1.2 — Add PostHog environment super property
 - [ ] 1-CP — **Checkpoint**: full suite green
 - [ ] 1-PUSH — **Push**: `/push` to PR
 

--- a/src/lib/posthog/client.ts
+++ b/src/lib/posthog/client.ts
@@ -15,6 +15,9 @@ export function getPostHogClient() {
       person_profiles: "identified_only",
       capture_pageview: false, // We capture manually in the provider
     });
+    posthog.register({
+      environment: process.env.NODE_ENV === "production" ? "production" : "development",
+    });
   }
 
   return posthog;


### PR DESCRIPTION
## Summary
- Registers an `environment` super property (`production` / `development`) on PostHog init
- All PostHog events are now tagged with the environment, enabling dashboard filtering
- Marks task 1.2 complete in the environment separation plan

## Test plan
- [x] Unit + integration tests pass (456 tests)
- [x] E2E tests pass (43 passed, 13 skipped)
- [x] ESLint clean (0 errors)
- [x] TypeScript type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated progress tracking documentation for environment separation.

* **New Features**
  * Implemented automatic environment detection and tracking for analytics, distinguishing between production and development deployments based on deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->