### PR TITLE
fix: update Modified timestamps after auto-save

### DIFF
--- a/apps/web/__tests__/integration/note-editor-panel.test.tsx
+++ b/apps/web/__tests__/integration/note-editor-panel.test.tsx
@@ -347,7 +347,7 @@ describe("NoteEditorPanel", () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
-  it("updates Modified timestamp after save via lastSavedAt", async () => {
+  it("renders Modified timestamp from initial note data", async () => {
     const noteId = nextNoteId();
     const oldDate = new Date(Date.now() - 60 * 60000).toISOString(); // 1h ago
     const newDate = new Date().toISOString();
@@ -388,7 +388,7 @@ describe("NoteEditorPanel", () => {
     expect(screen.getByText(/Modified 1h ago/)).toBeInTheDocument();
   });
 
-  it("calls onNoteUpdated callback when provided", async () => {
+  it("does not call onNoteUpdated on initial render", async () => {
     const noteId = nextNoteId();
     const onNoteUpdated = vi.fn();
 

--- a/apps/web/__tests__/integration/note-editor-panel.test.tsx
+++ b/apps/web/__tests__/integration/note-editor-panel.test.tsx
@@ -347,6 +347,72 @@ describe("NoteEditorPanel", () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
+  it("updates Modified timestamp after save via lastSavedAt", async () => {
+    const noteId = nextNoteId();
+    const oldDate = new Date(Date.now() - 60 * 60000).toISOString(); // 1h ago
+    const newDate = new Date().toISOString();
+
+    // Initial fetch returns old date
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...mockNote, id: noteId, updated_at: oldDate }),
+    });
+
+    await act(async () => {
+      render(
+        <Suspense fallback={<Skeleton height="2rem" />}>
+          <NoteEditorPanel noteId={noteId} />
+        </Suspense>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Modified 1h ago/)).toBeInTheDocument();
+    });
+
+    // Mock save response with new timestamp
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...mockNote, id: noteId, updated_at: newDate }),
+    });
+
+    // Trigger a title change to initiate auto-save
+    const titleInput = screen.getByLabelText("Note title");
+    await act(async () => {
+      await userEvent.setup().clear(titleInput);
+      await userEvent.setup().type(titleInput, "Updated");
+    });
+
+    // The debouncedSave is mocked, so lastSavedAt won't update through the hook.
+    // But we verify the initial "Modified" rendering with the old date works.
+    expect(screen.getByText(/Modified 1h ago/)).toBeInTheDocument();
+  });
+
+  it("calls onNoteUpdated callback when provided", async () => {
+    const noteId = nextNoteId();
+    const onNoteUpdated = vi.fn();
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ...mockNote, id: noteId }),
+    });
+
+    await act(async () => {
+      render(
+        <Suspense fallback={<Skeleton height="2rem" />}>
+          <NoteEditorPanel noteId={noteId} onNoteUpdated={onNoteUpdated} />
+        </Suspense>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Note title")).toBeInTheDocument();
+    });
+
+    // onNoteUpdated should not be called on initial render (lastSavedAt is null)
+    expect(onNoteUpdated).not.toHaveBeenCalled();
+  });
+
   it("renders timestamp icons for created and modified dates", async () => {
     const noteId = nextNoteId();
     mockFetch.mockResolvedValue({

--- a/apps/web/__tests__/integration/note-list.test.tsx
+++ b/apps/web/__tests__/integration/note-list.test.tsx
@@ -532,6 +532,56 @@ describe("NoteList", () => {
     });
   });
 
+  it("updates a note's timestamp in-place when lastNoteUpdate changes", async () => {
+    const trigger = nextTrigger();
+    const oldDate = new Date(Date.now() - 60 * 60000).toISOString(); // 1h ago
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([{ id: "note-ts", title: "Timestamp Note", updated_at: oldDate }]),
+    });
+
+    const { rerender } = await act(async () =>
+      render(
+        <Suspense fallback={<Skeleton height="2.5rem" />}>
+          <NoteList
+            notebookId="nb-1"
+            selectedNoteId={null}
+            onSelectNote={vi.fn()}
+            onCreateNote={vi.fn()}
+            refreshTrigger={trigger}
+            lastNoteUpdate={null}
+          />
+        </Suspense>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("1h ago")).toBeInTheDocument();
+    });
+
+    // Simulate a save that updates the timestamp to now
+    const newDate = new Date().toISOString();
+    await act(async () => {
+      rerender(
+        <Suspense fallback={<Skeleton height="2.5rem" />}>
+          <NoteList
+            notebookId="nb-1"
+            selectedNoteId={null}
+            onSelectNote={vi.fn()}
+            onCreateNote={vi.fn()}
+            refreshTrigger={trigger}
+            lastNoteUpdate={{ noteId: "note-ts", updatedAt: newDate }}
+          />
+        </Suspense>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("just now")).toBeInTheDocument();
+    });
+  });
+
   it("fetches notes for the given notebook ID", async () => {
     const trigger = nextTrigger();
     const onSelect = vi.fn();

--- a/apps/web/__tests__/unit/use-auto-save.test.ts
+++ b/apps/web/__tests__/unit/use-auto-save.test.ts
@@ -17,7 +17,10 @@ describe("useAutoSave", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    mockFetch.mockResolvedValue({ ok: true });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ updated_at: "2026-04-11T12:00:00Z" }),
+    });
   });
 
   afterEach(() => {
@@ -81,6 +84,47 @@ describe("useAutoSave", () => {
         body: JSON.stringify({ title: "Flush me" }),
       }),
     );
+  });
+
+  it("returns lastSavedAt from API response after save", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ updated_at: "2026-04-11T15:30:00Z" }),
+    });
+
+    const { result } = renderHook(() => useAutoSave({ noteId: "note-1", debounceMs: 100 }));
+
+    expect(result.current.lastSavedAt).toBeNull();
+
+    act(() => {
+      result.current.debouncedSave({ title: "Test" });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current.lastSavedAt).toBe("2026-04-11T15:30:00Z");
+  });
+
+  it("sets error status when response is not ok", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
+
+    const { result } = renderHook(() => useAutoSave({ noteId: "note-1", debounceMs: 100 }));
+
+    act(() => {
+      result.current.debouncedSave({ title: "Test" });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current.saveStatus).toBe("error");
+    expect(result.current.lastSavedAt).toBeNull();
   });
 
   it("does not save when noteId is null", async () => {

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -153,6 +153,10 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [lastNoteUpdate, setLastNoteUpdate] = useState<{
+    noteId: string;
+    updatedAt: string;
+  } | null>(null);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -176,6 +180,10 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
   const handleSelectNote = useCallback((noteId: string) => {
     setSelectedNoteId(noteId);
     setRefreshTrigger((prev) => prev + 1);
+  }, []);
+
+  const handleNoteUpdated = useCallback((noteId: string, updatedAt: string) => {
+    setLastNoteUpdate({ noteId, updatedAt });
   }, []);
 
   const handleSearchSelect = useCallback(
@@ -440,6 +448,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
               onDeleteNote={handleDeleteNote}
               notebooks={notebooks}
               refreshTrigger={refreshTrigger}
+              lastNoteUpdate={lastNoteUpdate}
             />
           </Suspense>
         ) : (
@@ -471,6 +480,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
               key={selectedNoteId}
               noteId={selectedNoteId}
               refreshTrigger={refreshTrigger}
+              onNoteUpdated={handleNoteUpdated}
             />
           </Suspense>
         ) : (

--- a/apps/web/src/components/notes/note-editor-panel.tsx
+++ b/apps/web/src/components/notes/note-editor-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState } from "react";
+import { use, useEffect, useState } from "react";
 import { NoteEditor } from "@/components/editor/note-editor";
 import { Badge } from "@/components/ui/badge";
 import { useAutoSave } from "@/hooks/use-auto-save";
@@ -13,6 +13,7 @@ import { MAX_TITLE_LENGTH } from "@drafto/shared";
 interface NoteEditorPanelProps {
   noteId: string;
   refreshTrigger?: number;
+  onNoteUpdated?: (noteId: string, updatedAt: string) => void;
 }
 
 interface NoteData {
@@ -87,11 +88,21 @@ function ClockIcon() {
   );
 }
 
-export function NoteEditorPanel({ noteId, refreshTrigger = 0 }: NoteEditorPanelProps) {
+export function NoteEditorPanel({
+  noteId,
+  refreshTrigger = 0,
+  onNoteUpdated,
+}: NoteEditorPanelProps) {
   const cacheKey = `${noteId}-${refreshTrigger}`;
   const note = use(fetchNote(noteId, cacheKey));
   const [title, setTitle] = useState(note?.title ?? "");
-  const { saveStatus, debouncedSave } = useAutoSave({ noteId });
+  const { saveStatus, debouncedSave, lastSavedAt } = useAutoSave({ noteId });
+
+  useEffect(() => {
+    if (lastSavedAt) {
+      onNoteUpdated?.(noteId, lastSavedAt);
+    }
+  }, [lastSavedAt, noteId, onNoteUpdated]);
 
   if (!note) {
     return (
@@ -143,7 +154,7 @@ export function NoteEditorPanel({ noteId, refreshTrigger = 0 }: NoteEditorPanelP
           </span>
           <span className="inline-flex items-center gap-1">
             <ClockIcon />
-            Modified {formatRelativeTime(note.updated_at)}
+            Modified {formatRelativeTime(lastSavedAt ?? note.updated_at)}
           </span>
         </div>
       </div>

--- a/apps/web/src/components/notes/note-list.tsx
+++ b/apps/web/src/components/notes/note-list.tsx
@@ -17,6 +17,11 @@ interface NotebookOption {
   name: string;
 }
 
+interface NoteUpdate {
+  noteId: string;
+  updatedAt: string;
+}
+
 interface NoteListProps {
   notebookId: string;
   selectedNoteId: string | null;
@@ -26,6 +31,7 @@ interface NoteListProps {
   onDeleteNote?: (noteId: string) => void;
   notebooks?: NotebookOption[];
   refreshTrigger?: number;
+  lastNoteUpdate?: NoteUpdate | null;
 }
 
 const notesCache = new Map<string, Promise<NoteListItem[]>>();
@@ -55,11 +61,13 @@ export function NoteList({
   onDeleteNote,
   notebooks = [],
   refreshTrigger = 0,
+  lastNoteUpdate,
 }: NoteListProps) {
   const cacheKey = `${notebookId}-${refreshTrigger}`;
   const initialNotes = use(fetchNotes(notebookId, cacheKey));
   const [notes, setNotes] = useState(initialNotes);
   const [prevInitialNotes, setPrevInitialNotes] = useState(initialNotes);
+  const [prevNoteUpdate, setPrevNoteUpdate] = useState(lastNoteUpdate);
   const [menuOpenForNote, setMenuOpenForNote] = useState<string | null>(null);
 
   // Update notes when cache key changes (new data loaded via refreshTrigger)
@@ -67,6 +75,16 @@ export function NoteList({
   if (prevInitialNotes !== initialNotes) {
     setPrevInitialNotes(initialNotes);
     setNotes(initialNotes);
+  }
+
+  // Update a single note's timestamp in-place after save (no re-fetch)
+  if (lastNoteUpdate && lastNoteUpdate !== prevNoteUpdate) {
+    setPrevNoteUpdate(lastNoteUpdate);
+    setNotes((prev) =>
+      prev.map((n) =>
+        n.id === lastNoteUpdate.noteId ? { ...n, updated_at: lastNoteUpdate.updatedAt } : n,
+      ),
+    );
   }
 
   const handleDelete = useCallback(

--- a/apps/web/src/hooks/use-auto-save.ts
+++ b/apps/web/src/hooks/use-auto-save.ts
@@ -10,6 +10,7 @@ interface UseAutoSaveOptions {
 
 export function useAutoSave({ noteId, debounceMs = 500 }: UseAutoSaveOptions) {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingData = useRef<Record<string, unknown> | null>(null);
   const savingRef = useRef(false);
@@ -39,7 +40,15 @@ export function useAutoSave({ noteId, debounceMs = 500 }: UseAutoSaveOptions) {
           return;
         }
 
-        setSaveStatus(res.ok ? "saved" : "error");
+        if (res.ok) {
+          setSaveStatus("saved");
+          const updated = await res.json();
+          if (updated?.updated_at) {
+            setLastSavedAt(updated.updated_at);
+          }
+        } else {
+          setSaveStatus("error");
+        }
       } catch {
         setSaveStatus("error");
       } finally {
@@ -93,5 +102,5 @@ export function useAutoSave({ noteId, debounceMs = 500 }: UseAutoSaveOptions) {
     };
   }, [noteId]);
 
-  return { saveStatus, debouncedSave };
+  return { saveStatus, debouncedSave, lastSavedAt };
 }


### PR DESCRIPTION
## Summary

- Capture `updated_at` from the PATCH response in `useAutoSave` (was previously discarded)
- Update the "Modified X ago" text in the editor header immediately after save
- Update the timestamp in the note list item in-place via a prop callback (no re-fetch, no visual reload)

## Test plan

- [x] 560 unit + integration tests pass
- [x] TypeScript check passes
- [ ] Manual: edit a note, wait for "Saved" badge → "Modified" shows "just now" in both editor header and note list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Modified" timestamps now update to the actual save time for clearer change visibility.
  * Notes list updates in-place when an edit is saved, so edits appear without manual refresh.
  * Editor now reports successful saves so the UI stays synchronized.

* **Tests**
  * Added unit and integration tests for saved-timestamp handling, in-place list updates, and save error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->