### PR TITLE
fix(mobile): add EAS env vars to fix startup crash

### DIFF
--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -11,7 +11,9 @@ const supabaseAnonKey = Constants.expoConfig?.extra?.supabaseAnonKey as string;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error(
-    "Missing Supabase configuration. Set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY in your environment.",
+    "Missing Supabase configuration. " +
+      "Set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY in your environment. " +
+      "For EAS builds, set these via `eas env:create` (see CLAUDE.md for details).",
   );
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: Mobile app crashed on startup from Google Play internal track because `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_ANON_KEY` were not set in EAS build environments (`.env` files are gitignored, so remote EAS builds had no Supabase config)
- **Fix**: Set both environment variables via `eas env:create` for production and preview environments
- **Code change**: Improved the error message in `supabase.ts` to mention EAS configuration for easier debugging

## What was done (outside this PR)

EAS environment variables were created on the EAS project:
```
EXPO_PUBLIC_SUPABASE_URL (plaintext) → production, preview
EXPO_PUBLIC_SUPABASE_ANON_KEY (sensitive) → production, preview
```

## Test plan

- [ ] Run `npx eas-cli env:list --environment production` to confirm vars are set
- [ ] Trigger EAS beta build: `cd apps/mobile && npx eas-cli build --profile beta --platform android --auto-submit --non-interactive`
- [ ] Install from Google Play internal track on Pixel 10 Pro XL
- [ ] Verify app launches, shows login screen, connects to production Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced error messaging for missing Supabase configuration to provide clearer setup instructions for EAS builds, including guidance on using the appropriate environment configuration tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->