### PR TITLE
fix: invalidate note editor cache on navigation

### DIFF
--- a/apps/web/__tests__/integration/note-editor-panel.test.tsx
+++ b/apps/web/__tests__/integration/note-editor-panel.test.tsx
@@ -303,6 +303,50 @@ describe("NoteEditorPanel", () => {
     expect(screen.queryByTestId("save-status-badge")).not.toBeInTheDocument();
   });
 
+  it("re-fetches note when refreshTrigger changes", async () => {
+    const noteId = nextNoteId();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ...mockNote, id: noteId, title: "Old Title" }),
+    });
+
+    const { unmount } = await act(async () =>
+      render(
+        <Suspense fallback={<Skeleton height="2rem" />}>
+          <NoteEditorPanel noteId={noteId} refreshTrigger={0} />
+        </Suspense>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Old Title")).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    unmount();
+
+    // Simulate refreshTrigger increment with updated data
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ...mockNote, id: noteId, title: "New Title" }),
+    });
+
+    await act(async () => {
+      render(
+        <Suspense fallback={<Skeleton height="2rem" />}>
+          <NoteEditorPanel noteId={noteId} refreshTrigger={1} />
+        </Suspense>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("New Title")).toBeInTheDocument();
+    });
+
+    // Should have fetched again because refreshTrigger changed
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it("renders timestamp icons for created and modified dates", async () => {
     const noteId = nextNoteId();
     mockFetch.mockResolvedValue({

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -173,6 +173,11 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
+  const handleSelectNote = useCallback((noteId: string) => {
+    setSelectedNoteId(noteId);
+    setRefreshTrigger((prev) => prev + 1);
+  }, []);
+
   const handleSearchSelect = useCallback(
     (noteId: string, notebookId: string, isTrashed: boolean) => {
       setSearchOpen(false);
@@ -184,6 +189,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
         setViewingTrash(false);
         setSelectedNotebookId(notebookId);
         setSelectedNoteId(noteId);
+        setRefreshTrigger((prev) => prev + 1);
       }
     },
     [],
@@ -428,7 +434,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             <NoteList
               notebookId={selectedNotebookId}
               selectedNoteId={selectedNoteId}
-              onSelectNote={setSelectedNoteId}
+              onSelectNote={handleSelectNote}
               onCreateNote={handleCreateNote}
               onMoveNote={handleMoveNote}
               onDeleteNote={handleDeleteNote}

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -461,7 +461,11 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
 
         {selectedNoteId ? (
           <Suspense fallback={<EditorLoadingSkeleton />}>
-            <NoteEditorPanel key={selectedNoteId} noteId={selectedNoteId} />
+            <NoteEditorPanel
+              key={selectedNoteId}
+              noteId={selectedNoteId}
+              refreshTrigger={refreshTrigger}
+            />
           </Suspense>
         ) : (
           <EmptyState icon={<DocumentIcon />} message="Select a note" />

--- a/apps/web/src/components/notes/note-editor-panel.tsx
+++ b/apps/web/src/components/notes/note-editor-panel.tsx
@@ -29,6 +29,13 @@ function fetchNote(noteId: string, cacheKey: string): Promise<NoteData | null> {
   const cached = noteCache.get(cacheKey);
   if (cached) return cached;
 
+  // Evict stale entries for the same note to keep cache bounded
+  for (const key of noteCache.keys()) {
+    if (key.startsWith(`${noteId}-`)) {
+      noteCache.delete(key);
+    }
+  }
+
   const promise = fetch(`/api/notes/${noteId}`).then((res) => {
     if (handleAuthError(res)) return null;
     return res.ok ? res.json() : null;

--- a/apps/web/src/components/notes/note-editor-panel.tsx
+++ b/apps/web/src/components/notes/note-editor-panel.tsx
@@ -12,6 +12,7 @@ import { MAX_TITLE_LENGTH } from "@drafto/shared";
 
 interface NoteEditorPanelProps {
   noteId: string;
+  refreshTrigger?: number;
 }
 
 interface NoteData {
@@ -24,8 +25,8 @@ interface NoteData {
 
 const noteCache = new Map<string, Promise<NoteData | null>>();
 
-function fetchNote(noteId: string): Promise<NoteData | null> {
-  const cached = noteCache.get(noteId);
+function fetchNote(noteId: string, cacheKey: string): Promise<NoteData | null> {
+  const cached = noteCache.get(cacheKey);
   if (cached) return cached;
 
   const promise = fetch(`/api/notes/${noteId}`).then((res) => {
@@ -33,7 +34,7 @@ function fetchNote(noteId: string): Promise<NoteData | null> {
     return res.ok ? res.json() : null;
   });
 
-  noteCache.set(noteId, promise);
+  noteCache.set(cacheKey, promise);
   return promise;
 }
 
@@ -79,8 +80,9 @@ function ClockIcon() {
   );
 }
 
-export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
-  const note = use(fetchNote(noteId));
+export function NoteEditorPanel({ noteId, refreshTrigger = 0 }: NoteEditorPanelProps) {
+  const cacheKey = `${noteId}-${refreshTrigger}`;
+  const note = use(fetchNote(noteId, cacheKey));
   const [title, setTitle] = useState(note?.title ?? "");
   const { saveStatus, debouncedSave } = useAutoSave({ noteId });
 


### PR DESCRIPTION
## Summary

- Fix stale note content shown when navigating away from an edited note and back
- Add `refreshTrigger` to `NoteEditorPanel` cache key, matching the pattern already used by `NoteList` and `TrashList`
- Add test verifying that changing `refreshTrigger` causes a fresh fetch

Relates to #262 (real-time sync for external modifications is tracked separately).

## Test plan

- [x] Unit + integration tests pass (555 tests)
- [x] TypeScript check passes
- [ ] Manual: edit a note, navigate to another note, navigate back — should show saved content (not stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Note editor now reliably refetches and displays updated content when a refresh is triggered, preventing stale displays.
* **Tests**
  * Added an integration test ensuring the note editor refresh flow updates content when a refresh event occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->