### PR TITLE
feat: add build monitoring phase to nightly support script

### DIFF
--- a/scripts/nightly-support.sh
+++ b/scripts/nightly-support.sh
@@ -128,6 +128,7 @@ done
 # Record the timestamp before Phase 3 so Phase 4 can find builds triggered during this phase.
 PHASE3_START_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 PROCESSED=0
+PHASE3_ISSUE_NUMBERS=()  # Track which issues were processed (for Phase 4 comments)
 for ISSUE_NUMBER in $(echo "$SUPPORT_ISSUES" | jq -r '.[].number'); do
   if [[ "$PROCESSED" -ge 10 ]]; then
     log "Reached max 10 support issues per run, skipping remaining."
@@ -166,6 +167,7 @@ PROMPT
     log "ERROR: Support issue #$ISSUE_NUMBER failed; continuing with next item"
   fi
   log "--- Done with issue #$ISSUE_NUMBER ---"
+  PHASE3_ISSUE_NUMBERS+=("$ISSUE_NUMBER")
   PROCESSED=$((PROCESSED + 1))
 done
 
@@ -208,10 +210,10 @@ wait_for_builds() {
   done
 }
 
-# Track retry counts per build platform (android/ios)
+# Track retry counts per build platform (android/ios — lowercase to match EAS CLI JSON output)
 declare -A PLATFORM_RETRIES
-PLATFORM_RETRIES[ANDROID]=0
-PLATFORM_RETRIES[IOS]=0
+PLATFORM_RETRIES[android]=0
+PLATFORM_RETRIES[ios]=0
 
 ROUND=0
 while true; do
@@ -324,8 +326,8 @@ log "Phase 4 summary: $FINAL_FINISHED succeeded, $FINAL_ERRORED failed, $FINAL_P
 
 if [[ "$FINAL_ERRORED" -gt 0 ]]; then
   log "WARNING: Some builds still failing after retries. Manual intervention needed."
-  # Comment on any related support issues that builds are still failing
-  for ISSUE_NUMBER in $(echo "$SUPPORT_ISSUES" | jq -r '.[].number'); do
+  # Comment only on support issues that were actually processed in Phase 3
+  for ISSUE_NUMBER in "${PHASE3_ISSUE_NUMBERS[@]}"; do
     FAILED_PLATFORMS=$(echo "$FINAL_BUILDS" | jq -r '[.[] | select(.status == "ERRORED") | .platform] | join(", ")')
     gh issue comment "$ISSUE_NUMBER" --repo JakubAnderwald/drafto --body "${NIGHTLY_MARKER}
 ## Build monitoring update


### PR DESCRIPTION
## Summary
- Adds **Phase 4** to the nightly support script that monitors EAS builds triggered during Phase 3
- Polls EAS build status every 60s (up to 45 min per round) until all builds reach a terminal state
- On build failure, launches a Claude session to diagnose the error, fix it via PR, and retrigger the build
- Retries up to **2 times per platform** (Android/iOS) before giving up
- Comments on related support issues with final build status if failures persist
- 2-hour hard deadline prevents the script from running indefinitely

## How it works
1. Phase 3 records its start timestamp
2. Phase 4 queries `eas-cli build:list` filtered to builds created after that timestamp
3. Waits for in-progress builds to complete
4. For each `ERRORED` build, spawns a Claude session with the build ID, error code, and error message
5. Claude diagnoses via build logs, creates a fix PR, merges it, and retriggers
6. Loops back to monitoring until all builds succeed or retries are exhausted

## Test plan
- [ ] Verify script syntax passes `bash -n` (done locally)
- [ ] Run nightly script with a known-failing EAS build to verify Phase 4 triggers
- [ ] Verify retry counting stops at MAX_BUILD_RETRIES=2
- [ ] Verify `needs-manual-intervention` label is added when retries exhaust
- [ ] Verify Phase 4 is skipped cleanly when no builds were triggered (no support issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive monitoring for mobile builds during nightly runs with automated error detection and recovery.
  * Support issues now automatically updated with status markers and flagged with intervention labels when manual action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->