### PR TITLE
feat: set up Expo Router with tab navigation skeleton (1.3)

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,0 +1,28 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export default function LoginScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Log In</Text>
+      <Text style={styles.subtitle}>Sign in to your Drafto account</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "bold",
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: "#666",
+  },
+});

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -1,10 +1,10 @@
 import { Text, View, StyleSheet } from "react-native";
 
-export default function HomeScreen() {
+export default function SignupScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Drafto</Text>
-      <Text style={styles.subtitle}>Your notes, everywhere.</Text>
+      <Text style={styles.title}>Sign Up</Text>
+      <Text style={styles.subtitle}>Create your Drafto account</Text>
     </View>
   );
 }
@@ -12,12 +12,12 @@ export default function HomeScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff",
     alignItems: "center",
     justifyContent: "center",
+    padding: 24,
   },
   title: {
-    fontSize: 32,
+    fontSize: 28,
     fontWeight: "bold",
     marginBottom: 8,
   },

--- a/apps/mobile/app/(auth)/waiting-for-approval.tsx
+++ b/apps/mobile/app/(auth)/waiting-for-approval.tsx
@@ -1,0 +1,32 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export default function WaitingForApprovalScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Awaiting Approval</Text>
+      <Text style={styles.subtitle}>
+        Your account is pending approval. You will be notified once an admin approves your access.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "bold",
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: "#666",
+    textAlign: "center",
+    lineHeight: 24,
+  },
+});

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,0 +1,40 @@
+import { Tabs } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+
+export default function TabsLayout() {
+  return (
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: "#4f46e5",
+      }}
+    >
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: "Notebooks",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="book-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="trash"
+        options={{
+          title: "Trash",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="trash-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: "Settings",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="settings-outline" size={size} color={color} />
+          ),
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,0 +1,21 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export default function NotebooksScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Notebooks</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  text: {
+    fontSize: 18,
+    color: "#666",
+  },
+});

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,0 +1,21 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Settings</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  text: {
+    fontSize: 18,
+    color: "#666",
+  },
+});

--- a/apps/mobile/app/(tabs)/trash.tsx
+++ b/apps/mobile/app/(tabs)/trash.tsx
@@ -1,0 +1,21 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export default function TrashScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Trash</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  text: {
+    fontSize: 18,
+    color: "#666",
+  },
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -4,7 +4,17 @@ import { StatusBar } from "expo-status-bar";
 export default function RootLayout() {
   return (
     <>
-      <Stack />
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="(auth)/login" options={{ title: "Log In" }} />
+        <Stack.Screen name="(auth)/signup" options={{ title: "Sign Up" }} />
+        <Stack.Screen
+          name="(auth)/waiting-for-approval"
+          options={{ title: "Awaiting Approval", headerBackVisible: false }}
+        />
+        <Stack.Screen name="notebooks/[id]" options={{ title: "Notes" }} />
+        <Stack.Screen name="notes/[id]" options={{ title: "Editor" }} />
+      </Stack>
       <StatusBar style="auto" />
     </>
   );

--- a/apps/mobile/app/notebooks/[id].tsx
+++ b/apps/mobile/app/notebooks/[id].tsx
@@ -1,0 +1,24 @@
+import { Text, View, StyleSheet } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+
+export default function NotesListScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Notes in notebook {id}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  text: {
+    fontSize: 18,
+    color: "#666",
+  },
+});

--- a/apps/mobile/app/notes/[id].tsx
+++ b/apps/mobile/app/notes/[id].tsx
@@ -1,0 +1,24 @@
+import { Text, View, StyleSheet } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+
+export default function EditorScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Editor for note {id}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  text: {
+    fontSize: 18,
+    color: "#666",
+  },
+});

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@drafto/shared": "workspace:*",
+    "@expo/vector-icons": "^15.1.1",
     "expo": "~55.0.5",
     "expo-constants": "~55.0.7",
     "expo-linking": "~55.0.7",

--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -77,7 +77,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 
 - [x] 1.1 — Initialize Expo project in `apps/mobile/` with TypeScript
 - [x] 1.2 — Configure ESLint, Prettier (matching web conventions)
-- [ ] 1.3 — Set up Expo Router with tab navigation skeleton (Notebooks, Trash, Settings)
+- [x] 1.3 — Set up Expo Router with tab navigation skeleton (Notebooks, Trash, Settings)
 - [ ] 1.4 — Create ADR-0009 (mobile app technology choices)
 - [ ] 1-CP — **Checkpoint**: `apps/mobile` builds for iOS simulator and Android emulator
 - [ ] 1-PUSH — **Push**: `/push` to PR

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@drafto/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@expo/vector-icons':
+        specifier: ^15.1.1
+        version: 15.1.1(expo-font@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo:
         specifier: ~55.0.5
         version: 55.0.5(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.4)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- Set up Expo Router navigation with root Stack, tab navigator (Notebooks, Trash, Settings), auth screens (login, signup, waiting-for-approval), and dynamic routes (notebooks/[id], notes/[id])
- Added `@expo/vector-icons` for tab bar Ionicons
- All screens are placeholder skeletons to be fleshed out in later phases

## Test plan

- [x] `cd apps/mobile && pnpm lint` passes
- [x] `cd apps/mobile && pnpm exec tsc --noEmit` passes
- [x] `cd apps/web && CI=true pnpm test -- --run` — all 513 tests pass
- [x] `cd apps/web && pnpm exec tsc --noEmit` passes
- [x] `cd packages/shared && pnpm exec tsc --noEmit && pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented login and signup screens with updated user interface text and styling.
  * Added tab-based navigation with Notebooks, Trash, and Settings sections.
  * Introduced account approval workflow for new user onboarding.
  * Created note editor and notebook management views for content organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->