### PR TITLE
chore: update SonarQube scan action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           name: coverage
           path: apps/web/coverage
-      - uses: SonarSource/sonarqube-scan-action@v5
+      - uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - uses: SonarSource/sonarqube-quality-gate-action@v1


### PR DESCRIPTION
## Summary
- Bump `SonarSource/sonarqube-scan-action` from v5 to v6 in CI workflow
- v5 was deprecated and flagged with a security vulnerability ([CI warning](https://github.com/JakubAnderwald/drafto/actions/runs/23220600513/job/67492213424?pr=163))

## Test plan
- [ ] Verify the `sonarcloud` CI job passes without the deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality scanning tool to the latest version in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->