### PR TITLE
chore: add iOS App Store submit config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,3 +286,27 @@ cd apps/mobile && npx eas-cli build --profile beta --platform android --auto-sub
 - App package: `eu.drafto.mobile`
 
 **CI automated deploy:** The `beta-release.yml` workflow writes the service account key from `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY` GitHub secret before building. Ensure this secret is set in repo settings.
+
+## App Store Deployment (EAS Build + Submit)
+
+Single command to build and deploy to TestFlight:
+
+```bash
+cd apps/mobile && npx eas-cli build --profile beta --platform ios --auto-submit --non-interactive
+```
+
+**Setup details:**
+
+- App Store Connect App ID: `6760675784`
+- Apple Developer Team ID: `4J2USPSG2U`
+- Submit destination: TestFlight (configured in `eas.json` submit.beta.ios)
+- Signing credentials: Managed by EAS (no local certificates or provisioning profiles needed)
+- EAS handles Apple authentication via `EXPO_TOKEN` — no separate Apple ID secrets required
+
+**First-time setup:** Run `cd apps/mobile && npx eas-cli credentials --platform ios` to configure signing credentials. This prompts for Apple ID login and stores certificates in EAS.
+
+**TestFlight notes:**
+
+- First build requires Apple review (~24-48h), subsequent builds are usually available instantly
+- Internal testers are invited via App Store Connect → TestFlight → Internal Testing
+- Testers install via the TestFlight app on their iOS device

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -20,6 +20,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     supportsTablet: true,
     bundleIdentifier: "eu.drafto.mobile",
     associatedDomains: ["applinks:drafto.eu", "applinks:www.drafto.eu"],
+    infoPlist: {
+      ITSAppUsesNonExemptEncryption: false,
+    },
   },
   android: {
     adaptiveIcon: {

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -40,12 +40,18 @@
       "android": {
         "serviceAccountKeyPath": "./google-play-service-account.json",
         "track": "internal"
+      },
+      "ios": {
+        "ascAppId": "6760675784"
       }
     },
     "production": {
       "android": {
         "serviceAccountKeyPath": "./google-play-service-account.json",
         "track": "production"
+      },
+      "ios": {
+        "ascAppId": "6760675784"
       }
     }
   }


### PR DESCRIPTION
## Summary

- Add iOS submit configuration to `eas.json` with App Store Connect App ID (`6760675784`)
- Set `ITSAppUsesNonExemptEncryption: false` in `app.config.ts` to skip the export compliance prompt on TestFlight
- Document iOS/TestFlight deployment workflow in `CLAUDE.md`

## Test plan

- [ ] `eas build --profile beta --platform ios --auto-submit --non-interactive` builds and submits to TestFlight
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS app can now be deployed to Apple App Store and TestFlight

* **Documentation**
  * Added detailed iOS deployment guide with setup instructions for App Store Connect credentials, team configuration, and single-command build-and-submit workflow
  * Covers TestFlight submission process and automatic signing configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->