### PR TITLE
chore: improve nightly script with CI fix loop and auto-deploy

### DIFF
--- a/scripts/nightly-support.sh
+++ b/scripts/nightly-support.sh
@@ -55,7 +55,10 @@ For each open issue labeled "support" (max 3 per run):
    - pnpm lint && pnpm typecheck
 8. Use /push to commit, push, create PR referencing "Closes #N", wait for CI.
 9. After CI is green, squash-merge the PR via gh api and capture the merge commit SHA from the response.
-10. Fetch main, checkout the merge commit SHA, and poll gh api repos/{owner}/{repo}/commits/{sha}/check-runs until all checks on that commit pass (Vercel auto-deploys drafto.eu on merge to main).
+10. Fetch main, checkout the merge commit SHA, and poll gh api repos/{owner}/{repo}/commits/{sha}/check-runs every 30s for up to 45 minutes.
+    - Gate only on required CI checks: "Lint & Typecheck", "Unit & Integration Tests", "E2E Tests", "Mobile Checks", "SonarCloud".
+    - If any required check fails or timeout is reached: comment on the issue, add label "needs-manual-intervention", and skip mobile deploy.
+    - Vercel auto-deploys drafto.eu on merge to main.
 11. Once main CI is green on the merge commit, trigger mobile builds from that exact commit:
    - cd apps/mobile && npx eas-cli build --profile beta --platform android --auto-submit --non-interactive
    - cd apps/mobile && npx eas-cli build --profile beta --platform ios --auto-submit --non-interactive


### PR DESCRIPTION
## Summary
- Dependabot PRs with failing CI now use `/push` to fix and iterate instead of closing
- Support issues are squash-merged after CI passes, then EAS builds deploy to TestFlight and Play Store internal track
- All three platforms (web, Android, iOS) ship from the same merged `main` commit

## Test plan
- [ ] Verify nightly script runs correctly with a test support issue
- [ ] Confirm EAS builds trigger after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD automation: introduced an iterative fix workflow for CI failures on minor/patch updates, expanded post-merge orchestration to verify merges, trigger platform builds from the exact merge commit, and post per-platform status or guidance, while retaining existing major-version and CI-pending handling for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->