### PR TITLE
fix: add idempotency to nightly support script

### DIFF
--- a/scripts/nightly-support.sh
+++ b/scripts/nightly-support.sh
@@ -18,6 +18,7 @@ find "$LOG_DIR" -type f -name 'nightly-*.log' -mtime +30 -delete 2>/dev/null || 
 cd "$REPO_ROOT"
 
 log() { echo "[$(date '+%H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
+NIGHTLY_MARKER='<!-- nightly-bot -->'
 
 # ── Failure notification ──
 cleanup() {
@@ -89,7 +90,7 @@ for PR_NUMBER in $(echo "$DEPENDABOT_PRS" | jq -r '.[].number'); do
     log "WARNING: Failed to fetch comments for PR #$PR_NUMBER; skipping to preserve idempotency."
     continue
   fi
-  if grep -Fq '<!-- nightly-bot -->' <<<"$COMMENT_BODIES"; then
+  if grep -Fq "$NIGHTLY_MARKER" <<<"$COMMENT_BODIES"; then
     log "PR #$PR_NUMBER already has nightly-bot comment, skipping."
     continue
   fi
@@ -100,7 +101,7 @@ You are an automated nightly job. Process ONLY Dependabot PR #$PR_NUMBER for Jak
 1. Read the PR: gh pr view $PR_NUMBER --json title,body,headRefName
 2. Check CI: gh pr checks $PR_NUMBER
 3. Decision:
-   - CI passes + minor/patch → squash merge via gh api, comment "<!-- nightly-bot -->Auto-merged: CI passed, minor/patch update."
+   - CI passes + minor/patch → squash merge via gh api, comment "${NIGHTLY_MARKER}Auto-merged: CI passed, minor/patch update."
    - CI fails + minor/patch → checkout the PR branch and use /push to fix failures and iterate until CI is green, then squash merge.
    - CI pending → poll \`gh pr checks $PR_NUMBER\` every 30 seconds for up to $POLL_TIMEOUT seconds until all checks complete. Then apply the rules above (merge/fix/flag). If still pending after timeout, log "CI still pending after timeout, skipping" and exit.
    - Major version bump → analyse the impact before flagging:
@@ -108,7 +109,7 @@ You are an automated nightly job. Process ONLY Dependabot PR #$PR_NUMBER for Jak
      2. Search the codebase for all imports and usages of the bumped package.
      3. Identify breaking changes from the changelog that affect this codebase.
      4. Check if the package's major bump requires peer dependency updates.
-     5. Add label "needs-review" and comment (starting with "<!-- nightly-bot -->") with a structured report:
+     5. Add label "needs-review" and comment (starting with "${NIGHTLY_MARKER}") with a structured report:
         - **Package**: name, old version → new version
         - **Breaking changes relevant to this codebase**: list each with affected files
         - **Breaking changes NOT relevant**: list briefly (features/APIs we don't use)


### PR DESCRIPTION
## Summary
- **Skip already-processed PRs**: Filter out Dependabot PRs already labeled `needs-review` before processing, preventing duplicate comments and wasted API credits
- **Comment marker safety net**: All nightly-bot comments now include `<!-- nightly-bot -->` marker; script checks for this before processing any PR (handles edge case of label removal)
- **Runtime tracking**: Log total elapsed time at end of each run

Also cleaned up duplicate comments on PRs #160-163 from prior runs, and re-triggered CI on PR #163 to verify the SonarCloud Dependabot secret fix.

## Test plan
- [ ] Run `bash scripts/nightly-support.sh` manually — verify already-labeled PRs are skipped in logs
- [ ] Verify PRs #160-163 now have only 1 bot comment each
- [ ] Check PR #163 CI re-run — SonarCloud should pass with Dependabot secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate automated comments by adding a hidden marker; PRs already containing the marker are skipped and flagged with a warning when comment retrieval fails.

* **Chores**
  * Added run-duration logging for nightly workflows.
  * Improved pull request collection and reporting with clearer processed vs. skipped counts.
  * Automated comments now are required to include the hidden marker for idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->