### PR TITLE
chore: mark Phase 0 push complete (0-PUSH)

### DIFF
--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -71,7 +71,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 - [x] 0.3 — Extract shared package (`packages/shared/` — types, constants)
 - [x] 0.4 — Update CI/CD workflows for monorepo
 - [x] 0-CP — **Checkpoint**: full web test suite green, `turbo build` passes
-- [ ] 0-PUSH — **Push**: `/push` to PR
+- [x] 0-PUSH — **Push**: `/push` to PR
 
 ### Phase 1: Expo Project Scaffolding
 


### PR DESCRIPTION
## Summary
- Marks 0-PUSH task as complete in `docs/mobile_app.md`
- Phase 0 (monorepo restructure) is now fully complete

## Test plan
- Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)