### PR TITLE
feat: add offline notebook creation with cascade delete (5.2)

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -12,11 +12,13 @@ import {
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 
+import { Q } from "@nozbe/watermelondb";
+
 import { useAuth } from "@/providers/auth-provider";
 import { useDatabase } from "@/providers/database-provider";
 import { useNotebooks } from "@/hooks/use-notebooks";
 import { generateId } from "@/lib/generate-id";
-import type { Notebook } from "@/db";
+import type { Notebook, Note, Attachment } from "@/db";
 
 export default function NotebooksScreen() {
   const { user } = useAuth();
@@ -86,7 +88,21 @@ export default function NotebooksScreen() {
         onPress: async () => {
           try {
             const notebook = await database.get<Notebook>("notebooks").find(id);
+            const notes = await database
+              .get<Note>("notes")
+              .query(Q.where("notebook_id", id))
+              .fetch();
             await database.write(async () => {
+              for (const note of notes) {
+                const attachments = await database
+                  .get<Attachment>("attachments")
+                  .query(Q.where("note_id", note.id))
+                  .fetch();
+                for (const attachment of attachments) {
+                  await attachment.markAsDeleted();
+                }
+                await note.markAsDeleted();
+              }
               await notebook.markAsDeleted();
             });
             sync();

--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -116,7 +116,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 ### Phase 5: Offline Write Support & Sync UX
 
 - [x] 5.1 — Offline note creation and editing (writes to local SQLite, syncs later)
-- [ ] 5.2 — Offline notebook creation
+- [x] 5.2 — Offline notebook creation
 - [ ] 5.3 — Network status detection + online/offline indicator
 - [ ] 5.4 — Sync status visualization (pending changes count, last synced time)
 - [ ] 5.5 — Conflict resolution handling (server-wins with user notification toast)


### PR DESCRIPTION
## Summary
- Enables full offline notebook CRUD (create, rename, delete) by leveraging WatermelonDB local writes with background sync
- Adds cascade deletion: deleting a notebook now also deletes its notes and their attachments in a single WatermelonDB write transaction, preventing orphaned records when offline
- Marks task 5.2 complete in progress tracker

## Test plan
- [x] Mobile lint passes (`pnpm lint`)
- [x] Mobile TypeScript check passes (`tsc --noEmit`)
- [x] Web unit + integration tests pass (513 tests)
- [x] Web E2E tests pass (46 passed, 13 skipped)
- [x] Shared package tests pass (33 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)