### PR TITLE
feat: add BlockNote <-> TipTap format converter (3.5)

### DIFF
--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -98,7 +98,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 - [x] 3.2 — Notebooks list screen (fetch, create, rename, delete)
 - [x] 3.3 — Notes list screen (fetch, create, select, trash)
 - [x] 3.4 — Note editor screen with 10tap-editor
-- [ ] 3.5 — BlockNote <-> TipTap format converter (in `packages/shared`)
+- [x] 3.5 — BlockNote <-> TipTap format converter (in `packages/shared`)
 - [ ] 3.6 — Auto-save with debounce
 - [ ] 3-CP — **Checkpoint**: full CRUD works online, content round-trips with web app
 - [ ] 3-PUSH — **Push**: `/push` to PR

--- a/packages/shared/__tests__/format-converter.test.ts
+++ b/packages/shared/__tests__/format-converter.test.ts
@@ -1,0 +1,720 @@
+import { describe, it, expect } from "vitest";
+import { blocknoteToTiptap, tiptapToBlocknote } from "../src/editor/format-converter";
+import type { BlockNoteBlock, TipTapDoc } from "../src/editor/types";
+
+describe("blocknoteToTiptap", () => {
+  it("converts a simple paragraph", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "Hello world", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+
+    expect(doc).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    });
+  });
+
+  it("converts a heading with level", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "heading",
+        props: { level: 2 },
+        content: [{ type: "text", text: "My Heading", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+
+    expect(doc.content[0]).toEqual({
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "My Heading" }],
+    });
+  });
+
+  it("converts styled text with bold and italic", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "bold", styles: { bold: true } },
+          { type: "text", text: " and ", styles: {} },
+          { type: "text", text: "italic", styles: { italic: true } },
+        ],
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+    const content = doc.content[0].content!;
+
+    expect(content[0]).toEqual({
+      type: "text",
+      text: "bold",
+      marks: [{ type: "bold" }],
+    });
+    expect(content[1]).toEqual({ type: "text", text: " and " });
+    expect(content[2]).toEqual({
+      type: "text",
+      text: "italic",
+      marks: [{ type: "italic" }],
+    });
+  });
+
+  it("converts a link", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "link",
+            text: "click here",
+            href: "https://drafto.eu",
+            content: [{ type: "text", text: "click here", styles: {} }],
+          },
+        ],
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+    const content = doc.content[0].content!;
+
+    expect(content[0]).toEqual({
+      type: "text",
+      text: "click here",
+      marks: [{ type: "link", attrs: { href: "https://drafto.eu" } }],
+    });
+  });
+
+  it("converts bullet list items and merges adjacent", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Item 1", styles: {} }],
+        children: [],
+      },
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Item 2", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+
+    expect(doc.content).toHaveLength(1);
+    expect(doc.content[0].type).toBe("bulletList");
+    expect(doc.content[0].content).toHaveLength(2);
+  });
+
+  it("converts numbered list items and merges adjacent", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "numberedListItem",
+        content: [{ type: "text", text: "First", styles: {} }],
+        children: [],
+      },
+      {
+        type: "numberedListItem",
+        content: [{ type: "text", text: "Second", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+
+    expect(doc.content).toHaveLength(1);
+    expect(doc.content[0].type).toBe("orderedList");
+    expect(doc.content[0].content).toHaveLength(2);
+  });
+
+  it("converts nested bullet list items", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Parent", styles: {} }],
+        children: [
+          {
+            type: "bulletListItem",
+            content: [{ type: "text", text: "Child", styles: {} }],
+            children: [],
+          },
+        ],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+
+    const li = doc.content[0].content![0];
+    expect(li.content).toHaveLength(2);
+    expect(li.content![1].type).toBe("bulletList");
+    expect(li.content![1].content![0].content![0].content![0].text).toBe("Child");
+  });
+
+  it("converts check list items", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "checkListItem",
+        props: { checked: true },
+        content: [{ type: "text", text: "Done task", styles: {} }],
+        children: [],
+      },
+      {
+        type: "checkListItem",
+        props: { checked: false },
+        content: [{ type: "text", text: "Todo task", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+
+    expect(doc.content).toHaveLength(1);
+    expect(doc.content[0].type).toBe("taskList");
+    const items = doc.content[0].content!;
+    expect(items[0].attrs?.checked).toBe(true);
+    expect(items[1].attrs?.checked).toBe(false);
+  });
+
+  it("converts a code block", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "codeBlock",
+        props: { language: "typescript" },
+        content: [{ type: "text", text: "const x = 1;", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+
+    expect(doc.content[0]).toEqual({
+      type: "codeBlock",
+      attrs: { language: "typescript" },
+      content: [{ type: "text", text: "const x = 1;" }],
+    });
+  });
+
+  it("converts an image", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "image",
+        props: { url: "https://example.com/img.png", caption: "A photo", width: 400 },
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+
+    expect(doc.content[0]).toEqual({
+      type: "image",
+      attrs: { src: "https://example.com/img.png", alt: "A photo", width: 400 },
+    });
+  });
+
+  it("converts a table", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "table",
+        content: {
+          type: "tableContent",
+          rows: [
+            {
+              cells: [
+                [{ type: "text", text: "A", styles: {} }],
+                [{ type: "text", text: "B", styles: {} }],
+              ],
+            },
+            {
+              cells: [
+                [{ type: "text", text: "C", styles: {} }],
+                [{ type: "text", text: "D", styles: {} }],
+              ],
+            },
+          ],
+        },
+        children: [],
+      },
+    ];
+
+    const doc = blocknoteToTiptap(blocks);
+    const table = doc.content[0];
+
+    expect(table.type).toBe("table");
+    expect(table.content).toHaveLength(2);
+    expect(table.content![0].type).toBe("tableRow");
+    expect(table.content![0].content![0].type).toBe("tableCell");
+  });
+
+  it("converts empty blocks", () => {
+    const blocks: BlockNoteBlock[] = [{ type: "paragraph", content: [], children: [] }];
+
+    const doc = blocknoteToTiptap(blocks);
+
+    expect(doc.content[0]).toEqual({ type: "paragraph" });
+  });
+
+  it("converts empty input", () => {
+    const doc = blocknoteToTiptap([]);
+    expect(doc).toEqual({ type: "doc", content: [] });
+  });
+});
+
+describe("tiptapToBlocknote", () => {
+  it("converts a simple paragraph", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks).toEqual([
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "Hello world", styles: {} }],
+        children: [],
+      },
+    ]);
+  });
+
+  it("converts a heading", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 3 },
+          content: [{ type: "text", text: "Title" }],
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks[0]).toEqual({
+      type: "heading",
+      props: { level: 3 },
+      content: [{ type: "text", text: "Title", styles: {} }],
+      children: [],
+    });
+  });
+
+  it("converts styled text with marks", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "bold text",
+              marks: [{ type: "bold" }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks[0].content).toEqual([
+      { type: "text", text: "bold text", styles: { bold: true } },
+    ]);
+  });
+
+  it("converts a link mark to link inline content", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "click",
+              marks: [{ type: "link", attrs: { href: "https://drafto.eu" } }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks[0].content).toEqual([
+      {
+        type: "link",
+        text: "click",
+        href: "https://drafto.eu",
+        content: [{ type: "text", text: "click", styles: {} }],
+      },
+    ]);
+  });
+
+  it("converts a bullet list", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [{ type: "paragraph", content: [{ type: "text", text: "A" }] }],
+            },
+            {
+              type: "listItem",
+              content: [{ type: "paragraph", content: [{ type: "text", text: "B" }] }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("bulletListItem");
+    expect(blocks[1].type).toBe("bulletListItem");
+  });
+
+  it("converts nested lists", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                { type: "paragraph", content: [{ type: "text", text: "Parent" }] },
+                {
+                  type: "bulletList",
+                  content: [
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Child" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].children).toHaveLength(1);
+    expect(blocks[0].children![0].type).toBe("bulletListItem");
+  });
+
+  it("converts a task list", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "taskList",
+          content: [
+            {
+              type: "taskItem",
+              attrs: { checked: true },
+              content: [{ type: "paragraph", content: [{ type: "text", text: "Done" }] }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks[0].type).toBe("checkListItem");
+    expect(blocks[0].props?.checked).toBe(true);
+  });
+
+  it("converts a code block", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "python" },
+          content: [{ type: "text", text: "print('hi')" }],
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks[0]).toEqual({
+      type: "codeBlock",
+      props: { language: "python" },
+      content: [{ type: "text", text: "print('hi')", styles: {} }],
+      children: [],
+    });
+  });
+
+  it("converts an image", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "image",
+          attrs: { src: "https://example.com/img.png", alt: "Photo", width: 300 },
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks[0]).toEqual({
+      type: "image",
+      props: { url: "https://example.com/img.png", caption: "Photo", width: 300 },
+      children: [],
+    });
+  });
+
+  it("converts a table", () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableCell",
+                  content: [{ type: "paragraph", content: [{ type: "text", text: "X" }] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blocks = tiptapToBlocknote(doc);
+
+    expect(blocks[0].type).toBe("table");
+    const tableContent = blocks[0].content as { type: string; rows: { cells: unknown[][] }[] };
+    expect(tableContent.type).toBe("tableContent");
+    expect(tableContent.rows).toHaveLength(1);
+    expect(tableContent.rows[0].cells).toHaveLength(1);
+  });
+
+  it("handles empty doc", () => {
+    const doc: TipTapDoc = { type: "doc", content: [] };
+    expect(tiptapToBlocknote(doc)).toEqual([]);
+  });
+});
+
+describe("round-trip fidelity", () => {
+  it("paragraph round-trips BlockNote -> TipTap -> BlockNote", () => {
+    const original: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "Hello ", styles: {} },
+          { type: "text", text: "world", styles: { bold: true } },
+        ],
+        children: [],
+      },
+    ];
+
+    const tiptap = blocknoteToTiptap(original);
+    const roundTripped = tiptapToBlocknote(tiptap);
+
+    expect(roundTripped).toEqual(original);
+  });
+
+  it("heading round-trips", () => {
+    const original: BlockNoteBlock[] = [
+      {
+        type: "heading",
+        props: { level: 2 },
+        content: [{ type: "text", text: "Title", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const roundTripped = tiptapToBlocknote(blocknoteToTiptap(original));
+    expect(roundTripped).toEqual(original);
+  });
+
+  it("bullet list round-trips", () => {
+    const original: BlockNoteBlock[] = [
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Item 1", styles: {} }],
+        children: [],
+      },
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Item 2", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const roundTripped = tiptapToBlocknote(blocknoteToTiptap(original));
+    expect(roundTripped).toEqual(original);
+  });
+
+  it("nested list round-trips", () => {
+    const original: BlockNoteBlock[] = [
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Parent", styles: {} }],
+        children: [
+          {
+            type: "bulletListItem",
+            content: [{ type: "text", text: "Child", styles: {} }],
+            children: [],
+          },
+        ],
+      },
+    ];
+
+    const roundTripped = tiptapToBlocknote(blocknoteToTiptap(original));
+    expect(roundTripped).toEqual(original);
+  });
+
+  it("check list round-trips", () => {
+    const original: BlockNoteBlock[] = [
+      {
+        type: "checkListItem",
+        props: { checked: true },
+        content: [{ type: "text", text: "Done", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const roundTripped = tiptapToBlocknote(blocknoteToTiptap(original));
+    expect(roundTripped).toEqual(original);
+  });
+
+  it("code block round-trips", () => {
+    const original: BlockNoteBlock[] = [
+      {
+        type: "codeBlock",
+        props: { language: "javascript" },
+        content: [{ type: "text", text: "const x = 1;", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const roundTripped = tiptapToBlocknote(blocknoteToTiptap(original));
+    expect(roundTripped).toEqual(original);
+  });
+
+  it("image round-trips", () => {
+    const original: BlockNoteBlock[] = [
+      {
+        type: "image",
+        props: { url: "https://example.com/img.png", caption: "Photo", width: 400 },
+        children: [],
+      },
+    ];
+
+    const roundTripped = tiptapToBlocknote(blocknoteToTiptap(original));
+    expect(roundTripped).toEqual(original);
+  });
+
+  it("complex document round-trips", () => {
+    const original: BlockNoteBlock[] = [
+      {
+        type: "heading",
+        props: { level: 1 },
+        content: [{ type: "text", text: "Welcome", styles: {} }],
+        children: [],
+      },
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "This is ", styles: {} },
+          { type: "text", text: "bold", styles: { bold: true } },
+          { type: "text", text: " and ", styles: {} },
+          { type: "text", text: "italic", styles: { italic: true } },
+        ],
+        children: [],
+      },
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "First", styles: {} }],
+        children: [],
+      },
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Second", styles: {} }],
+        children: [
+          {
+            type: "bulletListItem",
+            content: [{ type: "text", text: "Nested", styles: {} }],
+            children: [],
+          },
+        ],
+      },
+      {
+        type: "paragraph",
+        content: [],
+        children: [],
+      },
+      {
+        type: "codeBlock",
+        props: { language: "ts" },
+        content: [{ type: "text", text: "console.log('hi');", styles: {} }],
+        children: [],
+      },
+    ];
+
+    const roundTripped = tiptapToBlocknote(blocknoteToTiptap(original));
+    expect(roundTripped).toEqual(original);
+  });
+
+  it("TipTap -> BlockNote -> TipTap round-trips a paragraph", () => {
+    const original: TipTapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Hello" },
+            { type: "text", text: " bold", marks: [{ type: "bold" }] },
+          ],
+        },
+      ],
+    };
+
+    const roundTripped = blocknoteToTiptap(tiptapToBlocknote(original));
+    expect(roundTripped).toEqual(original);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,9 +10,10 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "echo \"No tests yet\""
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/shared/src/editor/format-converter.ts
+++ b/packages/shared/src/editor/format-converter.ts
@@ -1,0 +1,432 @@
+import type {
+  BlockNoteBlock,
+  BlockNoteInlineContent,
+  BlockNoteTableContent,
+  TipTapDoc,
+  TipTapMark,
+  TipTapNode,
+} from "./types";
+
+// --- BlockNote -> TipTap ---
+
+const STYLE_TO_MARK: Record<string, string> = {
+  bold: "bold",
+  italic: "italic",
+  underline: "underline",
+  strike: "strike",
+  code: "code",
+};
+
+function inlineContentToTipTap(inlineContent: BlockNoteInlineContent[]): TipTapNode[] {
+  const nodes: TipTapNode[] = [];
+
+  for (const item of inlineContent) {
+    const marks: TipTapMark[] = [];
+
+    if (item.styles) {
+      for (const [style, enabled] of Object.entries(item.styles)) {
+        if (enabled && STYLE_TO_MARK[style]) {
+          marks.push({ type: STYLE_TO_MARK[style] });
+        }
+      }
+    }
+
+    if (item.type === "link") {
+      marks.push({ type: "link", attrs: { href: item.href ?? "" } });
+      if (item.content && item.content.length > 0) {
+        for (const child of item.content) {
+          const childMarks = [...marks];
+          if (child.styles) {
+            for (const [style, enabled] of Object.entries(child.styles)) {
+              if (enabled && STYLE_TO_MARK[style]) {
+                childMarks.push({ type: STYLE_TO_MARK[style] });
+              }
+            }
+          }
+          const node: TipTapNode = { type: "text", text: child.text };
+          if (childMarks.length > 0) node.marks = childMarks;
+          nodes.push(node);
+        }
+      } else {
+        const node: TipTapNode = { type: "text", text: item.text };
+        if (marks.length > 0) node.marks = marks;
+        nodes.push(node);
+      }
+    } else {
+      const node: TipTapNode = { type: "text", text: item.text };
+      if (marks.length > 0) node.marks = marks;
+      nodes.push(node);
+    }
+  }
+
+  return nodes;
+}
+
+function blockToTipTapNode(block: BlockNoteBlock): TipTapNode[] {
+  switch (block.type) {
+    case "paragraph": {
+      const node: TipTapNode = { type: "paragraph" };
+      if (Array.isArray(block.content) && block.content.length > 0) {
+        node.content = inlineContentToTipTap(block.content);
+      }
+      return [node];
+    }
+
+    case "heading": {
+      const level = (block.props?.level as number) ?? 1;
+      const node: TipTapNode = {
+        type: "heading",
+        attrs: { level },
+      };
+      if (Array.isArray(block.content) && block.content.length > 0) {
+        node.content = inlineContentToTipTap(block.content);
+      }
+      return [node];
+    }
+
+    case "bulletListItem": {
+      const li: TipTapNode = { type: "listItem" };
+      const innerParagraph: TipTapNode = { type: "paragraph" };
+      if (Array.isArray(block.content) && block.content.length > 0) {
+        innerParagraph.content = inlineContentToTipTap(block.content);
+      }
+      const liContent: TipTapNode[] = [innerParagraph];
+      if (block.children && block.children.length > 0) {
+        const nestedList = convertChildrenToList(block.children, "bulletList");
+        if (nestedList) liContent.push(nestedList);
+      }
+      li.content = liContent;
+      return [{ type: "bulletList", content: [li] }];
+    }
+
+    case "numberedListItem": {
+      const li: TipTapNode = { type: "listItem" };
+      const innerParagraph: TipTapNode = { type: "paragraph" };
+      if (Array.isArray(block.content) && block.content.length > 0) {
+        innerParagraph.content = inlineContentToTipTap(block.content);
+      }
+      const liContent: TipTapNode[] = [innerParagraph];
+      if (block.children && block.children.length > 0) {
+        const nestedList = convertChildrenToList(block.children, "orderedList");
+        if (nestedList) liContent.push(nestedList);
+      }
+      li.content = liContent;
+      return [{ type: "orderedList", content: [li] }];
+    }
+
+    case "checkListItem": {
+      const checked = (block.props?.checked as boolean) ?? false;
+      const taskItem: TipTapNode = {
+        type: "taskItem",
+        attrs: { checked },
+      };
+      const innerParagraph: TipTapNode = { type: "paragraph" };
+      if (Array.isArray(block.content) && block.content.length > 0) {
+        innerParagraph.content = inlineContentToTipTap(block.content);
+      }
+      taskItem.content = [innerParagraph];
+      return [{ type: "taskList", content: [taskItem] }];
+    }
+
+    case "codeBlock": {
+      const language = (block.props?.language as string) ?? "";
+      const text =
+        Array.isArray(block.content) && block.content.length > 0
+          ? block.content.map((c) => c.text).join("")
+          : "";
+      const node: TipTapNode = {
+        type: "codeBlock",
+        attrs: { language },
+      };
+      if (text) {
+        node.content = [{ type: "text", text }];
+      }
+      return [node];
+    }
+
+    case "image": {
+      const src = (block.props?.url as string) ?? "";
+      const attrs: Record<string, unknown> = { src };
+      if (block.props?.caption) attrs.alt = block.props.caption;
+      if (block.props?.width) attrs.width = block.props.width;
+      return [{ type: "image", attrs }];
+    }
+
+    case "table": {
+      const tableContent = block.content as BlockNoteTableContent | undefined;
+      if (!tableContent || tableContent.type !== "tableContent") {
+        return [{ type: "table", content: [] }];
+      }
+      const rows: TipTapNode[] = tableContent.rows.map((row) => {
+        const cells: TipTapNode[] = row.cells.map((cell) => ({
+          type: "tableCell",
+          content: [
+            {
+              type: "paragraph",
+              content: cell.length > 0 ? inlineContentToTipTap(cell) : undefined,
+            },
+          ],
+        }));
+        return { type: "tableRow", content: cells };
+      });
+      return [{ type: "table", content: rows }];
+    }
+
+    default: {
+      // Unknown block type: convert as paragraph to avoid data loss
+      const node: TipTapNode = { type: "paragraph" };
+      if (Array.isArray(block.content) && block.content.length > 0) {
+        node.content = inlineContentToTipTap(block.content);
+      }
+      return [node];
+    }
+  }
+}
+
+function convertChildrenToList(children: BlockNoteBlock[], listType: string): TipTapNode | null {
+  const items: TipTapNode[] = [];
+  for (const child of children) {
+    const li: TipTapNode = { type: "listItem" };
+    const innerParagraph: TipTapNode = { type: "paragraph" };
+    if (Array.isArray(child.content) && child.content.length > 0) {
+      innerParagraph.content = inlineContentToTipTap(child.content);
+    }
+    const liContent: TipTapNode[] = [innerParagraph];
+    if (child.children && child.children.length > 0) {
+      const nestedList = convertChildrenToList(child.children, listType);
+      if (nestedList) liContent.push(nestedList);
+    }
+    li.content = liContent;
+    items.push(li);
+  }
+  if (items.length === 0) return null;
+  return { type: listType, content: items };
+}
+
+/**
+ * Merge adjacent list nodes of the same type into single lists.
+ * BlockNote represents each list item as a separate block, but TipTap
+ * expects them grouped under a single list node.
+ */
+function mergeAdjacentLists(nodes: TipTapNode[]): TipTapNode[] {
+  const merged: TipTapNode[] = [];
+  for (const node of nodes) {
+    const prev = merged[merged.length - 1];
+    if (
+      prev &&
+      prev.type === node.type &&
+      (node.type === "bulletList" || node.type === "orderedList" || node.type === "taskList")
+    ) {
+      prev.content = [...(prev.content ?? []), ...(node.content ?? [])];
+    } else {
+      merged.push(node);
+    }
+  }
+  return merged;
+}
+
+export function blocknoteToTiptap(blocks: BlockNoteBlock[]): TipTapDoc {
+  const nodes: TipTapNode[] = [];
+  for (const block of blocks) {
+    nodes.push(...blockToTipTapNode(block));
+  }
+  return { type: "doc", content: mergeAdjacentLists(nodes) };
+}
+
+// --- TipTap -> BlockNote ---
+
+const MARK_TO_STYLE: Record<string, string> = {
+  bold: "bold",
+  italic: "italic",
+  underline: "underline",
+  strike: "strike",
+  code: "code",
+};
+
+function tipTapInlineToBlockNote(nodes: TipTapNode[]): BlockNoteInlineContent[] {
+  const result: BlockNoteInlineContent[] = [];
+
+  for (const node of nodes) {
+    if (node.type !== "text" || !node.text) continue;
+
+    const styles: Record<string, boolean> = {};
+    let isLink = false;
+    let href = "";
+
+    if (node.marks) {
+      for (const mark of node.marks) {
+        if (mark.type === "link") {
+          isLink = true;
+          href = (mark.attrs?.href as string) ?? "";
+        } else if (MARK_TO_STYLE[mark.type]) {
+          styles[MARK_TO_STYLE[mark.type]] = true;
+        }
+      }
+    }
+
+    const hasStyles = Object.keys(styles).length > 0;
+
+    if (isLink) {
+      const item: BlockNoteInlineContent = {
+        type: "link",
+        text: node.text,
+        href,
+        content: [
+          {
+            type: "text",
+            text: node.text,
+            styles: hasStyles ? styles : {},
+          },
+        ],
+      };
+      result.push(item);
+    } else {
+      result.push({
+        type: "text",
+        text: node.text,
+        styles: hasStyles ? styles : {},
+      });
+    }
+  }
+
+  return result;
+}
+
+function extractListItems(listNode: TipTapNode, blockType: string): BlockNoteBlock[] {
+  const blocks: BlockNoteBlock[] = [];
+  for (const item of listNode.content ?? []) {
+    if (item.type !== "listItem" && item.type !== "taskItem") continue;
+
+    const block: BlockNoteBlock = { type: blockType, content: [], children: [] };
+
+    if (blockType === "checkListItem") {
+      block.props = { checked: (item.attrs?.checked as boolean) ?? false };
+    }
+
+    for (const child of item.content ?? []) {
+      if (child.type === "paragraph") {
+        block.content = tipTapInlineToBlockNote(child.content ?? []);
+      } else if (
+        child.type === "bulletList" ||
+        child.type === "orderedList" ||
+        child.type === "taskList"
+      ) {
+        const nestedType =
+          child.type === "bulletList"
+            ? "bulletListItem"
+            : child.type === "orderedList"
+              ? "numberedListItem"
+              : "checkListItem";
+        block.children = extractListItems(child, nestedType);
+      }
+    }
+
+    blocks.push(block);
+  }
+  return blocks;
+}
+
+function tipTapNodeToBlocks(node: TipTapNode): BlockNoteBlock[] {
+  switch (node.type) {
+    case "paragraph": {
+      return [
+        {
+          type: "paragraph",
+          content: tipTapInlineToBlockNote(node.content ?? []),
+          children: [],
+        },
+      ];
+    }
+
+    case "heading": {
+      const level = (node.attrs?.level as number) ?? 1;
+      return [
+        {
+          type: "heading",
+          props: { level },
+          content: tipTapInlineToBlockNote(node.content ?? []),
+          children: [],
+        },
+      ];
+    }
+
+    case "bulletList": {
+      return extractListItems(node, "bulletListItem");
+    }
+
+    case "orderedList": {
+      return extractListItems(node, "numberedListItem");
+    }
+
+    case "taskList": {
+      return extractListItems(node, "checkListItem");
+    }
+
+    case "codeBlock": {
+      const language = (node.attrs?.language as string) ?? "";
+      const text = (node.content ?? [])
+        .filter((n) => n.type === "text")
+        .map((n) => n.text ?? "")
+        .join("");
+      return [
+        {
+          type: "codeBlock",
+          props: { language },
+          content: text ? [{ type: "text", text, styles: {} }] : [],
+          children: [],
+        },
+      ];
+    }
+
+    case "image": {
+      const props: Record<string, unknown> = {};
+      if (node.attrs?.src) props.url = node.attrs.src;
+      if (node.attrs?.alt) props.caption = node.attrs.alt;
+      if (node.attrs?.width) props.width = node.attrs.width;
+      return [{ type: "image", props, children: [] }];
+    }
+
+    case "table": {
+      const rows = (node.content ?? [])
+        .filter((r) => r.type === "tableRow")
+        .map((row) => ({
+          cells: (row.content ?? [])
+            .filter((c) => c.type === "tableCell" || c.type === "tableHeader")
+            .map((cell) => {
+              const para = (cell.content ?? []).find((n) => n.type === "paragraph");
+              return para ? tipTapInlineToBlockNote(para.content ?? []) : [];
+            }),
+        }));
+      const tableContent: BlockNoteTableContent = {
+        type: "tableContent",
+        rows,
+      };
+      return [{ type: "table", content: tableContent, children: [] }];
+    }
+
+    default: {
+      // Unknown node: preserve text content as paragraph
+      if (node.content) {
+        const textNodes = node.content.filter((n) => n.type === "text");
+        if (textNodes.length > 0) {
+          return [
+            {
+              type: "paragraph",
+              content: tipTapInlineToBlockNote(textNodes),
+              children: [],
+            },
+          ];
+        }
+      }
+      return [];
+    }
+  }
+}
+
+export function tiptapToBlocknote(doc: TipTapDoc): BlockNoteBlock[] {
+  const blocks: BlockNoteBlock[] = [];
+  for (const node of doc.content) {
+    blocks.push(...tipTapNodeToBlocks(node));
+  }
+  return blocks;
+}

--- a/packages/shared/src/editor/types.ts
+++ b/packages/shared/src/editor/types.ts
@@ -1,0 +1,40 @@
+// BlockNote block types (web editor format)
+export interface BlockNoteInlineContent {
+  type: "text" | "link";
+  text: string;
+  styles?: Record<string, boolean>;
+  href?: string;
+  content?: BlockNoteInlineContent[];
+}
+
+export interface BlockNoteTableContent {
+  type: "tableContent";
+  rows: { cells: BlockNoteInlineContent[][] }[];
+}
+
+export interface BlockNoteBlock {
+  id?: string;
+  type: string;
+  props?: Record<string, unknown>;
+  content?: BlockNoteInlineContent[] | BlockNoteTableContent;
+  children?: BlockNoteBlock[];
+}
+
+// TipTap/ProseMirror document types (mobile editor format)
+export interface TipTapMark {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+export interface TipTapNode {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: TipTapNode[];
+  text?: string;
+  marks?: TipTapMark[];
+}
+
+export interface TipTapDoc {
+  type: "doc";
+  content: TipTapNode[];
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,3 +19,12 @@ export {
   BUCKET_NAME,
   SIGNED_URL_EXPIRY_SECONDS,
 } from "./constants";
+export { blocknoteToTiptap, tiptapToBlocknote } from "./editor/format-converter";
+export type {
+  BlockNoteBlock,
+  BlockNoteInlineContent,
+  BlockNoteTableContent,
+  TipTapDoc,
+  TipTapNode,
+  TipTapMark,
+} from "./editor/types";

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -12,6 +12,6 @@
     "incremental": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
 
 packages:
 
@@ -7620,7 +7623,7 @@ snapshots:
       '@tiptap/extension-link': 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/extension-strike': 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
-      '@tiptap/extension-text-style': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))
+      '@tiptap/extension-text-style': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       '@tiptap/extension-underline': 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       '@tiptap/extensions': 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/pm': 3.20.0
@@ -10569,7 +10572,7 @@ snapshots:
 
   '@tiptap/extension-bullet-list@3.20.1(@tiptap/extension-list@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))':
     dependencies:
-      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
+      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
 
   '@tiptap/extension-code-block@3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)':
     dependencies:
@@ -10591,7 +10594,7 @@ snapshots:
 
   '@tiptap/extension-color@3.20.1(@tiptap/extension-text-style@3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0)))':
     dependencies:
-      '@tiptap/extension-text-style': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))
+      '@tiptap/extension-text-style': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
 
   '@tiptap/extension-document@3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))':
     dependencies:
@@ -10603,7 +10606,7 @@ snapshots:
 
   '@tiptap/extension-dropcursor@3.20.1(@tiptap/extensions@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))':
     dependencies:
-      '@tiptap/extensions': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
+      '@tiptap/extensions': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
 
   '@tiptap/extension-floating-menu@3.20.0(@floating-ui/dom@1.7.5)(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)':
     dependencies:
@@ -10614,7 +10617,7 @@ snapshots:
 
   '@tiptap/extension-gapcursor@3.20.1(@tiptap/extensions@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))':
     dependencies:
-      '@tiptap/extensions': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
+      '@tiptap/extensions': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
 
   '@tiptap/extension-hard-break@3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))':
     dependencies:
@@ -10672,25 +10675,20 @@ snapshots:
 
   '@tiptap/extension-list-item@3.20.1(@tiptap/extension-list@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))':
     dependencies:
-      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
+      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
 
   '@tiptap/extension-list-keymap@3.20.1(@tiptap/extension-list@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))':
     dependencies:
-      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
+      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
 
   '@tiptap/extension-list@3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)':
     dependencies:
       '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
       '@tiptap/pm': 3.20.0
 
-  '@tiptap/extension-list@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)':
-    dependencies:
-      '@tiptap/core': 3.20.1(@tiptap/pm@3.20.1)
-      '@tiptap/pm': 3.20.1
-
   '@tiptap/extension-ordered-list@3.20.1(@tiptap/extension-list@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))':
     dependencies:
-      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
+      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
 
   '@tiptap/extension-paragraph@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))':
     dependencies:
@@ -10708,9 +10706,9 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.20.1(@tiptap/pm@3.20.1)
 
-  '@tiptap/extension-text-style@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))':
+  '@tiptap/extension-text-style@3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))':
     dependencies:
-      '@tiptap/core': 3.20.1(@tiptap/pm@3.20.1)
+      '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
 
   '@tiptap/extension-text@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))':
     dependencies:
@@ -10733,10 +10731,10 @@ snapshots:
       '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
       '@tiptap/pm': 3.20.0
 
-  '@tiptap/extensions@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)':
+  '@tiptap/extensions@3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)':
     dependencies:
-      '@tiptap/core': 3.20.1(@tiptap/pm@3.20.1)
-      '@tiptap/pm': 3.20.1
+      '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
+      '@tiptap/pm': 3.20.0
 
   '@tiptap/pm@3.20.0':
     dependencies:
@@ -10830,7 +10828,7 @@ snapshots:
       '@tiptap/extension-horizontal-rule': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
       '@tiptap/extension-italic': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))
       '@tiptap/extension-link': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
-      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
+      '@tiptap/extension-list': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/extension-list-item': 3.20.1(@tiptap/extension-list@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))
       '@tiptap/extension-list-keymap': 3.20.1(@tiptap/extension-list@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))
       '@tiptap/extension-ordered-list': 3.20.1(@tiptap/extension-list@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))
@@ -10838,7 +10836,7 @@ snapshots:
       '@tiptap/extension-strike': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))
       '@tiptap/extension-text': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))
       '@tiptap/extension-underline': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))
-      '@tiptap/extensions': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)
+      '@tiptap/extensions': 3.20.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/pm': 3.20.1
 
   '@tybys/wasm-util@0.10.1':


### PR DESCRIPTION
## Summary
- Add bidirectional format converter (`blocknoteToTiptap` / `tiptapToBlocknote`) in `packages/shared/src/editor/`
- Supports all block types: paragraphs, headings, bullet/numbered/check lists (with nesting), code blocks, images, tables, links, and inline styles (bold, italic, underline, strike, code)
- Adjacent list items are merged into single TipTap list nodes
- Set up vitest for `@drafto/shared` with 33 unit tests including round-trip fidelity checks
- Mark task 3.5 complete in progress tracker

## Test plan
- [x] 33 unit tests pass (`cd packages/shared && pnpm test`)
- [x] Shared package typechecks (`pnpm exec tsc --noEmit`)
- [x] Web app unit + integration tests pass (513 tests)
- [x] Web app E2E tests pass (46 passed, 13 skipped)
- [x] Web app lint passes (0 errors)
- [x] Mobile app typechecks

🤖 Generated with [Claude Code](https://claude.com/claude-code)