### PR TITLE
feat: add Supabase client for React Native with expo-secure-store (2.1)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -30,5 +30,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   web: {
     favicon: "./assets/favicon.png",
   },
-  plugins: ["expo-router"],
+  extra: {
+    supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL,
+    supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY,
+  },
+  plugins: ["expo-router", "expo-secure-store"],
 });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -13,10 +13,12 @@
   "dependencies": {
     "@drafto/shared": "workspace:*",
     "@expo/vector-icons": "^15.1.1",
+    "@supabase/supabase-js": "^2.98.0",
     "expo": "~55.0.5",
     "expo-constants": "~55.0.7",
     "expo-linking": "~55.0.7",
     "expo-router": "~55.0.4",
+    "expo-secure-store": "^55.0.8",
     "expo-status-bar": "~55.0.4",
     "react": "19.2.0",
     "react-native": "0.83.2",

--- a/apps/mobile/src/lib/secure-store-adapter.ts
+++ b/apps/mobile/src/lib/secure-store-adapter.ts
@@ -1,0 +1,13 @@
+import * as SecureStore from "expo-secure-store";
+
+export const secureStoreAdapter = {
+  getItem: (key: string): Promise<string | null> => {
+    return SecureStore.getItemAsync(key);
+  },
+  setItem: (key: string, value: string): Promise<void> => {
+    return SecureStore.setItemAsync(key, value);
+  },
+  removeItem: (key: string): Promise<void> => {
+    return SecureStore.deleteItemAsync(key);
+  },
+};

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -1,0 +1,25 @@
+import { createClient } from "@supabase/supabase-js";
+import Constants from "expo-constants";
+import { Platform } from "react-native";
+
+import type { Database } from "@drafto/shared";
+
+import { secureStoreAdapter } from "./secure-store-adapter";
+
+const supabaseUrl = Constants.expoConfig?.extra?.supabaseUrl as string;
+const supabaseAnonKey = Constants.expoConfig?.extra?.supabaseAnonKey as string;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    "Missing Supabase configuration. Set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY in your environment.",
+  );
+}
+
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    storage: secureStoreAdapter,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: Platform.OS === "web",
+  },
+});

--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -84,7 +84,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 
 ### Phase 2: Authentication
 
-- [ ] 2.1 — Supabase client for React Native with `expo-secure-store` token storage
+- [x] 2.1 — Supabase client for React Native with `expo-secure-store` token storage
 - [ ] 2.2 — Login screen (email/password)
 - [ ] 2.3 — Signup screen + waiting-for-approval screen
 - [ ] 2.4 — Auth provider (session persistence, auto-refresh, approval check)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.1.1
         version: 15.1.1(expo-font@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@supabase/supabase-js':
+        specifier: ^2.98.0
+        version: 2.98.0
       expo:
         specifier: ~55.0.5
         version: 55.0.5(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.4)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -54,6 +57,9 @@ importers:
       expo-router:
         specifier: ~55.0.4
         version: 55.0.4(@expo/log-box@55.0.7)(@expo/metro-runtime@55.0.6)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(expo-constants@55.0.7)(expo-font@55.0.4)(expo-linking@55.0.7)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native-safe-area-context@5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-screens@4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-secure-store:
+        specifier: ^55.0.8
+        version: 55.0.8(expo@55.0.5)
       expo-status-bar:
         specifier: ~55.0.4
         version: 55.0.4(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -4337,6 +4343,11 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
+
+  expo-secure-store@55.0.8:
+    resolution: {integrity: sha512-8w9tQe8U6oRo5YIzqCqVhRrOnfoODNDoitBtLXEx+zS6WLUnkRq5kH7ViJuOgiM7PzLr9pvAliRiDOKyvFbTuQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-server@55.0.6:
     resolution: {integrity: sha512-xI72FTm469FfuuBL2R5aNtthgH+GR7ygOpsx/KcPS0K8AZaZd7VjtEExbzn9/qyyYkWW3T+3dAmCDKOMX8gdmQ==}
@@ -12188,6 +12199,10 @@ snapshots:
       - '@types/react-dom'
       - expo-font
       - supports-color
+
+  expo-secure-store@55.0.8(expo@55.0.5):
+    dependencies:
+      expo: 55.0.5(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.4)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-server@55.0.6: {}
 


### PR DESCRIPTION
## Summary
- Install `@supabase/supabase-js` and `expo-secure-store` in `apps/mobile`
- Create `SecureStore` adapter for secure token persistence across app restarts
- Create typed Supabase client at `apps/mobile/src/lib/supabase.ts` using `Database` type from `@drafto/shared`
- Configure `app.config.ts` with `extra` field for Supabase env vars (`EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_ANON_KEY`)
- Add `expo-secure-store` plugin to Expo config

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)