### PR TITLE
docs: add macOS desktop app implementation plan

### DIFF
--- a/docs/macos-desktop-app.md
+++ b/docs/macos-desktop-app.md
@@ -214,7 +214,8 @@ New test suite verifying data flows correctly across all 4 platforms. Located in
 - Controls macOS via Detox or AppleScript
 - Controls Android via Maestro (existing) or Detox
 - Controls iOS via Detox
-- Shares a test Supabase account across all platforms
+- Uses isolated test identities/workspaces per test case (or per platform run)
+- Seeds deterministic fixtures before each scenario and cleans up after completion
 - Waits for sync intervals between platform actions
 
 **Minimum viable cross-platform E2E**: Start with Desktop ↔ Web sync tests (both can run on CI macOS runner), then expand to include mobile simulators.


### PR DESCRIPTION
## Summary
- Add implementation plan for a native macOS desktop app using React Native macOS
- Covers architecture, WatermelonDB offline-first storage, Supabase sync, Mac App Store deployment
- Details ~70% code reuse from the existing mobile app
- Includes cross-platform E2E testing strategy, design system consistency rules, and parallelized implementation phases

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Review plan content for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive implementation plan for a native macOS desktop app: chosen tech approach, architecture blueprint mapping shared/mobile modules to a macOS app, data/sync and auth strategies, editor strategy with fallback, design system consistency guidance, phased rollout and verification checklist, Mac App Store deployment and CI/CD beta workflow, and macOS-focused testing and E2E plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->