### PR TITLE
fix: images not showing in iOS app

### DIFF
--- a/apps/mobile/src/lib/data/attachment-queue.ts
+++ b/apps/mobile/src/lib/data/attachment-queue.ts
@@ -83,8 +83,10 @@ async function uploadSingleAttachment(attachment: Attachment): Promise<void> {
     throw new Error("Local file not found");
   }
 
-  // Read file as blob for upload
-  const blob = localFile as unknown as Blob;
+  // Read file as a proper Blob via fetch — expo-file-system's File class
+  // is NOT a web Blob, so casting it directly fails on iOS.
+  const fetchResponse = await fetch(localUri);
+  const blob = await fetchResponse.blob();
 
   // Upload to Supabase Storage
   const { error: uploadError } = await supabase.storage


### PR DESCRIPTION
## Summary

- Fix attachment uploads failing silently on iOS due to incorrect file-to-Blob conversion
- The `uploadSingleAttachment` function was casting expo-file-system's `File` object to `Blob` via `as unknown as Blob` — this doesn't work because expo-file-system's `File` class does not implement the web `Blob` interface
- Now uses `fetch(localUri)` to properly read the local file into a real `Blob` before uploading to Supabase Storage, matching the pattern already used in the non-queued upload path (`attachments.ts`)

Closes #147

## Test plan

- [ ] Build iOS app and upload an image attachment
- [ ] Verify the image thumbnail appears in the attachment list immediately
- [ ] Verify the image persists after leaving and re-entering the note
- [ ] Test with different image formats (JPEG, PNG, HEIC)
- [ ] Test on Android to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file upload handling in the mobile app by optimizing how attachments are prepared for transmission. The underlying upload and error handling logic remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->