### PR TITLE
docs: mark mobile app v1 as complete (9-PUSH)

### DIFF
--- a/docs/mobile_app.md
+++ b/docs/mobile_app.md
@@ -163,7 +163,7 @@ Maestro is a YAML-based mobile E2E framework. Tests run locally on iOS Simulator
 - [x] 9.6 — Performance profiling (startup < 2s, sync perf with 1000 notes)
 - [x] 9.7 — Beta testing (TestFlight + Google Play Internal Testing)
 - [x] 9.8 — Final compliance checklist
-- [ ] 9-PUSH — **Push**: `/push` to PR — MOBILE APP v1 COMPLETE
+- [x] 9-PUSH — **Push**: `/push` to PR — MOBILE APP v1 COMPLETE
 
 ---
 


### PR DESCRIPTION
## Summary
- Marks the final 9-PUSH task as complete in `docs/mobile_app.md`
- All Phase 0–9 tasks are now checked off — MOBILE APP v1 COMPLETE

## Test plan
- [x] All web tests pass (513 unit/integration, 46 E2E)
- [x] All shared tests pass (46)
- [x] All mobile tests pass (42 unit/integration, lint, typecheck)
- [x] Doc change only — no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Mobile App v1 completion status in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->