### PR TITLE
feat: add versioning strategy with Sentry release tagging

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -41,6 +41,28 @@ jobs:
       - name: Run shared package tests
         run: cd packages/shared && pnpm test
 
+  tag:
+    name: Tag Mobile Release
+    needs: checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Read mobile version and create tag
+        run: |
+          VERSION=$(node -p "require('./apps/mobile/package.json').version")
+          TAG="mobile@${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Created tag $TAG"
+          fi
+
   build-ios:
     name: Build & Submit iOS (TestFlight)
     needs: checks

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,11 +1,12 @@
 import { ExpoConfig, ConfigContext } from "expo/config";
+import pkg from "./package.json";
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: "Drafto",
   slug: "drafto",
   owner: "jakubanderwald",
-  version: "1.0.0",
+  version: pkg.version,
   orientation: "portrait",
   icon: "./assets/icon.png",
   userInterfaceStyle: "automatic",

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "resolveJsonModule": true,
     "experimentalDecorators": true,
     "paths": {
       "@/*": ["./src/*"]

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  release: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? "dev",
   environment:
     process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ??
     (process.env.NODE_ENV === "production" ? "production" : "development"),

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -17,4 +17,7 @@ export default withSentryConfig(nextConfig, {
   project: "drafto",
   silent: !process.env.CI,
   widenClientFileUpload: true,
+  release: {
+    name: process.env.VERCEL_GIT_COMMIT_SHA,
+  },
 });

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  release: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? "dev",
   environment:
     process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ??
     (process.env.NODE_ENV === "production" ? "production" : "development"),

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  release: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? "dev",
   environment:
     process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ??
     (process.env.NODE_ENV === "production" ? "production" : "development"),

--- a/apps/web/src/components/layout/app-menu.tsx
+++ b/apps/web/src/components/layout/app-menu.tsx
@@ -76,6 +76,13 @@ export function AppMenu({ onImportEvernote }: AppMenuProps) {
         <DropdownMenuItem variant="danger" onClick={handleLogout} data-testid="logout-button">
           Log out
         </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <span className="text-fg-muted block px-3 py-1.5 text-xs" data-testid="app-version">
+          v.
+          {process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
+            ? process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA.slice(0, 7)
+            : "dev"}
+        </span>
       </DropdownMenu>
     </div>
   );

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -13,6 +13,7 @@ export const env = createEnv({
     NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),
     NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
     NEXT_PUBLIC_SENTRY_ENVIRONMENT: z.string().optional(),
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: z.string().optional(),
   },
   runtimeEnv: {
     CRON_SECRET: process.env.CRON_SECRET,
@@ -23,6 +24,7 @@ export const env = createEnv({
     NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
     NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     NEXT_PUBLIC_SENTRY_ENVIRONMENT: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
   },
   skipValidation: process.env.SKIP_ENV_VALIDATION === "true",
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "supabase:link:prod": "supabase link --project-ref tbmjbxxseonkciqovnpl",
     "supabase:push": "supabase db push",
     "migration:check": "bash scripts/check-migration-safety.sh",
-    "prepare": "husky"
+    "prepare": "husky",
+    "version:mobile": "cd apps/mobile && npm version"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,mts}": [


### PR DESCRIPTION
## Summary
- **Sentry release tagging**: All three Sentry init files (client, server, edge) and `withSentryConfig` now use the Vercel git commit SHA as the release identifier, enabling error-to-deployment correlation
- **User-visible version**: AppMenu dropdown shows the short commit SHA (`v.abc1234`) or `dev` locally
- **Mobile single source of truth**: `app.config.ts` reads version from `package.json` instead of a hardcoded string; added `version:mobile` convenience script
- **Git tagging**: Beta-release workflow creates `mobile@x.y.z` tags automatically

## Test plan
- [x] `pnpm typecheck` — all 3 packages pass
- [x] `pnpm lint` — no new warnings
- [x] `pnpm format:check` — clean
- [x] `cd apps/web && pnpm test` — 535 tests pass
- [x] `cd packages/shared && pnpm test` — 69 tests pass
- [ ] Deploy to Vercel preview → verify Sentry dashboard shows commit SHA as release
- [ ] Open AppMenu dropdown → confirm version string appears
- [ ] Run `pnpm version:mobile 1.1.0` → verify `app.config.ts` picks up new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)