### PR TITLE
chore: mark phase 4 push complete (4-PUSH)

### DIFF
--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -111,7 +111,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 - [x] 4.4 — Migrate screens from direct Supabase queries to WatermelonDB observables
 - [x] 4.5 — Create ADR-0010 (offline sync strategy with WatermelonDB)
 - [x] 4-CP — **Checkpoint**: app works offline (read + write), syncs when online
-- [ ] 4-PUSH — **Push**: `/push` to PR
+- [x] 4-PUSH — **Push**: `/push` to PR
 
 ### Phase 5: Offline Write Support & Sync UX
 


### PR DESCRIPTION
## Summary
- Marks the 4-PUSH task as complete in the mobile app progress tracker
- All Phase 4 work (WatermelonDB offline storage) was already merged via PRs #124-#128

## Test plan
- [x] No code changes, only tracker update in `docs/mobile_app.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)