### PR TITLE
chore: bump mobile version to 1.1.0

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drafto/mobile",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- Bump mobile app version from 1.0.0 to 1.1.0

**Changes since 1.0.0:**
- feat: cross-notebook search for web and mobile
- feat: versioning strategy with Sentry release tagging and version display
- feat: optimized mobile build process
- fix: flush pending saves on iOS note editor
- fix: read attachment file as proper Blob before uploading to Supabase
- fix: replace expiring signed URLs with stable attachment:// scheme
- fix(mobile): revert react-native to 0.83.2 for Expo SDK 55
- fix(mobile): add EAS env vars for Supabase config to fix startup crash
- chore: iOS App Store submit config and encryption declaration

## Test plan
- [x] Version bump only — single field change in `apps/mobile/package.json`
- [ ] CI checks pass
- [ ] After merge, trigger EAS builds for both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)