### PR TITLE
feat: add typed WatermelonDB model classes (4.2)

### DIFF
--- a/apps/mobile/src/db/models/attachment.ts
+++ b/apps/mobile/src/db/models/attachment.ts
@@ -1,5 +1,7 @@
-import { Model } from "@nozbe/watermelondb";
+import { Model, Relation } from "@nozbe/watermelondb";
 import { field, date, readonly, relation } from "@nozbe/watermelondb/decorators";
+
+import type { Note } from "./note";
 
 export class Attachment extends Model {
   static table = "attachments";
@@ -17,5 +19,5 @@ export class Attachment extends Model {
   @field("mime_type") mimeType!: string;
   @readonly @date("created_at") createdAt!: Date;
 
-  @relation("notes", "note_id") note!: unknown;
+  @relation("notes", "note_id") note!: Relation<Note>;
 }

--- a/apps/mobile/src/db/models/note.ts
+++ b/apps/mobile/src/db/models/note.ts
@@ -1,5 +1,8 @@
-import { Model } from "@nozbe/watermelondb";
+import { Model, Query, Relation } from "@nozbe/watermelondb";
 import { field, date, readonly, children, relation } from "@nozbe/watermelondb/decorators";
+
+import type { Attachment } from "./attachment";
+import type { Notebook } from "./notebook";
 
 export class Note extends Model {
   static table = "notes";
@@ -19,6 +22,6 @@ export class Note extends Model {
   @readonly @date("created_at") createdAt!: Date;
   @date("updated_at") updatedAt!: Date;
 
-  @relation("notebooks", "notebook_id") notebook!: unknown;
-  @children("attachments") attachments!: unknown;
+  @relation("notebooks", "notebook_id") notebook!: Relation<Notebook>;
+  @children("attachments") attachments!: Query<Attachment>;
 }

--- a/apps/mobile/src/db/models/notebook.ts
+++ b/apps/mobile/src/db/models/notebook.ts
@@ -1,5 +1,7 @@
-import { Model } from "@nozbe/watermelondb";
+import { Model, Query } from "@nozbe/watermelondb";
 import { field, date, readonly, children } from "@nozbe/watermelondb/decorators";
+
+import type { Note } from "./note";
 
 export class Notebook extends Model {
   static table = "notebooks";
@@ -14,5 +16,5 @@ export class Notebook extends Model {
   @readonly @date("created_at") createdAt!: Date;
   @date("updated_at") updatedAt!: Date;
 
-  @children("notes") notes!: unknown;
+  @children("notes") notes!: Query<Note>;
 }

--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -106,7 +106,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 ### Phase 4: Offline Storage with WatermelonDB
 
 - [x] 4.1 — Install and configure WatermelonDB with schema (notebooks, notes, attachments)
-- [ ] 4.2 — WatermelonDB model classes with field decorators
+- [x] 4.2 — WatermelonDB model classes with field decorators
 - [ ] 4.3 — Supabase sync adapter (pullChanges + pushChanges)
 - [ ] 4.4 — Migrate screens from direct Supabase queries to WatermelonDB observables
 - [ ] 4.5 — Create ADR-0010 (offline sync strategy with WatermelonDB)


### PR DESCRIPTION
## Summary
- Add proper TypeScript types (`Query<T>`, `Relation<T>`) to WatermelonDB model relation/children fields, replacing `unknown` types
- Models: Notebook, Note, Attachment with associations, field decorators, and date handling
- Mark task 4.2 as complete in progress tracker

## Test plan
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Lint passes
- [x] Mobile tests pass
- [x] Shared package tests pass (33/33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)