### PR TITLE
feat: add Supabase sync adapter for WatermelonDB (4.3)

### DIFF
--- a/apps/mobile/src/db/sync.ts
+++ b/apps/mobile/src/db/sync.ts
@@ -1,0 +1,224 @@
+import { synchronize } from "@nozbe/watermelondb/sync";
+
+import type { Database as WMDatabase } from "@nozbe/watermelondb";
+import type { SyncPullResult } from "@nozbe/watermelondb/sync";
+
+import type { Database } from "@drafto/shared";
+
+import { supabase } from "@/lib/supabase";
+
+type NotebookRow = Database["public"]["Tables"]["notebooks"]["Row"];
+type NoteRow = Database["public"]["Tables"]["notes"]["Row"];
+type AttachmentRow = Database["public"]["Tables"]["attachments"]["Row"];
+
+type SyncRecord = Record<string, unknown>;
+
+type SyncTableChanges = {
+  created: SyncRecord[];
+  updated: SyncRecord[];
+  deleted: string[];
+};
+
+function toTimestamp(iso: string): number {
+  return new Date(iso).getTime();
+}
+
+function toISO(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}
+
+function mapNotebookRow(row: NotebookRow): SyncRecord {
+  return {
+    id: row.id,
+    remote_id: row.id,
+    user_id: row.user_id,
+    name: row.name,
+    created_at: toTimestamp(row.created_at),
+    updated_at: toTimestamp(row.updated_at),
+  };
+}
+
+function mapNoteRow(row: NoteRow): SyncRecord {
+  return {
+    id: row.id,
+    remote_id: row.id,
+    notebook_id: row.notebook_id,
+    user_id: row.user_id,
+    title: row.title,
+    content: row.content ? JSON.stringify(row.content) : null,
+    is_trashed: row.is_trashed,
+    trashed_at: row.trashed_at ? toTimestamp(row.trashed_at) : null,
+    created_at: toTimestamp(row.created_at),
+    updated_at: toTimestamp(row.updated_at),
+  };
+}
+
+function mapAttachmentRow(row: AttachmentRow): SyncRecord {
+  return {
+    id: row.id,
+    remote_id: row.id,
+    note_id: row.note_id,
+    user_id: row.user_id,
+    file_name: row.file_name,
+    file_path: row.file_path,
+    file_size: row.file_size,
+    mime_type: row.mime_type,
+    created_at: toTimestamp(row.created_at),
+  };
+}
+
+async function fetchTable<T>(
+  table: "notebooks" | "notes" | "attachments",
+  timestampCol: string,
+  lastPulledAt: number | undefined,
+  mapFn: (row: T) => SyncRecord,
+): Promise<SyncRecord[]> {
+  let query = supabase.from(table).select("*");
+  if (lastPulledAt !== undefined) {
+    query = query.gt(timestampCol, toISO(lastPulledAt));
+  }
+  const { data, error } = await query;
+  if (error) throw new Error(`Pull ${table} failed: ${error.message}`);
+  return (data as T[]).map(mapFn);
+}
+
+function splitChanges(records: SyncRecord[], isFirstSync: boolean): SyncTableChanges {
+  if (isFirstSync) {
+    return { created: records, updated: [], deleted: [] };
+  }
+  // On incremental sync, all returned records are treated as updated.
+  // WatermelonDB handles the case where an "updated" record doesn't
+  // exist locally — it creates it automatically.
+  return { created: [], updated: records, deleted: [] };
+}
+
+async function pullChanges({ lastPulledAt }: { lastPulledAt?: number }): Promise<SyncPullResult> {
+  const isFirstSync = lastPulledAt === undefined;
+  const serverTimestamp = Date.now();
+
+  const [notebooks, notes, attachments] = await Promise.all([
+    fetchTable<NotebookRow>("notebooks", "updated_at", lastPulledAt, mapNotebookRow),
+    fetchTable<NoteRow>("notes", "updated_at", lastPulledAt, mapNoteRow),
+    fetchTable<AttachmentRow>("attachments", "created_at", lastPulledAt, mapAttachmentRow),
+  ]);
+
+  return {
+    changes: {
+      notebooks: splitChanges(notebooks, isFirstSync),
+      notes: splitChanges(notes, isFirstSync),
+      attachments: splitChanges(attachments, isFirstSync),
+    },
+    timestamp: serverTimestamp,
+  };
+}
+
+async function pushNotebookChanges(changes: SyncTableChanges) {
+  if (changes.created.length > 0) {
+    const rows = changes.created.map((r) => ({
+      id: r.remote_id as string,
+      user_id: r.user_id as string,
+      name: r.name as string,
+    }));
+    const { error } = await supabase.from("notebooks").upsert(rows);
+    if (error) throw new Error(`Push notebooks (create) failed: ${error.message}`);
+  }
+
+  if (changes.updated.length > 0) {
+    for (const r of changes.updated) {
+      const { error } = await supabase
+        .from("notebooks")
+        .update({
+          name: r.name as string,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", r.remote_id as string);
+      if (error) throw new Error(`Push notebook update failed: ${error.message}`);
+    }
+  }
+
+  if (changes.deleted.length > 0) {
+    const { error } = await supabase.from("notebooks").delete().in("id", changes.deleted);
+    if (error) throw new Error(`Push notebooks (delete) failed: ${error.message}`);
+  }
+}
+
+async function pushNoteChanges(changes: SyncTableChanges) {
+  if (changes.created.length > 0) {
+    const rows = changes.created.map((r) => ({
+      id: r.remote_id as string,
+      notebook_id: r.notebook_id as string,
+      user_id: r.user_id as string,
+      title: r.title as string,
+      content: r.content ? JSON.parse(r.content as string) : null,
+      is_trashed: (r.is_trashed as boolean) ?? false,
+      trashed_at: r.trashed_at ? toISO(r.trashed_at as number) : null,
+    }));
+    const { error } = await supabase.from("notes").upsert(rows);
+    if (error) throw new Error(`Push notes (create) failed: ${error.message}`);
+  }
+
+  if (changes.updated.length > 0) {
+    for (const r of changes.updated) {
+      const { error } = await supabase
+        .from("notes")
+        .update({
+          notebook_id: r.notebook_id as string,
+          title: r.title as string,
+          content: r.content ? JSON.parse(r.content as string) : null,
+          is_trashed: (r.is_trashed as boolean) ?? false,
+          trashed_at: r.trashed_at ? toISO(r.trashed_at as number) : null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", r.remote_id as string);
+      if (error) throw new Error(`Push note update failed: ${error.message}`);
+    }
+  }
+
+  if (changes.deleted.length > 0) {
+    const { error } = await supabase.from("notes").delete().in("id", changes.deleted);
+    if (error) throw new Error(`Push notes (delete) failed: ${error.message}`);
+  }
+}
+
+async function pushAttachmentChanges(changes: SyncTableChanges) {
+  if (changes.created.length > 0) {
+    const rows = changes.created.map((r) => ({
+      id: r.remote_id as string,
+      note_id: r.note_id as string,
+      user_id: r.user_id as string,
+      file_name: r.file_name as string,
+      file_path: r.file_path as string,
+      file_size: r.file_size as number,
+      mime_type: r.mime_type as string,
+    }));
+    const { error } = await supabase.from("attachments").upsert(rows);
+    if (error) throw new Error(`Push attachments (create) failed: ${error.message}`);
+  }
+
+  // Attachments are immutable — no updates needed
+
+  if (changes.deleted.length > 0) {
+    const { error } = await supabase.from("attachments").delete().in("id", changes.deleted);
+    if (error) throw new Error(`Push attachments (delete) failed: ${error.message}`);
+  }
+}
+
+async function pushChanges({ changes }: { changes: Record<string, SyncTableChanges> }) {
+  const notebookChanges = changes["notebooks"] as SyncTableChanges;
+  const noteChanges = changes["notes"] as SyncTableChanges;
+  const attachmentChanges = changes["attachments"] as SyncTableChanges;
+
+  // Push in order: notebooks first (notes depend on them), then notes, then attachments
+  await pushNotebookChanges(notebookChanges);
+  await pushNoteChanges(noteChanges);
+  await pushAttachmentChanges(attachmentChanges);
+}
+
+export async function syncDatabase(db: WMDatabase): Promise<void> {
+  await synchronize({
+    database: db,
+    pullChanges,
+    pushChanges,
+    migrationsEnabledAtVersion: 1,
+  });
+}

--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -107,7 +107,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 
 - [x] 4.1 — Install and configure WatermelonDB with schema (notebooks, notes, attachments)
 - [x] 4.2 — WatermelonDB model classes with field decorators
-- [ ] 4.3 — Supabase sync adapter (pullChanges + pushChanges)
+- [x] 4.3 — Supabase sync adapter (pullChanges + pushChanges)
 - [ ] 4.4 — Migrate screens from direct Supabase queries to WatermelonDB observables
 - [ ] 4.5 — Create ADR-0010 (offline sync strategy with WatermelonDB)
 - [ ] 4-CP — **Checkpoint**: app works offline (read + write), syncs when online


### PR DESCRIPTION
## Summary
- Implement `pullChanges` and `pushChanges` functions in `apps/mobile/src/db/sync.ts` that bridge WatermelonDB's sync protocol with Supabase
- Pull queries Supabase rows by `updated_at > lastPulledAt`, maps them to WatermelonDB sync format
- Push handles create (upsert), update, and delete operations for notebooks, notes, and attachments
- Handles JSON serialization of note content between local SQLite (string) and Supabase (jsonb)

## Test plan
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes (`pnpm lint`)
- [x] Shared package tests pass (`packages/shared pnpm test`)
- [x] Mobile tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)