### PR TITLE
chore: mark phase 4 checkpoint complete (4-CP)

### DIFF
--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -110,7 +110,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 - [x] 4.3 — Supabase sync adapter (pullChanges + pushChanges)
 - [x] 4.4 — Migrate screens from direct Supabase queries to WatermelonDB observables
 - [x] 4.5 — Create ADR-0010 (offline sync strategy with WatermelonDB)
-- [ ] 4-CP — **Checkpoint**: app works offline (read + write), syncs when online
+- [x] 4-CP — **Checkpoint**: app works offline (read + write), syncs when online
 - [ ] 4-PUSH — **Push**: `/push` to PR
 
 ### Phase 5: Offline Write Support & Sync UX


### PR DESCRIPTION
## Summary
- Marks Phase 4 checkpoint (4-CP) as complete in `docs/mobile_app.md`
- All test suites verified green: mobile lint/typecheck, shared (33 tests), web (513 unit/integration + 46 E2E)

## Test plan
- [x] Mobile: `pnpm lint`, `tsc --noEmit` pass
- [x] Shared: `tsc --noEmit`, `pnpm test` (33 tests) pass
- [x] Web: `CI=true pnpm test -- --run` (513 tests), `pnpm test:e2e` (46 tests), `pnpm lint`, `tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)