### PR TITLE
feat: add notes list screen with full CRUD (3.3)

### DIFF
--- a/apps/mobile/app/notebooks/[id].tsx
+++ b/apps/mobile/app/notebooks/[id].tsx
@@ -1,12 +1,235 @@
-import { Text, View, StyleSheet } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+import {
+  Text,
+  View,
+  FlatList,
+  Pressable,
+  TextInput,
+  Alert,
+  ActivityIndicator,
+  StyleSheet,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import type { NoteRow } from "@drafto/shared";
+
+import { useAuth } from "@/providers/auth-provider";
+import { getNotes, createNote, updateNote, trashNote } from "@/lib/data";
 
 export default function NotesListScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id: notebookId } = useLocalSearchParams<{ id: string }>();
+  const { user } = useAuth();
+  const router = useRouter();
+
+  const [notes, setNotes] = useState<NoteRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const fetchNotes = useCallback(async () => {
+    if (!notebookId) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await getNotes(notebookId);
+      setNotes(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load notes");
+    } finally {
+      setLoading(false);
+    }
+  }, [notebookId]);
+
+  useEffect(() => {
+    fetchNotes();
+  }, [fetchNotes]);
+
+  const handleCreate = async () => {
+    const trimmed = newTitle.trim();
+    if (!user || !notebookId || submitting) return;
+
+    try {
+      setSubmitting(true);
+      const note = await createNote(user.id, notebookId, trimmed || undefined);
+      setNotes((prev) => [note, ...prev]);
+      setNewTitle("");
+      setCreating(false);
+    } catch (err) {
+      Alert.alert("Error", err instanceof Error ? err.message : "Failed to create note");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRename = async (id: string) => {
+    const trimmed = editTitle.trim();
+    if (!trimmed || submitting) return;
+
+    try {
+      setSubmitting(true);
+      const updated = await updateNote(id, { title: trimmed });
+      setNotes((prev) => prev.map((n) => (n.id === id ? updated : n)));
+      setEditingId(null);
+      setEditTitle("");
+    } catch (err) {
+      Alert.alert("Error", err instanceof Error ? err.message : "Failed to rename note");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleTrash = (id: string, title: string) => {
+    Alert.alert("Move to Trash", `Are you sure you want to trash "${title}"?`, [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Trash",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await trashNote(id);
+            setNotes((prev) => prev.filter((n) => n.id !== id));
+          } catch (err) {
+            Alert.alert("Error", err instanceof Error ? err.message : "Failed to trash note");
+          }
+        },
+      },
+    ]);
+  };
+
+  const startEditing = (note: NoteRow) => {
+    setEditingId(note.id);
+    setEditTitle(note.title);
+  };
+
+  const renderNote = ({ item }: { item: NoteRow }) => {
+    if (editingId === item.id) {
+      return (
+        <View style={styles.row}>
+          <TextInput
+            style={[styles.input, styles.editInput]}
+            value={editTitle}
+            onChangeText={setEditTitle}
+            autoFocus
+            onSubmitEditing={() => handleRename(item.id)}
+            returnKeyType="done"
+          />
+          <Pressable onPress={() => handleRename(item.id)} style={styles.iconButton}>
+            <Ionicons name="checkmark" size={22} color="#4f46e5" />
+          </Pressable>
+          <Pressable
+            onPress={() => {
+              setEditingId(null);
+              setEditTitle("");
+            }}
+            style={styles.iconButton}
+          >
+            <Ionicons name="close" size={22} color="#6b7280" />
+          </Pressable>
+        </View>
+      );
+    }
+
+    return (
+      <Pressable
+        style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+        onPress={() => router.push(`/notes/${item.id}`)}
+        onLongPress={() => startEditing(item)}
+      >
+        <Ionicons name="document-text-outline" size={20} color="#4f46e5" style={styles.rowIcon} />
+        <View style={styles.rowContent}>
+          <Text style={styles.rowText} numberOfLines={1}>
+            {item.title}
+          </Text>
+          <Text style={styles.rowDate} numberOfLines={1}>
+            {new Date(item.updated_at).toLocaleDateString()}
+          </Text>
+        </View>
+        <Pressable
+          onPress={() => handleTrash(item.id, item.title)}
+          style={styles.iconButton}
+          hitSlop={8}
+        >
+          <Ionicons name="trash-outline" size={18} color="#9ca3af" />
+        </Pressable>
+      </Pressable>
+    );
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color="#4f46e5" />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{error}</Text>
+        <Pressable style={styles.retryButton} onPress={fetchNotes}>
+          <Text style={styles.retryText}>Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Notes in notebook {id}</Text>
+      {creating && (
+        <View style={styles.createBar}>
+          <TextInput
+            style={[styles.input, styles.createInput]}
+            placeholder="Note title (optional)"
+            placeholderTextColor="#9ca3af"
+            value={newTitle}
+            onChangeText={setNewTitle}
+            autoFocus
+            onSubmitEditing={handleCreate}
+            returnKeyType="done"
+          />
+          <Pressable onPress={handleCreate} style={styles.iconButton}>
+            <Ionicons name="checkmark" size={22} color="#4f46e5" />
+          </Pressable>
+          <Pressable
+            onPress={() => {
+              setCreating(false);
+              setNewTitle("");
+            }}
+            style={styles.iconButton}
+          >
+            <Ionicons name="close" size={22} color="#6b7280" />
+          </Pressable>
+        </View>
+      )}
+
+      {notes.length === 0 && !creating ? (
+        <View style={styles.centered}>
+          <Ionicons name="document-text-outline" size={48} color="#d1d5db" />
+          <Text style={styles.emptyText}>No notes yet</Text>
+          <Text style={styles.emptySubtext}>Tap + to create one</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={notes}
+          keyExtractor={(item) => item.id}
+          renderItem={renderNote}
+          contentContainerStyle={styles.list}
+        />
+      )}
+
+      {!creating && (
+        <Pressable
+          style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
+          onPress={() => setCreating(true)}
+        >
+          <Ionicons name="add" size={28} color="#fff" />
+        </Pressable>
+      )}
     </View>
   );
 }
@@ -14,11 +237,118 @@ export default function NotesListScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: "#fafaf9",
+  },
+  centered: {
+    flex: 1,
     alignItems: "center",
     justifyContent: "center",
+    padding: 24,
+    backgroundColor: "#fafaf9",
   },
-  text: {
+  list: {
+    paddingVertical: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    backgroundColor: "#fff",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#e5e7eb",
+  },
+  rowPressed: {
+    backgroundColor: "#f3f4f6",
+  },
+  rowIcon: {
+    marginRight: 12,
+  },
+  rowContent: {
+    flex: 1,
+  },
+  rowText: {
+    fontSize: 16,
+    color: "#111827",
+  },
+  rowDate: {
+    fontSize: 12,
+    color: "#9ca3af",
+    marginTop: 2,
+  },
+  iconButton: {
+    padding: 6,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderRadius: 8,
+    padding: 10,
+    fontSize: 16,
+    backgroundColor: "#fff",
+    color: "#111827",
+  },
+  createBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    backgroundColor: "#fff",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#e5e7eb",
+  },
+  createInput: {
+    flex: 1,
+    marginRight: 8,
+  },
+  editInput: {
+    flex: 1,
+    marginRight: 8,
+  },
+  fab: {
+    position: "absolute",
+    right: 20,
+    bottom: 20,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: "#4f46e5",
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 4,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+  },
+  fabPressed: {
+    backgroundColor: "#4338ca",
+  },
+  emptyText: {
     fontSize: 18,
-    color: "#666",
+    color: "#6b7280",
+    marginTop: 12,
+  },
+  emptySubtext: {
+    fontSize: 14,
+    color: "#9ca3af",
+    marginTop: 4,
+  },
+  errorText: {
+    fontSize: 16,
+    color: "#dc2626",
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  retryButton: {
+    backgroundColor: "#4f46e5",
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+  },
+  retryText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
   },
 });

--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -96,7 +96,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 
 - [x] 3.1 — Supabase data layer (typed query functions for notebooks, notes, trash)
 - [x] 3.2 — Notebooks list screen (fetch, create, rename, delete)
-- [ ] 3.3 — Notes list screen (fetch, create, select, trash)
+- [x] 3.3 — Notes list screen (fetch, create, select, trash)
 - [ ] 3.4 — Note editor screen with 10tap-editor
 - [ ] 3.5 — BlockNote <-> TipTap format converter (in `packages/shared`)
 - [ ] 3.6 — Auto-save with debounce


### PR DESCRIPTION
## Summary
- Implement notes list screen at `notebooks/[id].tsx` with full CRUD operations
- Fetch, create, rename (long-press), and trash notes with confirmation
- Navigate to note editor on tap, shows updated_at date per note
- Follows same patterns as notebooks list screen (loading/error/empty states, FAB, inline editing)

## Test plan
- [x] Mobile lint passes
- [x] Mobile TypeScript check passes
- [x] Web unit + integration tests pass (513 tests)
- [x] Web E2E tests pass (46 tests)
- [x] Shared package checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)