### PR TITLE
docs: add design system guardrails to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,26 @@ Never work directly on `main`. Always use the `/worktree` command to create an i
 - Kebab-case file names (e.g., `user-profile.tsx`, not `UserProfile.tsx`)
 - Use `@/` import alias for all `src/` imports
 
+## Design System (Enforced)
+
+All UI code must use the design system defined in `apps/web/src/app/globals.css`. See the live showcase at `/design-system`.
+
+**Token usage:**
+
+- Use semantic token classes (`bg-bg`, `text-fg-muted`, `border-border`) for surfaces — never raw Tailwind colors (`bg-gray-100`, `text-slate-500`)
+- Use scale token classes (`bg-primary-500`, `text-accent-400`, `text-neutral-600`) from the defined palette — never arbitrary color values (`bg-[#4f46e5]`)
+- Use design system shadows (`shadow-sm`, `shadow-md`), radii (`rounded-md`, `rounded-lg`), and transitions (`transition-fast`, `transition-normal`) — never hardcoded values
+
+**Component reuse:**
+
+- Check `apps/web/src/components/ui/` before building any new button, input, card, badge, dialog, dropdown, or skeleton — a primitive likely already exists
+- When a new reusable UI pattern emerges, extract it to `apps/web/src/components/ui/` following existing conventions (variant props, `cn()` utility, design tokens)
+
+**Keeping the system current:**
+
+- When adding a new token to `globals.css`, add a corresponding example to the showcase page (`apps/web/src/app/design-system/page.tsx`)
+- When adding a new UI primitive, add it to the showcase page with all variants demonstrated
+
 ## Testing Requirements
 
 Every feature needs:


### PR DESCRIPTION
## Summary

- Add "Design System (Enforced)" section to CLAUDE.md with rules for token usage, component reuse, and keeping the showcase page current
- Closes the gap identified in ADR 0004 where design system discipline relied solely on code review

## Test plan

- [x] Verify referenced paths exist (`globals.css`, `components/ui/`, `design-system/page.tsx`)
- [x] Confirm section placement and formatting is consistent with existing CLAUDE.md style

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Design System (Enforced) guidelines covering token usage, design tokens, component reuse, and system maintenance best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->