### PR TITLE
feat: add signup screen and waiting-for-approval screen (2.3)

### DIFF
--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -1,17 +1,138 @@
-import { Text, View, StyleSheet } from "react-native";
+import { useState } from "react";
+import {
+  Text,
+  View,
+  TextInput,
+  Pressable,
+  StyleSheet,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from "react-native";
+import { Link, router } from "expo-router";
+
+import { supabase } from "@/lib/supabase";
 
 export default function SignupScreen() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSignup = async () => {
+    if (!email.trim() || !password) {
+      setError("Please enter your email and password.");
+      return;
+    }
+
+    if (password.length < 6) {
+      setError("Password must be at least 6 characters.");
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+
+    try {
+      const { error: signUpError } = await supabase.auth.signUp({
+        email: email.trim(),
+        password,
+      });
+
+      if (signUpError) {
+        setError(signUpError.message);
+        return;
+      }
+
+      router.replace("/(auth)/waiting-for-approval");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Sign Up</Text>
-      <Text style={styles.subtitle}>Create your Drafto account</Text>
-    </View>
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+    >
+      <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+        <Text style={styles.title}>Sign Up</Text>
+        <Text style={styles.subtitle}>Create your Drafto account</Text>
+
+        {error && (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        )}
+
+        <View style={styles.form}>
+          <Text style={styles.label}>Email</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="you@example.com"
+            placeholderTextColor="#9ca3af"
+            value={email}
+            onChangeText={setEmail}
+            autoCapitalize="none"
+            autoComplete="email"
+            keyboardType="email-address"
+            textContentType="emailAddress"
+            editable={!loading}
+          />
+
+          <Text style={styles.label}>Password</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Min. 6 characters"
+            placeholderTextColor="#9ca3af"
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry
+            autoCapitalize="none"
+            autoCorrect={false}
+            autoComplete="password"
+            textContentType="newPassword"
+            editable={!loading}
+            onSubmitEditing={handleSignup}
+          />
+
+          <Pressable
+            style={({ pressed }) => [
+              styles.button,
+              pressed && styles.buttonPressed,
+              loading && styles.buttonDisabled,
+            ]}
+            onPress={handleSignup}
+            disabled={loading}
+          >
+            {loading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.buttonText}>Sign up</Text>
+            )}
+          </Pressable>
+        </View>
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            Already have an account?{" "}
+            <Link href="/(auth)/login" style={styles.link}>
+              Log in
+            </Link>
+          </Text>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  flex: {
     flex: 1,
+  },
+  container: {
+    flexGrow: 1,
     alignItems: "center",
     justifyContent: "center",
     padding: 24,
@@ -24,5 +145,68 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: 16,
     color: "#666",
+    marginBottom: 24,
+  },
+  errorContainer: {
+    backgroundColor: "#fef2f2",
+    borderWidth: 1,
+    borderColor: "#fecaca",
+    borderRadius: 8,
+    padding: 12,
+    width: "100%",
+    marginBottom: 16,
+  },
+  errorText: {
+    color: "#dc2626",
+    fontSize: 14,
+    textAlign: "center",
+  },
+  form: {
+    width: "100%",
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: 6,
+    color: "#374151",
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    marginBottom: 16,
+    backgroundColor: "#fff",
+    color: "#111827",
+  },
+  button: {
+    backgroundColor: "#4f46e5",
+    borderRadius: 8,
+    padding: 14,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  buttonPressed: {
+    backgroundColor: "#4338ca",
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+  buttonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  footer: {
+    marginTop: 24,
+  },
+  footerText: {
+    fontSize: 14,
+    color: "#666",
+  },
+  link: {
+    color: "#4f46e5",
+    fontWeight: "600",
   },
 });

--- a/apps/mobile/app/(auth)/waiting-for-approval.tsx
+++ b/apps/mobile/app/(auth)/waiting-for-approval.tsx
@@ -1,12 +1,106 @@
-import { Text, View, StyleSheet } from "react-native";
+import { useState } from "react";
+import { Text, View, Pressable, StyleSheet, ActivityIndicator } from "react-native";
+import { router } from "expo-router";
+
+import { supabase } from "@/lib/supabase";
 
 export default function WaitingForApprovalScreen() {
+  const [checking, setChecking] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCheckApproval = async () => {
+    setError(null);
+    setChecking(true);
+
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        router.replace("/(auth)/login");
+        return;
+      }
+
+      const { data: profile, error: profileError } = await supabase
+        .from("profiles")
+        .select("is_approved")
+        .eq("id", user.id)
+        .single();
+
+      if (profileError) {
+        setError("Could not check approval status. Please try again.");
+        return;
+      }
+
+      if (profile?.is_approved) {
+        router.replace("/(tabs)");
+      } else {
+        setError("Your account is still pending approval.");
+      }
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const handleSignOut = async () => {
+    setSigningOut(true);
+
+    try {
+      await supabase.auth.signOut();
+      router.replace("/(auth)/login");
+    } finally {
+      setSigningOut(false);
+    }
+  };
+
   return (
     <View style={styles.container}>
+      <Text style={styles.icon}>&#9203;</Text>
       <Text style={styles.title}>Awaiting Approval</Text>
       <Text style={styles.subtitle}>
-        Your account is pending approval. You will be notified once an admin approves your access.
+        Your account has been created and is pending admin approval. You will be able to access
+        Drafto once an admin approves your account.
       </Text>
+
+      {error && (
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      )}
+
+      <Pressable
+        style={({ pressed }) => [
+          styles.button,
+          pressed && styles.buttonPressed,
+          checking && styles.buttonDisabled,
+        ]}
+        onPress={handleCheckApproval}
+        disabled={checking || signingOut}
+      >
+        {checking ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text style={styles.buttonText}>Check approval status</Text>
+        )}
+      </Pressable>
+
+      <Pressable
+        style={({ pressed }) => [
+          styles.signOutButton,
+          pressed && styles.signOutButtonPressed,
+          signingOut && styles.buttonDisabled,
+        ]}
+        onPress={handleSignOut}
+        disabled={checking || signingOut}
+      >
+        {signingOut ? (
+          <ActivityIndicator color="#4f46e5" />
+        ) : (
+          <Text style={styles.signOutButtonText}>Sign out</Text>
+        )}
+      </Pressable>
     </View>
   );
 }
@@ -18,6 +112,10 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     padding: 24,
   },
+  icon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
   title: {
     fontSize: 28,
     fontWeight: "bold",
@@ -28,5 +126,55 @@ const styles = StyleSheet.create({
     color: "#666",
     textAlign: "center",
     lineHeight: 24,
+    marginBottom: 32,
+  },
+  errorContainer: {
+    backgroundColor: "#fef2f2",
+    borderWidth: 1,
+    borderColor: "#fecaca",
+    borderRadius: 8,
+    padding: 12,
+    width: "100%",
+    marginBottom: 16,
+  },
+  errorText: {
+    color: "#dc2626",
+    fontSize: 14,
+    textAlign: "center",
+  },
+  button: {
+    backgroundColor: "#4f46e5",
+    borderRadius: 8,
+    padding: 14,
+    alignItems: "center",
+    width: "100%",
+    marginBottom: 12,
+  },
+  buttonPressed: {
+    backgroundColor: "#4338ca",
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+  buttonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  signOutButton: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderRadius: 8,
+    padding: 14,
+    alignItems: "center",
+    width: "100%",
+  },
+  signOutButtonPressed: {
+    backgroundColor: "#f3f4f6",
+  },
+  signOutButtonText: {
+    color: "#4f46e5",
+    fontSize: 16,
+    fontWeight: "600",
   },
 });

--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -86,7 +86,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 
 - [x] 2.1 — Supabase client for React Native with `expo-secure-store` token storage
 - [x] 2.2 — Login screen (email/password)
-- [ ] 2.3 — Signup screen + waiting-for-approval screen
+- [x] 2.3 — Signup screen + waiting-for-approval screen
 - [ ] 2.4 — Auth provider (session persistence, auto-refresh, approval check)
 - [ ] 2.5 — Protected route guard (redirect unauthenticated/unapproved users)
 - [ ] 2-CP — **Checkpoint**: login/signup works on simulator, tokens persist across app restarts


### PR DESCRIPTION
## Summary

- Implement signup screen with email/password form, validation (min 6 char password), and `supabase.auth.signUp()` integration
- Implement waiting-for-approval screen with "Check approval status" button (queries `profiles.is_approved`) and sign-out functionality
- Both screens follow existing login screen patterns and indigo styling

## Test plan

- [x] `pnpm lint` passes
- [x] `tsc --noEmit` passes
- [ ] Manual test: signup flow on iOS simulator
- [ ] Manual test: waiting-for-approval check and sign-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)