### PR TITLE
fix: make editor text visible in dark mode

### DIFF
--- a/apps/mobile/__tests__/screens/editor.test.tsx
+++ b/apps/mobile/__tests__/screens/editor.test.tsx
@@ -60,6 +60,7 @@ jest.mock("@10play/tentap-editor", () => ({
     setContent: mockSetContent,
     injectCSS: jest.fn(),
   }),
+  useBridgeState: () => ({ isReady: true }),
   TenTapStartKit: [],
   RichText: () => null,
   Toolbar: () => null,

--- a/apps/mobile/app/notes/[id].tsx
+++ b/apps/mobile/app/notes/[id].tsx
@@ -9,7 +9,12 @@ import {
   Platform,
 } from "react-native";
 import { useLocalSearchParams, Stack } from "expo-router";
-import { useEditorBridge, TenTapStartKit, darkEditorTheme } from "@10play/tentap-editor";
+import {
+  useEditorBridge,
+  useBridgeState,
+  TenTapStartKit,
+  darkEditorTheme,
+} from "@10play/tentap-editor";
 
 import { useDatabase } from "@/providers/database-provider";
 import { useTheme } from "@/providers/theme-provider";
@@ -128,7 +133,10 @@ function NoteEditorView({ noteId, initialNote }: NoteEditorViewProps) {
     },
   });
 
+  const { isReady } = useBridgeState(editor);
+
   useEffect(() => {
+    if (!isReady) return;
     const css = isDark
       ? `
         * { background-color: ${semantic.bg}; color: ${semantic.fg}; }
@@ -137,7 +145,7 @@ function NoteEditorView({ noteId, initialNote }: NoteEditorViewProps) {
       `
       : `* { background-color: ${semantic.bg}; color: ${semantic.fg}; }`;
     editor.injectCSS(css, "dark-mode");
-  }, [isDark, semantic, editor]);
+  }, [isDark, semantic, editor, isReady]);
 
   useEffect(() => {
     contentSave.cancel();


### PR DESCRIPTION
## Summary
- Inject dark theme CSS into the TenTap WebView using the app's semantic color tokens (`#0f0f0f` bg, `#ededed` fg) so editor text is visible in dark mode
- Pass `darkEditorTheme` to `useEditorBridge` for toolbar dark mode support, with custom webview background override
- Update editor test mock to include `injectCSS` and `darkEditorTheme`

## Test plan
- [ ] Run on Android emulator in dark mode — editor text should be light on dark background
- [ ] Toggle between light/dark mode — editor content adapts
- [ ] Verify toolbar styling adapts in dark mode
- [x] `cd apps/mobile && pnpm test` — all 42 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dark mode now available in the notes editor; UI colors for background, text, borders and highlights adapt to your theme.
  * Editor styling is applied dynamically and updates when the theme changes for consistent appearance.

* **Bug Fixes**
  * Styling is now reliably applied only after the editor bridge is ready, preventing flash-of-unstyled content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->