### PR TITLE
chore: mark Phase 0 checkpoint complete

### DIFF
--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -70,7 +70,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 - [x] 0.2 — Move web app to `apps/web/` (update all paths, tsconfig, CI, Vercel)
 - [x] 0.3 — Extract shared package (`packages/shared/` — types, constants)
 - [x] 0.4 — Update CI/CD workflows for monorepo
-- [ ] 0-CP — **Checkpoint**: full web test suite green, `turbo build` passes
+- [x] 0-CP — **Checkpoint**: full web test suite green, `turbo build` passes
 - [ ] 0-PUSH — **Push**: `/push` to PR
 
 ### Phase 1: Expo Project Scaffolding


### PR DESCRIPTION
## Summary
- Verified all Phase 0 monorepo restructure checks pass
- Web unit/integration tests: 513 passed
- Web E2E tests: 46 passed (13 skipped)
- Lint, typecheck, turbo build: all green
- Marked 0-CP task as complete in `docs/mobile_app.md`

## Test plan
- [x] `cd apps/web && pnpm test` — 513 tests passed
- [x] `cd apps/web && pnpm test:e2e` — 46 passed
- [x] `cd apps/web && pnpm lint` — 0 errors
- [x] `cd apps/web && pnpm exec tsc --noEmit` — clean
- [x] `cd packages/shared && pnpm exec tsc --noEmit && pnpm test` — clean
- [x] `pnpm turbo build` — successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)