### PR TITLE
feat: add MCP server for Claude Cowork integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,24 @@ Supabase provides daily automatic backups. The Pro plan enables Point-in-Time Re
 - Server/edge configs: `sentry.server.config.ts`, `sentry.edge.config.ts` (loaded via `instrumentation.ts`)
 - Do not swallow errors silently — let them propagate to Sentry
 
+## MCP Server (Claude Cowork Integration)
+
+Drafto exposes a remote MCP server at `/api/mcp` for integration with Claude Desktop, Claude Cowork, and other MCP clients. Authenticated via API keys (managed at `/settings`).
+
+**Key files:**
+
+- `apps/web/src/app/api/mcp/route.ts` — MCP tool registry and handlers (all 9 tools defined here)
+- `apps/web/src/lib/api/mcp-auth.ts` — API key authentication
+- `packages/shared/src/editor/markdown-converter.ts` — BlockNote <-> Markdown conversion
+- `supabase/migrations/20260411000001_api_keys.sql` — API keys table
+
+**Maintenance rules (agents must follow):**
+
+- When adding a new user-facing feature (API route, data model, capability), evaluate whether it should be exposed as an MCP tool and update `apps/web/src/app/api/mcp/route.ts` accordingly
+- When changing an existing API route's behavior or schema, update the corresponding MCP tool handler and its input/output schemas to match
+- When adding or modifying database tables/columns that affect note content or structure, update `packages/shared/src/editor/markdown-converter.ts` if the new content type needs Markdown representation
+- Run MCP-related tests after changes: `cd apps/web && pnpm test` (includes mcp-auth and api-keys tests)
+
 ## Local Dev Setup
 
 After cloning and running `pnpm install`, ensure these CLI tools are also installed:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ Before pushing any changes, run these checks locally to avoid CI failures:
 Never push code that fails any of these checks. Common CI failure patterns to watch for:
 
 - **Missing test coverage**: When adding new code, write tests concurrently. Check coverage locally before pushing rather than iterating via CI.
+- **SonarCloud quality gate failure**: To check the specific failing conditions, query the SonarCloud API: `https://sonarcloud.io/api/qualitygates/project_status?projectKey=JakubAnderwald_drafto&pullRequest=<PR_NUMBER>`. This returns the exact metrics (e.g., coverage %, duplications) that failed the gate.
 - **E2E assumptions**: E2E tests depend on database state (migrations applied, seed data). If adding features that require new migrations, ensure the migration is applied to dev before running E2E tests.
 
 ## Supabase Patterns

--- a/apps/web/__tests__/integration/app-menu.test.tsx
+++ b/apps/web/__tests__/integration/app-menu.test.tsx
@@ -3,6 +3,12 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AppMenu } from "@/components/layout/app-menu";
 
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 // Mock Supabase client
 const mockSignOut = vi.fn().mockResolvedValue({ error: null });
 vi.mock("@/lib/supabase/client", () => ({

--- a/apps/web/__tests__/integration/app-shell.test.tsx
+++ b/apps/web/__tests__/integration/app-shell.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
 vi.mock("@/env", () => ({
   env: {
     NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",

--- a/apps/web/__tests__/integration/settings.test.tsx
+++ b/apps/web/__tests__/integration/settings.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SettingsPage from "@/app/settings/page";
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock navigator.clipboard
+const mockWriteText = vi.fn().mockResolvedValue(undefined);
+Object.assign(navigator, {
+  clipboard: {
+    writeText: mockWriteText,
+  },
+});
+
+describe("SettingsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the settings page with API keys heading", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("API Keys")).toBeInTheDocument();
+  });
+
+  it("shows loading state and then empty message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No API keys yet. Generate one to get started.")).toBeInTheDocument();
+    });
+  });
+
+  it("displays existing API keys", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: "key-1",
+            key_prefix: "dk_abcde",
+            name: "Claude Desktop",
+            created_at: "2026-04-11T00:00:00Z",
+            last_used_at: "2026-04-11T12:00:00Z",
+            revoked_at: null,
+          },
+        ]),
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Claude Desktop")).toBeInTheDocument();
+      expect(screen.getByText(/dk_abcde/)).toBeInTheDocument();
+    });
+  });
+
+  it("creates a new API key and shows it", async () => {
+    const user = userEvent.setup();
+
+    // First: fetch existing keys (empty)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No API keys yet. Generate one to get started.")).toBeInTheDocument();
+    });
+
+    // Type key name
+    const input = screen.getByPlaceholderText("Key name (e.g. Claude Desktop)");
+    await user.type(input, "Test Key");
+
+    // Mock create response
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: "key-new",
+          key_prefix: "dk_test12",
+          name: "Test Key",
+          key: "dk_abcdef123456789012345678901234567890123456789012",
+        }),
+    });
+
+    // Mock refresh response
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: "key-new",
+            key_prefix: "dk_test12",
+            name: "Test Key",
+            created_at: "2026-04-11T00:00:00Z",
+            last_used_at: null,
+            revoked_at: null,
+          },
+        ]),
+    });
+
+    // Click generate
+    await user.click(screen.getByText("Generate key"));
+
+    // Wait for the key to appear
+    await waitFor(() => {
+      expect(screen.getByText(/dk_abcdef/)).toBeInTheDocument();
+    });
+  });
+
+  it("revokes an API key", async () => {
+    const user = userEvent.setup();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: "key-1",
+            key_prefix: "dk_abcde",
+            name: "My Key",
+            created_at: "2026-04-11T00:00:00Z",
+            last_used_at: null,
+            revoked_at: null,
+          },
+        ]),
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("My Key")).toBeInTheDocument();
+    });
+
+    // Mock revoke response
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: "key-1", revoked: true }),
+    });
+
+    // Mock refresh response (empty - key is revoked)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    await user.click(screen.getByText("Revoke"));
+
+    await waitFor(() => {
+      expect(screen.getByText("No API keys yet. Generate one to get started.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the MCP connection config", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText("Connect to Claude")).toBeInTheDocument();
+    expect(screen.getByText(/YOUR_API_KEY/)).toBeInTheDocument();
+  });
+
+  it("shows error when key creation fails", async () => {
+    const user = userEvent.setup();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No API keys yet. Generate one to get started.")).toBeInTheDocument();
+    });
+
+    // Mock failed create
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: "Rate limited" }),
+    });
+
+    await user.click(screen.getByText("Generate key"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Rate limited")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/__tests__/unit/api-keys.test.ts
+++ b/apps/web/__tests__/unit/api-keys.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-key",
+  },
+}));
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({
+    getAll: () => [],
+    set: vi.fn(),
+  }),
+}));
+
+const { GET, POST } = await import("@/app/api/api-keys/route");
+
+const approvedProfile = {
+  select: () => ({
+    eq: () => ({
+      single: () => Promise.resolve({ data: { is_approved: true }, error: null }),
+    }),
+  }),
+};
+
+function authenticateAs(userId: string) {
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: userId, email: "test@test.com" } },
+    error: null,
+  });
+}
+
+describe("GET /api/api-keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: "Not auth" } });
+
+    const response = await GET();
+    expect(response.status).toBe(401);
+  });
+
+  it("returns API keys for authenticated user", async () => {
+    authenticateAs("user-1");
+
+    const keys = [
+      {
+        id: "key-1",
+        key_prefix: "dk_abcde",
+        name: "Claude Desktop",
+        created_at: "2026-04-11T00:00:00Z",
+        last_used_at: null,
+        revoked_at: null,
+      },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "profiles") return approvedProfile;
+      return {
+        select: () => ({
+          eq: () => ({
+            order: () => Promise.resolve({ data: keys, error: null }),
+          }),
+        }),
+      };
+    });
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].name).toBe("Claude Desktop");
+  });
+});
+
+describe("POST /api/api-keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: "Not auth" } });
+
+    const req = new NextRequest("http://localhost/api/api-keys", {
+      method: "POST",
+      body: JSON.stringify({ name: "Test Key" }),
+    });
+
+    const response = await POST(req);
+    expect(response.status).toBe(401);
+  });
+
+  it("creates a new API key and returns the raw key", async () => {
+    authenticateAs("user-1");
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "profiles") return approvedProfile;
+      return {
+        insert: () => ({
+          select: () => ({
+            single: () =>
+              Promise.resolve({
+                data: { id: "key-new", key_prefix: "dk_test1", name: "Test Key" },
+                error: null,
+              }),
+          }),
+        }),
+      };
+    });
+
+    const req = new NextRequest("http://localhost/api/api-keys", {
+      method: "POST",
+      body: JSON.stringify({ name: "Test Key" }),
+    });
+
+    const response = await POST(req);
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.key).toMatch(/^dk_/);
+    expect(body.key).toHaveLength(51); // dk_ + 48 hex chars
+    expect(body.id).toBe("key-new");
+  });
+});

--- a/apps/web/__tests__/unit/mcp-auth.test.ts
+++ b/apps/web/__tests__/unit/mcp-auth.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockFrom = vi.fn();
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-key",
+    SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+  },
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+const { authenticateMcpRequest } = await import("@/lib/api/mcp-auth");
+
+describe("authenticateMcpRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws on missing Authorization header", async () => {
+    await expect(authenticateMcpRequest(null)).rejects.toThrow(
+      "Missing or invalid Authorization header",
+    );
+  });
+
+  it("throws on non-Bearer auth header", async () => {
+    await expect(authenticateMcpRequest("Basic abc123")).rejects.toThrow(
+      "Missing or invalid Authorization header",
+    );
+  });
+
+  it("throws on empty Bearer token", async () => {
+    await expect(authenticateMcpRequest("Bearer ")).rejects.toThrow("Empty API key");
+  });
+
+  it("throws when API key is not found", async () => {
+    mockFrom.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: null, error: { message: "Not found" } }),
+        }),
+      }),
+    }));
+
+    await expect(authenticateMcpRequest("Bearer dk_somefakekey12345")).rejects.toThrow(
+      "Invalid API key",
+    );
+  });
+
+  it("throws when API key is revoked", async () => {
+    mockFrom.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          single: () =>
+            Promise.resolve({
+              data: { id: "key-1", user_id: "user-1", revoked_at: "2026-01-01" },
+              error: null,
+            }),
+        }),
+      }),
+    }));
+
+    await expect(authenticateMcpRequest("Bearer dk_somefakekey12345")).rejects.toThrow(
+      "API key has been revoked",
+    );
+  });
+
+  it("throws when user is not approved", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "api_keys") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: { id: "key-1", user_id: "user-1", revoked_at: null },
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+      if (table === "profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: { is_approved: false },
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    await expect(authenticateMcpRequest("Bearer dk_somefakekey12345")).rejects.toThrow(
+      "User account is not approved",
+    );
+  });
+
+  it("returns userId and supabase client when authentication succeeds", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "api_keys") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: { id: "key-1", user_id: "user-1", revoked_at: null },
+                  error: null,
+                }),
+            }),
+          }),
+          update: () => ({
+            eq: () => ({
+              then: (cb: () => void) => cb(),
+            }),
+          }),
+        };
+      }
+      if (table === "profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: { is_approved: true },
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const result = await authenticateMcpRequest("Bearer dk_somefakekey12345");
+    expect(result.userId).toBe("user-1");
+    expect(result.supabase).toBeDefined();
+  });
+});

--- a/apps/web/__tests__/unit/mcp-route.test.ts
+++ b/apps/web/__tests__/unit/mcp-route.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock env before importing route
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-key",
+    SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+  },
+}));
+
+// Mock the MCP auth
+vi.mock("@/lib/api/mcp-auth", () => ({
+  authenticateMcpRequest: vi.fn(),
+}));
+
+// We need to mock the SDK modules so the route can be imported without errors
+const mockHandleRequest = vi.fn();
+const mockTransportClose = vi.fn();
+const mockServerConnect = vi.fn();
+const mockServerClose = vi.fn();
+const mockTool = vi.fn();
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+  McpServer: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.tool = mockTool;
+    this.connect = mockServerConnect;
+    this.close = mockServerClose;
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js", () => ({
+  WebStandardStreamableHTTPServerTransport: vi.fn().mockImplementation(function (
+    this: Record<string, unknown>,
+  ) {
+    this.handleRequest = mockHandleRequest;
+    this.close = mockTransportClose;
+  }),
+}));
+
+const { authenticateMcpRequest } = await import("@/lib/api/mcp-auth");
+const { POST, GET, DELETE } = await import("@/app/api/mcp/route");
+
+describe("POST /api/mcp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHandleRequest.mockResolvedValue(
+      new Response(JSON.stringify({ jsonrpc: "2.0", result: {} }), { status: 200 }),
+    );
+  });
+
+  it("returns 401 when authentication fails", async () => {
+    vi.mocked(authenticateMcpRequest).mockRejectedValue(new Error("Invalid API key"));
+
+    const request = new Request("http://localhost/api/mcp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error.message).toBe("Invalid API key");
+  });
+
+  it("returns 401 when no Authorization header", async () => {
+    vi.mocked(authenticateMcpRequest).mockRejectedValue(
+      new Error("Missing or invalid Authorization header"),
+    );
+
+    const request = new Request("http://localhost/api/mcp", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+  });
+
+  it("processes MCP request when authenticated", async () => {
+    const mockFrom = vi.fn();
+    vi.mocked(authenticateMcpRequest).mockResolvedValue({
+      userId: "user-1",
+      supabase: { from: mockFrom } as never,
+    });
+
+    const request = new Request("http://localhost/api/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer dk_test123",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    expect(mockServerConnect).toHaveBeenCalled();
+    expect(mockHandleRequest).toHaveBeenCalledWith(request);
+    expect(mockServerClose).toHaveBeenCalled();
+    expect(mockTransportClose).toHaveBeenCalled();
+  });
+
+  it("registers 9 MCP tools", async () => {
+    const mockFrom = vi.fn();
+    vi.mocked(authenticateMcpRequest).mockResolvedValue({
+      userId: "user-1",
+      supabase: { from: mockFrom } as never,
+    });
+
+    const request = new Request("http://localhost/api/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer dk_test123",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+    });
+
+    await POST(request);
+
+    // Verify all 9 tools are registered
+    const toolNames = mockTool.mock.calls.map((call: unknown[]) => call[0]);
+    expect(toolNames).toContain("list_notebooks");
+    expect(toolNames).toContain("list_notes");
+    expect(toolNames).toContain("read_note");
+    expect(toolNames).toContain("search_notes");
+    expect(toolNames).toContain("create_notebook");
+    expect(toolNames).toContain("create_note");
+    expect(toolNames).toContain("update_note");
+    expect(toolNames).toContain("move_note");
+    expect(toolNames).toContain("trash_note");
+    expect(toolNames).toHaveLength(9);
+  });
+
+  it("calls close on server and transport after processing", async () => {
+    vi.mocked(authenticateMcpRequest).mockResolvedValue({
+      userId: "user-1",
+      supabase: { from: vi.fn() } as never,
+    });
+
+    const request = new Request("http://localhost/api/mcp", {
+      method: "POST",
+      headers: { Authorization: "Bearer dk_test123" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 }),
+    });
+
+    await POST(request);
+    expect(mockServerClose).toHaveBeenCalled();
+    expect(mockTransportClose).toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/mcp", () => {
+  it("returns 405", async () => {
+    const response = await GET();
+    expect(response.status).toBe(405);
+  });
+});
+
+describe("DELETE /api/mcp", () => {
+  it("returns 405", async () => {
+    const response = await DELETE();
+    expect(response.status).toBe(405);
+  });
+});

--- a/apps/web/__tests__/unit/mcp-tools.test.ts
+++ b/apps/web/__tests__/unit/mcp-tools.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-key",
+  },
+}));
+
+const {
+  listNotebooks,
+  listNotes,
+  readNote,
+  searchNotes,
+  createNotebook,
+  createNote,
+  updateNote,
+  moveNote,
+  trashNote,
+} = await import("@/lib/api/mcp-tools");
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+function createMockSupabase(fromImpl: MockFn, rpcImpl?: MockFn) {
+  return {
+    from: fromImpl,
+    rpc: rpcImpl ?? vi.fn(),
+  } as never;
+}
+
+function chainOk(data: unknown) {
+  return {
+    select: () => ({
+      eq: () => ({
+        order: () => Promise.resolve({ data, error: null }),
+        eq: () => ({
+          order: () => Promise.resolve({ data, error: null }),
+          eq: () => ({
+            order: () => Promise.resolve({ data, error: null }),
+            single: () => Promise.resolve({ data, error: null }),
+          }),
+          single: () => Promise.resolve({ data, error: null }),
+        }),
+        single: () => Promise.resolve({ data, error: null }),
+      }),
+    }),
+    insert: () => ({
+      select: () => ({
+        single: () => Promise.resolve({ data, error: null }),
+      }),
+    }),
+    update: () => ({
+      eq: () => ({
+        eq: () => ({
+          select: () => ({
+            single: () => Promise.resolve({ data, error: null }),
+          }),
+        }),
+        select: () => ({
+          single: () => Promise.resolve({ data, error: null }),
+        }),
+      }),
+    }),
+  };
+}
+
+function chainErr(message: string) {
+  return {
+    select: () => ({
+      eq: () => ({
+        order: () => Promise.resolve({ data: null, error: { message } }),
+        eq: () => ({
+          order: () => Promise.resolve({ data: null, error: { message } }),
+          eq: () => ({
+            order: () => Promise.resolve({ data: null, error: { message } }),
+          }),
+        }),
+        single: () => Promise.resolve({ data: null, error: { message } }),
+      }),
+    }),
+    insert: () => ({
+      select: () => ({
+        single: () => Promise.resolve({ data: null, error: { message } }),
+      }),
+    }),
+    update: () => ({
+      eq: () => ({
+        eq: () => ({
+          select: () => ({
+            single: () => Promise.resolve({ data: null, error: { message } }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe("listNotebooks", () => {
+  it("returns notebooks on success", async () => {
+    const notebooks = [{ id: "nb-1", name: "Notes" }];
+    const supabase = createMockSupabase(vi.fn(() => chainOk(notebooks)));
+
+    const result = await listNotebooks(supabase, "user-1");
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual(notebooks);
+  });
+
+  it("returns error on failure", async () => {
+    const supabase = createMockSupabase(vi.fn(() => chainErr("Query failed")));
+
+    const result = await listNotebooks(supabase, "user-1");
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Query failed");
+  });
+});
+
+describe("listNotes", () => {
+  it("returns notes on success", async () => {
+    const notes = [{ id: "note-1", title: "Test" }];
+    const supabase = createMockSupabase(vi.fn(() => chainOk(notes)));
+
+    const result = await listNotes(supabase, "user-1", "nb-1");
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual(notes);
+  });
+});
+
+describe("readNote", () => {
+  it("returns note content as markdown", async () => {
+    const note = {
+      id: "note-1",
+      title: "Test Note",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Hello", styles: {} }], children: [] },
+      ],
+      notebook_id: "nb-1",
+      is_trashed: false,
+      created_at: "2026-01-01",
+      updated_at: "2026-01-02",
+    };
+    const notebook = { name: "My Notebook" };
+
+    const mockFrom = vi.fn((table: string) => {
+      if (table === "notes") return chainOk(note);
+      if (table === "notebooks") return chainOk(notebook);
+      return chainOk(null);
+    });
+
+    const result = await readNote(createMockSupabase(mockFrom), "user-1", "note-1");
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("# Test Note");
+    expect(result.content[0].text).toContain("Hello");
+    expect(result.content[0].text).toContain("My Notebook");
+  });
+
+  it("returns error when note not found", async () => {
+    const supabase = createMockSupabase(
+      vi.fn(() => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: null, error: { message: "Not found" } }),
+            }),
+          }),
+        }),
+      })),
+    );
+
+    const result = await readNote(supabase, "user-1", "bad-id");
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Note not found");
+  });
+});
+
+describe("searchNotes", () => {
+  it("returns search results on success", async () => {
+    const results = [{ id: "note-1", title: "Match" }];
+    const mockRpc = vi.fn().mockResolvedValue({ data: results, error: null });
+
+    const result = await searchNotes(createMockSupabase(vi.fn(), mockRpc), "user-1", "test");
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual(results);
+  });
+
+  it("returns error on RPC failure", async () => {
+    const mockRpc = vi.fn().mockResolvedValue({ data: null, error: { message: "RPC error" } });
+
+    const result = await searchNotes(createMockSupabase(vi.fn(), mockRpc), "user-1", "test");
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("createNotebook", () => {
+  it("creates notebook successfully", async () => {
+    const nb = { id: "nb-new", name: "New" };
+    const supabase = createMockSupabase(vi.fn(() => chainOk(nb)));
+
+    const result = await createNotebook(supabase, "user-1", "New");
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual(nb);
+  });
+});
+
+describe("createNote", () => {
+  it("creates note with markdown content", async () => {
+    const noteData = { id: "note-new", title: "Hello" };
+    const supabase = createMockSupabase(vi.fn(() => chainOk(noteData)));
+
+    const result = await createNote(supabase, "user-1", "nb-1", "Hello", "# Content");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("creates note without content", async () => {
+    const noteData = { id: "note-new", title: "Hello" };
+    const supabase = createMockSupabase(vi.fn(() => chainOk(noteData)));
+
+    const result = await createNote(supabase, "user-1", "nb-1", "Hello");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("returns error when notebook not found", async () => {
+    const supabase = createMockSupabase(
+      vi.fn(() => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: null, error: { message: "not found" } }),
+            }),
+          }),
+        }),
+      })),
+    );
+
+    const result = await createNote(supabase, "user-1", "bad-nb", "Title");
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Notebook not found");
+  });
+});
+
+describe("updateNote", () => {
+  it("updates title successfully", async () => {
+    const updated = { id: "note-1", title: "New Title", updated_at: "2026-01-02" };
+    const supabase = createMockSupabase(vi.fn(() => chainOk(updated)));
+
+    const result = await updateNote(supabase, "user-1", "note-1", "New Title");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("updates content with markdown", async () => {
+    const updated = { id: "note-1", title: "Title", updated_at: "2026-01-02" };
+    const supabase = createMockSupabase(vi.fn(() => chainOk(updated)));
+
+    const result = await updateNote(supabase, "user-1", "note-1", undefined, "# New content");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("returns error when no fields provided", async () => {
+    const supabase = createMockSupabase(vi.fn());
+
+    const result = await updateNote(supabase, "user-1", "note-1");
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("No fields to update");
+  });
+});
+
+describe("moveNote", () => {
+  it("moves note successfully", async () => {
+    const moved = { id: "note-1", title: "Test", notebook_id: "nb-2" };
+    const supabase = createMockSupabase(vi.fn(() => chainOk(moved)));
+
+    const result = await moveNote(supabase, "user-1", "note-1", "nb-2");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("returns error when target notebook not found", async () => {
+    const supabase = createMockSupabase(
+      vi.fn(() => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: null, error: { message: "not found" } }),
+            }),
+          }),
+        }),
+      })),
+    );
+
+    const result = await moveNote(supabase, "user-1", "note-1", "bad-nb");
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Target notebook not found");
+  });
+});
+
+describe("trashNote", () => {
+  it("trashes note successfully", async () => {
+    const trashed = { id: "note-1", title: "Test" };
+    const supabase = createMockSupabase(vi.fn(() => chainOk(trashed)));
+
+    const result = await trashNote(supabase, "user-1", "note-1");
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("moved to trash");
+  });
+});

--- a/apps/web/__tests__/unit/mcp-tools.test.ts
+++ b/apps/web/__tests__/unit/mcp-tools.test.ts
@@ -175,17 +175,41 @@ describe("readNote", () => {
 describe("searchNotes", () => {
   it("returns search results on success", async () => {
     const results = [{ id: "note-1", title: "Match" }];
-    const mockRpc = vi.fn().mockResolvedValue({ data: results, error: null });
+    const supabase = createMockSupabase(
+      vi.fn(() => ({
+        select: () => ({
+          eq: () => ({
+            ilike: () => ({
+              order: () => ({
+                limit: () => Promise.resolve({ data: results, error: null }),
+              }),
+            }),
+          }),
+        }),
+      })),
+    );
 
-    const result = await searchNotes(createMockSupabase(vi.fn(), mockRpc), "user-1", "test");
+    const result = await searchNotes(supabase, "user-1", "test");
     expect(result.isError).toBeUndefined();
     expect(JSON.parse(result.content[0].text)).toEqual(results);
   });
 
-  it("returns error on RPC failure", async () => {
-    const mockRpc = vi.fn().mockResolvedValue({ data: null, error: { message: "RPC error" } });
+  it("returns error on query failure", async () => {
+    const supabase = createMockSupabase(
+      vi.fn(() => ({
+        select: () => ({
+          eq: () => ({
+            ilike: () => ({
+              order: () => ({
+                limit: () => Promise.resolve({ data: null, error: { message: "Query error" } }),
+              }),
+            }),
+          }),
+        }),
+      })),
+    );
 
-    const result = await searchNotes(createMockSupabase(vi.fn(), mockRpc), "user-1", "test");
+    const result = await searchNotes(supabase, "user-1", "test");
     expect(result.isError).toBe(true);
   });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,11 +18,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@drafto/shared": "workspace:*",
     "@blocknote/core": "^0.47.3",
     "@blocknote/mantine": "^0.47.3",
     "@blocknote/react": "^0.47.3",
+    "@drafto/shared": "workspace:*",
     "@mantine/core": "^8.3.18",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@sentry/nextjs": "^10.47.0",
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.101.1",
@@ -48,7 +49,6 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.2",
-    "vite": "^8.0.5",
     "eslint": "^9",
     "eslint-config-next": "16.2.2",
     "eslint-config-prettier": "^10.1.8",

--- a/apps/web/src/app/api/api-keys/[id]/route.ts
+++ b/apps/web/src/app/api/api-keys/[id]/route.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from "next/server";
+import { getAuthenticatedUser, errorResponse, successResponse } from "@/lib/api/utils";
+
+/**
+ * DELETE /api/api-keys/[id] — Revoke an API key (soft-delete by setting revoked_at).
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { data: auth, error: authError } = await getAuthenticatedUser();
+  if (authError) return authError;
+
+  const { supabase, user } = auth;
+  const { id } = await params;
+
+  const { data, error } = await supabase
+    .from("api_keys")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .is("revoked_at", null)
+    .select("id")
+    .single();
+
+  if (error || !data) return errorResponse("API key not found", 404);
+
+  return successResponse({ id: data.id, revoked: true });
+}

--- a/apps/web/src/app/api/api-keys/route.ts
+++ b/apps/web/src/app/api/api-keys/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getAuthenticatedUser, errorResponse, successResponse } from "@/lib/api/utils";
+
+/**
+ * GET /api/api-keys — List the current user's API keys (excludes key_hash).
+ */
+export async function GET() {
+  const { data: auth, error: authError } = await getAuthenticatedUser();
+  if (authError) return authError;
+
+  const { supabase, user } = auth;
+
+  const { data, error } = await supabase
+    .from("api_keys")
+    .select("id, key_prefix, name, created_at, last_used_at, revoked_at")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+
+  if (error) return errorResponse(error.message, 500);
+
+  return successResponse(data);
+}
+
+/**
+ * POST /api/api-keys — Generate a new API key.
+ * Body: { name?: string }
+ * Returns: { id, key, key_prefix, name } where `key` is the raw key (shown once).
+ */
+export async function POST(request: NextRequest) {
+  const { data: auth, error: authError } = await getAuthenticatedUser();
+  if (authError) return authError;
+
+  const { supabase, user } = auth;
+
+  const body = (await request.json()) as { name?: string };
+  const name = (body.name ?? "").trim() || "Untitled key";
+
+  // Generate a random API key: "dk_" prefix + 48 random hex chars
+  const randomBytes = new Uint8Array(24);
+  crypto.getRandomValues(randomBytes);
+  const randomHex = Array.from(randomBytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const rawKey = `dk_${randomHex}`;
+  const keyPrefix = rawKey.slice(0, 8);
+
+  // Hash the key
+  const encoder = new TextEncoder();
+  const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(rawKey));
+  const keyHash = Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  const { data, error } = await supabase
+    .from("api_keys")
+    .insert({ user_id: user.id, key_prefix: keyPrefix, key_hash: keyHash, name })
+    .select("id, key_prefix, name")
+    .single();
+
+  if (error) return errorResponse(error.message, 500);
+
+  // Return the raw key — it can only be seen this once
+  return NextResponse.json({ ...data, key: rawKey }, { status: 201 });
+}

--- a/apps/web/src/app/api/mcp/route.ts
+++ b/apps/web/src/app/api/mcp/route.ts
@@ -1,0 +1,389 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { z } from "zod";
+import { authenticateMcpRequest } from "@/lib/api/mcp-auth";
+import { blockNoteToMarkdown, markdownToBlockNote, contentToBlocknote } from "@drafto/shared";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "@/lib/supabase/database.types";
+
+function createMcpServer(supabase: SupabaseClient<Database>, userId: string): McpServer {
+  const server = new McpServer(
+    { name: "drafto", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  // --- list_notebooks ---
+  server.tool("list_notebooks", "List all notebooks for the current user", {}, async () => {
+    const { data, error } = await supabase
+      .from("notebooks")
+      .select("id, name, created_at, updated_at")
+      .eq("user_id", userId)
+      .order("name");
+
+    if (error)
+      return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(data, null, 2),
+        },
+      ],
+    };
+  });
+
+  // --- list_notes ---
+  server.tool(
+    "list_notes",
+    "List notes in a notebook (non-trashed, ordered by last updated)",
+    { notebook_id: z.string().uuid().describe("The notebook ID to list notes from") },
+    async ({ notebook_id }) => {
+      const { data, error } = await supabase
+        .from("notes")
+        .select("id, title, created_at, updated_at")
+        .eq("notebook_id", notebook_id)
+        .eq("user_id", userId)
+        .eq("is_trashed", false)
+        .order("updated_at", { ascending: false });
+
+      if (error)
+        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(data, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // --- read_note ---
+  server.tool(
+    "read_note",
+    "Read a note's full content as Markdown",
+    { note_id: z.string().uuid().describe("The note ID to read") },
+    async ({ note_id }) => {
+      const { data: note, error } = await supabase
+        .from("notes")
+        .select("id, title, content, notebook_id, is_trashed, created_at, updated_at")
+        .eq("id", note_id)
+        .eq("user_id", userId)
+        .single();
+
+      if (error || !note) {
+        return { content: [{ type: "text", text: "Error: Note not found" }], isError: true };
+      }
+
+      // Get notebook name
+      const { data: notebook } = await supabase
+        .from("notebooks")
+        .select("name")
+        .eq("id", note.notebook_id)
+        .single();
+
+      // Convert content to Markdown
+      const blocks = contentToBlocknote(note.content);
+      const contentMarkdown = blockNoteToMarkdown(blocks);
+
+      const header = [
+        `# ${note.title}`,
+        ``,
+        `- **Notebook**: ${notebook?.name ?? "Unknown"}`,
+        `- **Created**: ${note.created_at}`,
+        `- **Updated**: ${note.updated_at}`,
+        `- **Trashed**: ${note.is_trashed ? "Yes" : "No"}`,
+        ``,
+        `---`,
+        ``,
+      ].join("\n");
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: header + contentMarkdown,
+          },
+        ],
+      };
+    },
+  );
+
+  // --- search_notes ---
+  server.tool(
+    "search_notes",
+    "Full-text search across all notes (titles, content, and notebook names)",
+    { query: z.string().min(1).max(200).describe("Search query") },
+    async ({ query }) => {
+      const { data, error } = await supabase.rpc(
+        "search_notes" as never,
+        {
+          search_query: query,
+          requesting_user_id: userId,
+        } as never,
+      );
+
+      if (error)
+        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(data, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // --- create_notebook ---
+  server.tool(
+    "create_notebook",
+    "Create a new notebook",
+    { name: z.string().min(1).max(100).describe("Notebook name") },
+    async ({ name }) => {
+      const { data, error } = await supabase
+        .from("notebooks")
+        .insert({ user_id: userId, name: name.trim() })
+        .select("id, name")
+        .single();
+
+      if (error)
+        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(data, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // --- create_note ---
+  server.tool(
+    "create_note",
+    "Create a new note in a notebook with optional Markdown content",
+    {
+      notebook_id: z.string().uuid().describe("The notebook ID to create the note in"),
+      title: z.string().min(1).max(255).describe("Note title"),
+      content_markdown: z.string().optional().describe("Note content in Markdown format"),
+    },
+    async ({ notebook_id, title, content_markdown }) => {
+      // Verify notebook ownership
+      const { data: notebook, error: nbError } = await supabase
+        .from("notebooks")
+        .select("id")
+        .eq("id", notebook_id)
+        .eq("user_id", userId)
+        .single();
+
+      if (nbError || !notebook) {
+        return { content: [{ type: "text", text: "Error: Notebook not found" }], isError: true };
+      }
+
+      const content = content_markdown
+        ? (markdownToBlockNote(content_markdown) as unknown as Json)
+        : null;
+
+      const { data: note, error } = await supabase
+        .from("notes")
+        .insert({
+          notebook_id,
+          user_id: userId,
+          title: title.trim(),
+          content,
+        })
+        .select("id, title")
+        .single();
+
+      if (error)
+        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(note, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // --- update_note ---
+  server.tool(
+    "update_note",
+    "Update a note's title and/or content (provide Markdown for content)",
+    {
+      note_id: z.string().uuid().describe("The note ID to update"),
+      title: z.string().min(1).max(255).optional().describe("New title"),
+      content_markdown: z.string().optional().describe("New content in Markdown format"),
+    },
+    async ({ note_id, title, content_markdown }) => {
+      const update: Record<string, unknown> = {};
+      if (title !== undefined) update.title = title.trim();
+      if (content_markdown !== undefined)
+        update.content = markdownToBlockNote(content_markdown) as unknown as Json;
+
+      if (Object.keys(update).length === 0) {
+        return { content: [{ type: "text", text: "Error: No fields to update" }], isError: true };
+      }
+
+      const { data, error } = await supabase
+        .from("notes")
+        .update(update)
+        .eq("id", note_id)
+        .eq("user_id", userId)
+        .select("id, title, updated_at")
+        .single();
+
+      if (error)
+        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(data, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // --- move_note ---
+  server.tool(
+    "move_note",
+    "Move a note to a different notebook",
+    {
+      note_id: z.string().uuid().describe("The note ID to move"),
+      notebook_id: z.string().uuid().describe("The target notebook ID"),
+    },
+    async ({ note_id, notebook_id }) => {
+      // Verify target notebook ownership
+      const { data: notebook, error: nbError } = await supabase
+        .from("notebooks")
+        .select("id")
+        .eq("id", notebook_id)
+        .eq("user_id", userId)
+        .single();
+
+      if (nbError || !notebook) {
+        return {
+          content: [{ type: "text", text: "Error: Target notebook not found" }],
+          isError: true,
+        };
+      }
+
+      const { data, error } = await supabase
+        .from("notes")
+        .update({ notebook_id })
+        .eq("id", note_id)
+        .eq("user_id", userId)
+        .select("id, title, notebook_id")
+        .single();
+
+      if (error)
+        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(data, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // --- trash_note ---
+  server.tool(
+    "trash_note",
+    "Move a note to trash (soft-delete, recoverable for 30 days)",
+    { note_id: z.string().uuid().describe("The note ID to trash") },
+    async ({ note_id }) => {
+      const { data, error } = await supabase
+        .from("notes")
+        .update({ is_trashed: true, trashed_at: new Date().toISOString() })
+        .eq("id", note_id)
+        .eq("user_id", userId)
+        .select("id, title")
+        .single();
+
+      if (error)
+        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Note "${data.title}" moved to trash.`,
+          },
+        ],
+      };
+    },
+  );
+
+  return server;
+}
+
+export async function POST(request: Request): Promise<Response> {
+  // Authenticate via API key
+  let supabase: SupabaseClient<Database>;
+  let userId: string;
+
+  try {
+    const auth = await authenticateMcpRequest(request.headers.get("authorization"));
+    supabase = auth.supabase;
+    userId = auth.userId;
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: (err as Error).message },
+        id: null,
+      }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // Create stateless MCP transport (no session persistence needed for serverless)
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // stateless
+    enableJsonResponse: true, // simpler for serverless — no SSE needed
+  });
+
+  const server = createMcpServer(supabase, userId);
+  await server.connect(transport);
+
+  try {
+    return await transport.handleRequest(request);
+  } finally {
+    await server.close();
+    await transport.close();
+  }
+}
+
+// MCP requires GET for SSE streams — return method not allowed in stateless mode
+export async function GET(): Promise<Response> {
+  return new Response(JSON.stringify({ error: "Method not allowed. Use POST for MCP requests." }), {
+    status: 405,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// MCP DELETE for session termination — not needed in stateless mode
+export async function DELETE(): Promise<Response> {
+  return new Response(JSON.stringify({ error: "Method not allowed. Stateless server." }), {
+    status: 405,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/apps/web/src/app/api/mcp/route.ts
+++ b/apps/web/src/app/api/mcp/route.ts
@@ -2,9 +2,19 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { z } from "zod";
 import { authenticateMcpRequest } from "@/lib/api/mcp-auth";
-import { blockNoteToMarkdown, markdownToBlockNote, contentToBlocknote } from "@drafto/shared";
+import {
+  listNotebooks,
+  listNotes,
+  readNote,
+  searchNotes,
+  createNotebook,
+  createNote,
+  updateNote,
+  moveNote,
+  trashNote,
+} from "@/lib/api/mcp-tools";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database, Json } from "@/lib/supabase/database.types";
+import type { Database } from "@/lib/supabase/database.types";
 
 function createMcpServer(supabase: SupabaseClient<Database>, userId: string): McpServer {
   const server = new McpServer(
@@ -12,161 +22,38 @@ function createMcpServer(supabase: SupabaseClient<Database>, userId: string): Mc
     { capabilities: { tools: {} } },
   );
 
-  // --- list_notebooks ---
-  server.tool("list_notebooks", "List all notebooks for the current user", {}, async () => {
-    const { data, error } = await supabase
-      .from("notebooks")
-      .select("id, name, created_at, updated_at")
-      .eq("user_id", userId)
-      .order("name");
+  server.tool("list_notebooks", "List all notebooks for the current user", {}, () =>
+    listNotebooks(supabase, userId),
+  );
 
-    if (error)
-      return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(data, null, 2),
-        },
-      ],
-    };
-  });
-
-  // --- list_notes ---
   server.tool(
     "list_notes",
     "List notes in a notebook (non-trashed, ordered by last updated)",
     { notebook_id: z.string().uuid().describe("The notebook ID to list notes from") },
-    async ({ notebook_id }) => {
-      const { data, error } = await supabase
-        .from("notes")
-        .select("id, title, created_at, updated_at")
-        .eq("notebook_id", notebook_id)
-        .eq("user_id", userId)
-        .eq("is_trashed", false)
-        .order("updated_at", { ascending: false });
-
-      if (error)
-        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(data, null, 2),
-          },
-        ],
-      };
-    },
+    ({ notebook_id }) => listNotes(supabase, userId, notebook_id),
   );
 
-  // --- read_note ---
   server.tool(
     "read_note",
     "Read a note's full content as Markdown",
     { note_id: z.string().uuid().describe("The note ID to read") },
-    async ({ note_id }) => {
-      const { data: note, error } = await supabase
-        .from("notes")
-        .select("id, title, content, notebook_id, is_trashed, created_at, updated_at")
-        .eq("id", note_id)
-        .eq("user_id", userId)
-        .single();
-
-      if (error || !note) {
-        return { content: [{ type: "text", text: "Error: Note not found" }], isError: true };
-      }
-
-      // Get notebook name
-      const { data: notebook } = await supabase
-        .from("notebooks")
-        .select("name")
-        .eq("id", note.notebook_id)
-        .single();
-
-      // Convert content to Markdown
-      const blocks = contentToBlocknote(note.content);
-      const contentMarkdown = blockNoteToMarkdown(blocks);
-
-      const header = [
-        `# ${note.title}`,
-        ``,
-        `- **Notebook**: ${notebook?.name ?? "Unknown"}`,
-        `- **Created**: ${note.created_at}`,
-        `- **Updated**: ${note.updated_at}`,
-        `- **Trashed**: ${note.is_trashed ? "Yes" : "No"}`,
-        ``,
-        `---`,
-        ``,
-      ].join("\n");
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: header + contentMarkdown,
-          },
-        ],
-      };
-    },
+    ({ note_id }) => readNote(supabase, userId, note_id),
   );
 
-  // --- search_notes ---
   server.tool(
     "search_notes",
     "Full-text search across all notes (titles, content, and notebook names)",
     { query: z.string().min(1).max(200).describe("Search query") },
-    async ({ query }) => {
-      const { data, error } = await supabase.rpc(
-        "search_notes" as never,
-        {
-          search_query: query,
-          requesting_user_id: userId,
-        } as never,
-      );
-
-      if (error)
-        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(data, null, 2),
-          },
-        ],
-      };
-    },
+    ({ query }) => searchNotes(supabase, userId, query),
   );
 
-  // --- create_notebook ---
   server.tool(
     "create_notebook",
     "Create a new notebook",
     { name: z.string().min(1).max(100).describe("Notebook name") },
-    async ({ name }) => {
-      const { data, error } = await supabase
-        .from("notebooks")
-        .insert({ user_id: userId, name: name.trim() })
-        .select("id, name")
-        .single();
-
-      if (error)
-        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(data, null, 2),
-          },
-        ],
-      };
-    },
+    ({ name }) => createNotebook(supabase, userId, name),
   );
 
-  // --- create_note ---
   server.tool(
     "create_note",
     "Create a new note in a notebook with optional Markdown content",
@@ -175,49 +62,10 @@ function createMcpServer(supabase: SupabaseClient<Database>, userId: string): Mc
       title: z.string().min(1).max(255).describe("Note title"),
       content_markdown: z.string().optional().describe("Note content in Markdown format"),
     },
-    async ({ notebook_id, title, content_markdown }) => {
-      // Verify notebook ownership
-      const { data: notebook, error: nbError } = await supabase
-        .from("notebooks")
-        .select("id")
-        .eq("id", notebook_id)
-        .eq("user_id", userId)
-        .single();
-
-      if (nbError || !notebook) {
-        return { content: [{ type: "text", text: "Error: Notebook not found" }], isError: true };
-      }
-
-      const content = content_markdown
-        ? (markdownToBlockNote(content_markdown) as unknown as Json)
-        : null;
-
-      const { data: note, error } = await supabase
-        .from("notes")
-        .insert({
-          notebook_id,
-          user_id: userId,
-          title: title.trim(),
-          content,
-        })
-        .select("id, title")
-        .single();
-
-      if (error)
-        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(note, null, 2),
-          },
-        ],
-      };
-    },
+    ({ notebook_id, title, content_markdown }) =>
+      createNote(supabase, userId, notebook_id, title, content_markdown),
   );
 
-  // --- update_note ---
   server.tool(
     "update_note",
     "Update a note's title and/or content (provide Markdown for content)",
@@ -226,39 +74,10 @@ function createMcpServer(supabase: SupabaseClient<Database>, userId: string): Mc
       title: z.string().min(1).max(255).optional().describe("New title"),
       content_markdown: z.string().optional().describe("New content in Markdown format"),
     },
-    async ({ note_id, title, content_markdown }) => {
-      const update: Record<string, unknown> = {};
-      if (title !== undefined) update.title = title.trim();
-      if (content_markdown !== undefined)
-        update.content = markdownToBlockNote(content_markdown) as unknown as Json;
-
-      if (Object.keys(update).length === 0) {
-        return { content: [{ type: "text", text: "Error: No fields to update" }], isError: true };
-      }
-
-      const { data, error } = await supabase
-        .from("notes")
-        .update(update)
-        .eq("id", note_id)
-        .eq("user_id", userId)
-        .select("id, title, updated_at")
-        .single();
-
-      if (error)
-        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(data, null, 2),
-          },
-        ],
-      };
-    },
+    ({ note_id, title, content_markdown }) =>
+      updateNote(supabase, userId, note_id, title, content_markdown),
   );
 
-  // --- move_note ---
   server.tool(
     "move_note",
     "Move a note to a different notebook",
@@ -266,77 +85,20 @@ function createMcpServer(supabase: SupabaseClient<Database>, userId: string): Mc
       note_id: z.string().uuid().describe("The note ID to move"),
       notebook_id: z.string().uuid().describe("The target notebook ID"),
     },
-    async ({ note_id, notebook_id }) => {
-      // Verify target notebook ownership
-      const { data: notebook, error: nbError } = await supabase
-        .from("notebooks")
-        .select("id")
-        .eq("id", notebook_id)
-        .eq("user_id", userId)
-        .single();
-
-      if (nbError || !notebook) {
-        return {
-          content: [{ type: "text", text: "Error: Target notebook not found" }],
-          isError: true,
-        };
-      }
-
-      const { data, error } = await supabase
-        .from("notes")
-        .update({ notebook_id })
-        .eq("id", note_id)
-        .eq("user_id", userId)
-        .select("id, title, notebook_id")
-        .single();
-
-      if (error)
-        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(data, null, 2),
-          },
-        ],
-      };
-    },
+    ({ note_id, notebook_id }) => moveNote(supabase, userId, note_id, notebook_id),
   );
 
-  // --- trash_note ---
   server.tool(
     "trash_note",
     "Move a note to trash (soft-delete, recoverable for 30 days)",
     { note_id: z.string().uuid().describe("The note ID to trash") },
-    async ({ note_id }) => {
-      const { data, error } = await supabase
-        .from("notes")
-        .update({ is_trashed: true, trashed_at: new Date().toISOString() })
-        .eq("id", note_id)
-        .eq("user_id", userId)
-        .select("id, title")
-        .single();
-
-      if (error)
-        return { content: [{ type: "text", text: `Error: ${error.message}` }], isError: true };
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Note "${data.title}" moved to trash.`,
-          },
-        ],
-      };
-    },
+    ({ note_id }) => trashNote(supabase, userId, note_id),
   );
 
   return server;
 }
 
 export async function POST(request: Request): Promise<Response> {
-  // Authenticate via API key
   let supabase: SupabaseClient<Database>;
   let userId: string;
 
@@ -355,10 +117,9 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // Create stateless MCP transport (no session persistence needed for serverless)
   const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: undefined, // stateless
-    enableJsonResponse: true, // simpler for serverless — no SSE needed
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
   });
 
   const server = createMcpServer(supabase, userId);
@@ -372,7 +133,6 @@ export async function POST(request: Request): Promise<Response> {
   }
 }
 
-// MCP requires GET for SSE streams — return method not allowed in stateless mode
 export async function GET(): Promise<Response> {
   return new Response(JSON.stringify({ error: "Method not allowed. Use POST for MCP requests." }), {
     status: 405,
@@ -380,7 +140,6 @@ export async function GET(): Promise<Response> {
   });
 }
 
-// MCP DELETE for session termination — not needed in stateless mode
 export async function DELETE(): Promise<Response> {
   return new Response(JSON.stringify({ error: "Method not allowed. Stateless server." }), {
     status: 405,

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardHeader, CardBody } from "@/components/ui/card";
+
+interface ApiKey {
+  id: string;
+  key_prefix: string;
+  name: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+export default function SettingsPage() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [newKeyName, setNewKeyName] = useState("");
+  const [revealedKey, setRevealedKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const hasFetched = useRef(false);
+
+  async function fetchKeys() {
+    const res = await fetch("/api/api-keys");
+    if (res.ok) {
+      const data = await res.json();
+      setKeys(data);
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    if (hasFetched.current) return;
+    hasFetched.current = true;
+    fetchKeys();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setError(null);
+    setRevealedKey(null);
+
+    const res = await fetch("/api/api-keys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newKeyName }),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      setRevealedKey(data.key);
+      setNewKeyName("");
+      await fetchKeys();
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to create key");
+    }
+    setCreating(false);
+  };
+
+  const handleRevoke = async (id: string) => {
+    const res = await fetch(`/api/api-keys/${id}`, { method: "DELETE" });
+    if (res.ok) {
+      await fetchKeys();
+    }
+  };
+
+  const activeKeys = keys.filter((k) => !k.revoked_at);
+
+  return (
+    <div className="mx-auto max-w-2xl p-8">
+      <h1 className="text-fg mb-2 text-2xl font-bold">Settings</h1>
+      <p className="text-fg-muted mb-8 text-sm">
+        Manage API keys for MCP integrations like Claude Cowork.
+      </p>
+
+      <Card>
+        <CardHeader>
+          <h2 className="text-fg text-lg font-semibold">API Keys</h2>
+          <p className="text-fg-muted text-sm">
+            Generate keys to connect Drafto with Claude Desktop, Claude Cowork, or other MCP
+            clients.
+          </p>
+        </CardHeader>
+        <CardBody>
+          {/* Create new key */}
+          <div className="mb-6 flex gap-2">
+            <Input
+              value={newKeyName}
+              onChange={(e) => setNewKeyName(e.target.value)}
+              placeholder="Key name (e.g. Claude Desktop)"
+              inputSize="sm"
+              className="flex-1"
+            />
+            <Button size="sm" onClick={handleCreate} loading={creating} disabled={creating}>
+              Generate key
+            </Button>
+          </div>
+
+          {/* Revealed key (shown once) */}
+          {revealedKey && (
+            <div className="bg-success-bg border-success mb-6 rounded-md border p-4">
+              <p className="text-fg mb-1 text-sm font-medium">
+                Your new API key (copy it now — it will not be shown again):
+              </p>
+              <code className="text-fg bg-bg-muted block rounded px-2 py-1 font-mono text-sm break-all">
+                {revealedKey}
+              </code>
+              <Button
+                size="sm"
+                variant="secondary"
+                className="mt-2"
+                onClick={() => {
+                  navigator.clipboard.writeText(revealedKey);
+                }}
+              >
+                Copy to clipboard
+              </Button>
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-error-bg text-error mb-4 rounded-md p-3 text-sm">{error}</div>
+          )}
+
+          {/* Key list */}
+          {loading ? (
+            <p className="text-fg-muted text-sm">Loading...</p>
+          ) : activeKeys.length === 0 ? (
+            <p className="text-fg-muted text-sm">No API keys yet. Generate one to get started.</p>
+          ) : (
+            <ul className="divide-border divide-y">
+              {activeKeys.map((key) => (
+                <li key={key.id} className="flex items-center justify-between py-3">
+                  <div>
+                    <p className="text-fg text-sm font-medium">{key.name}</p>
+                    <p className="text-fg-subtle text-xs">
+                      <code>{key.key_prefix}...</code>
+                      {" · "}
+                      Created {new Date(key.created_at).toLocaleDateString()}
+                      {key.last_used_at && (
+                        <>
+                          {" · "}
+                          Last used {new Date(key.last_used_at).toLocaleDateString()}
+                        </>
+                      )}
+                    </p>
+                  </div>
+                  <Button size="sm" variant="danger" onClick={() => handleRevoke(key.id)}>
+                    Revoke
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardBody>
+      </Card>
+
+      {/* MCP connection info */}
+      <Card className="mt-6">
+        <CardHeader>
+          <h2 className="text-fg text-lg font-semibold">Connect to Claude</h2>
+        </CardHeader>
+        <CardBody>
+          <p className="text-fg-muted mb-3 text-sm">
+            Add this remote MCP server to Claude Desktop or Claude Cowork:
+          </p>
+          <code className="text-fg bg-bg-muted block overflow-x-auto rounded-md p-3 font-mono text-sm">
+            {JSON.stringify(
+              {
+                mcpServers: {
+                  drafto: {
+                    url: `${typeof window !== "undefined" ? window.location.origin : "https://drafto.eu"}/api/mcp`,
+                    headers: {
+                      Authorization: "Bearer YOUR_API_KEY",
+                    },
+                  },
+                },
+              },
+              null,
+              2,
+            )}
+          </code>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/app-menu.tsx
+++ b/apps/web/src/components/layout/app-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { IconButton } from "@/components/ui/icon-button";
 import {
@@ -36,6 +37,7 @@ function EllipsisIcon() {
 export function AppMenu({ onImportEvernote }: AppMenuProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
 
   const handleLogout = async () => {
     const supabase = createClient();
@@ -71,6 +73,15 @@ export function AppMenu({ onImportEvernote }: AppMenuProps) {
           data-testid="import-evernote-button"
         >
           Import from Evernote
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => {
+            setOpen(false);
+            router.push("/settings");
+          }}
+          data-testid="settings-button"
+        >
+          Settings
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem variant="danger" onClick={handleLogout} data-testid="logout-button">

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -5,6 +5,7 @@ export const env = createEnv({
   server: {
     SENTRY_AUTH_TOKEN: z.string().optional(),
     CRON_SECRET: z.string().optional(),
+    SUPABASE_SERVICE_ROLE_KEY: z.string().min(1).optional(),
   },
   client: {
     NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
@@ -17,6 +18,7 @@ export const env = createEnv({
   },
   runtimeEnv: {
     CRON_SECRET: process.env.CRON_SECRET,
+    SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
     SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
     NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/apps/web/src/lib/api/mcp-auth.ts
+++ b/apps/web/src/lib/api/mcp-auth.ts
@@ -1,0 +1,87 @@
+import { createClient } from "@supabase/supabase-js";
+import { env } from "@/env";
+import type { Database } from "@/lib/supabase/database.types";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+interface McpAuthResult {
+  userId: string;
+  supabase: SupabaseClient<Database>;
+}
+
+/**
+ * Authenticate an MCP request via Bearer token (API key).
+ * Returns an authenticated Supabase client scoped to the key's owner,
+ * or throws an error string if authentication fails.
+ */
+export async function authenticateMcpRequest(authHeader: string | null): Promise<McpAuthResult> {
+  if (!authHeader?.startsWith("Bearer ")) {
+    throw new Error("Missing or invalid Authorization header");
+  }
+
+  const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceRoleKey) {
+    throw new Error("MCP server not configured");
+  }
+
+  const apiKey = authHeader.slice(7);
+  if (!apiKey) {
+    throw new Error("Empty API key");
+  }
+
+  // Hash the provided key
+  const encoder = new TextEncoder();
+  const data = encoder.encode(apiKey);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const keyHash = Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  // Use service role client to look up the key (bypasses RLS)
+  const adminClient = createClient<Database>(env.NEXT_PUBLIC_SUPABASE_URL, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Look up key by hash
+  const { data: keyRow, error: keyError } = await adminClient
+    .from("api_keys")
+    .select("id, user_id, revoked_at")
+    .eq("key_hash", keyHash)
+    .single();
+
+  if (keyError || !keyRow) {
+    throw new Error("Invalid API key");
+  }
+
+  if (keyRow.revoked_at) {
+    throw new Error("API key has been revoked");
+  }
+
+  // Verify user is approved
+  const { data: profile, error: profileError } = await adminClient
+    .from("profiles")
+    .select("is_approved")
+    .eq("id", keyRow.user_id)
+    .single();
+
+  if (profileError || !profile?.is_approved) {
+    throw new Error("User account is not approved");
+  }
+
+  // Update last_used_at (fire-and-forget)
+  adminClient
+    .from("api_keys")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("id", keyRow.id)
+    .then(() => {});
+
+  // Create a client that impersonates the user via RLS
+  // We use the service role client for data access since API key auth
+  // doesn't have a Supabase session. RLS is handled by filtering on user_id.
+  // To properly scope queries, we'll pass the userId and use it in queries.
+  // However, for simplicity and RLS compliance, we use the admin client
+  // with explicit user_id filtering in each tool handler.
+  return {
+    userId: keyRow.user_id,
+    supabase: adminClient,
+  };
+}

--- a/apps/web/src/lib/api/mcp-tools.ts
+++ b/apps/web/src/lib/api/mcp-tools.ts
@@ -1,0 +1,218 @@
+import { blockNoteToMarkdown, markdownToBlockNote, contentToBlocknote } from "@drafto/shared";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "@/lib/supabase/database.types";
+
+interface ToolResult {
+  [key: string]: unknown;
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}
+
+function ok(text: string): ToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function err(text: string): ToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+export async function listNotebooks(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<ToolResult> {
+  const { data, error } = await supabase
+    .from("notebooks")
+    .select("id, name, created_at, updated_at")
+    .eq("user_id", userId)
+    .order("name");
+
+  if (error) return err(`Error: ${error.message}`);
+  return ok(JSON.stringify(data, null, 2));
+}
+
+export async function listNotes(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  notebookId: string,
+): Promise<ToolResult> {
+  const { data, error } = await supabase
+    .from("notes")
+    .select("id, title, created_at, updated_at")
+    .eq("notebook_id", notebookId)
+    .eq("user_id", userId)
+    .eq("is_trashed", false)
+    .order("updated_at", { ascending: false });
+
+  if (error) return err(`Error: ${error.message}`);
+  return ok(JSON.stringify(data, null, 2));
+}
+
+export async function readNote(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  noteId: string,
+): Promise<ToolResult> {
+  const { data: note, error } = await supabase
+    .from("notes")
+    .select("id, title, content, notebook_id, is_trashed, created_at, updated_at")
+    .eq("id", noteId)
+    .eq("user_id", userId)
+    .single();
+
+  if (error || !note) return err("Error: Note not found");
+
+  const { data: notebook } = await supabase
+    .from("notebooks")
+    .select("name")
+    .eq("id", note.notebook_id)
+    .single();
+
+  const blocks = contentToBlocknote(note.content);
+  const contentMarkdown = blockNoteToMarkdown(blocks);
+
+  const header = [
+    `# ${note.title}`,
+    ``,
+    `- **Notebook**: ${notebook?.name ?? "Unknown"}`,
+    `- **Created**: ${note.created_at}`,
+    `- **Updated**: ${note.updated_at}`,
+    `- **Trashed**: ${note.is_trashed ? "Yes" : "No"}`,
+    ``,
+    `---`,
+    ``,
+  ].join("\n");
+
+  return ok(header + contentMarkdown);
+}
+
+export async function searchNotes(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  query: string,
+): Promise<ToolResult> {
+  const { data, error } = await supabase.rpc(
+    "search_notes" as never,
+    {
+      search_query: query,
+      requesting_user_id: userId,
+    } as never,
+  );
+
+  if (error) return err(`Error: ${error.message}`);
+  return ok(JSON.stringify(data, null, 2));
+}
+
+export async function createNotebook(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  name: string,
+): Promise<ToolResult> {
+  const { data, error } = await supabase
+    .from("notebooks")
+    .insert({ user_id: userId, name: name.trim() })
+    .select("id, name")
+    .single();
+
+  if (error) return err(`Error: ${error.message}`);
+  return ok(JSON.stringify(data, null, 2));
+}
+
+export async function createNote(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  notebookId: string,
+  title: string,
+  contentMarkdown?: string,
+): Promise<ToolResult> {
+  const { data: notebook, error: nbError } = await supabase
+    .from("notebooks")
+    .select("id")
+    .eq("id", notebookId)
+    .eq("user_id", userId)
+    .single();
+
+  if (nbError || !notebook) return err("Error: Notebook not found");
+
+  const content = contentMarkdown
+    ? (markdownToBlockNote(contentMarkdown) as unknown as Json)
+    : null;
+
+  const { data: note, error } = await supabase
+    .from("notes")
+    .insert({ notebook_id: notebookId, user_id: userId, title: title.trim(), content })
+    .select("id, title")
+    .single();
+
+  if (error) return err(`Error: ${error.message}`);
+  return ok(JSON.stringify(note, null, 2));
+}
+
+export async function updateNote(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  noteId: string,
+  title?: string,
+  contentMarkdown?: string,
+): Promise<ToolResult> {
+  const update: Record<string, unknown> = {};
+  if (title !== undefined) update.title = title.trim();
+  if (contentMarkdown !== undefined)
+    update.content = markdownToBlockNote(contentMarkdown) as unknown as Json;
+
+  if (Object.keys(update).length === 0) return err("Error: No fields to update");
+
+  const { data, error } = await supabase
+    .from("notes")
+    .update(update)
+    .eq("id", noteId)
+    .eq("user_id", userId)
+    .select("id, title, updated_at")
+    .single();
+
+  if (error) return err(`Error: ${error.message}`);
+  return ok(JSON.stringify(data, null, 2));
+}
+
+export async function moveNote(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  noteId: string,
+  notebookId: string,
+): Promise<ToolResult> {
+  const { data: notebook, error: nbError } = await supabase
+    .from("notebooks")
+    .select("id")
+    .eq("id", notebookId)
+    .eq("user_id", userId)
+    .single();
+
+  if (nbError || !notebook) return err("Error: Target notebook not found");
+
+  const { data, error } = await supabase
+    .from("notes")
+    .update({ notebook_id: notebookId })
+    .eq("id", noteId)
+    .eq("user_id", userId)
+    .select("id, title, notebook_id")
+    .single();
+
+  if (error) return err(`Error: ${error.message}`);
+  return ok(JSON.stringify(data, null, 2));
+}
+
+export async function trashNote(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  noteId: string,
+): Promise<ToolResult> {
+  const { data, error } = await supabase
+    .from("notes")
+    .update({ is_trashed: true, trashed_at: new Date().toISOString() })
+    .eq("id", noteId)
+    .eq("user_id", userId)
+    .select("id, title")
+    .single();
+
+  if (error) return err(`Error: ${error.message}`);
+  return ok(`Note "${data.title}" moved to trash.`);
+}

--- a/apps/web/src/lib/api/mcp-tools.ts
+++ b/apps/web/src/lib/api/mcp-tools.ts
@@ -90,13 +90,16 @@ export async function searchNotes(
   userId: string,
   query: string,
 ): Promise<ToolResult> {
-  const { data, error } = await supabase.rpc(
-    "search_notes" as never,
-    {
-      search_query: query,
-      requesting_user_id: userId,
-    } as never,
-  );
+  // Direct query instead of RPC — the search_notes RPC uses auth.uid() which
+  // is not set for service-role clients. We do a simple ilike search instead.
+  const pattern = `%${query}%`;
+  const { data, error } = await supabase
+    .from("notes")
+    .select("id, title, notebook_id, is_trashed, updated_at")
+    .eq("user_id", userId)
+    .ilike("title", pattern)
+    .order("updated_at", { ascending: false })
+    .limit(50);
 
   if (error) return err(`Error: ${error.message}`);
   return ok(JSON.stringify(data, null, 2));

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -10,6 +10,7 @@ const PUBLIC_ROUTES = [
   "/forgot-password",
   "/reset-password",
   "/api/health",
+  "/api/mcp",
 ];
 
 function isPublicRoute(pathname: string): boolean {

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -18,6 +18,13 @@ function isPublicRoute(pathname: string): boolean {
 }
 
 export async function updateSession(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Fast-path: MCP uses Bearer token auth, skip Supabase session lookup
+  if (pathname === "/api/mcp" || pathname.startsWith("/api/mcp/")) {
+    return NextResponse.next({ request });
+  }
+
   let supabaseResponse = NextResponse.next({
     request,
   });
@@ -48,8 +55,6 @@ export async function updateSession(request: NextRequest) {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-
-  const { pathname } = request.nextUrl;
 
   // Public routes: allow access regardless of auth state
   if (isPublicRoute(pathname)) {

--- a/docs/adr/0017-mcp-server-for-claude-cowork.md
+++ b/docs/adr/0017-mcp-server-for-claude-cowork.md
@@ -1,0 +1,43 @@
+# 0017 — MCP Server for Claude Cowork Integration
+
+- **Status**: Accepted
+- **Date**: 2026-04-11
+- **Authors**: Jakub
+
+## Context
+
+Claude Cowork (Anthropic's agentic AI tool) supports connecting to third-party apps via Remote MCP (Model Context Protocol) servers. Making Drafto's notes accessible from Claude Cowork enables AI-assisted note-taking workflows — Claude can read, search, create, and update notes directly.
+
+The integration needs to authenticate users securely, respect existing RLS policies, and fit into the Vercel serverless deployment model.
+
+## Decision
+
+Build a remote MCP server as a Next.js API route at `/api/mcp` within the existing `apps/web/` application. Authentication uses API keys (hashed with SHA-256, stored in a new `api_keys` table). The MCP transport uses stateless Streamable HTTP with JSON responses (no SSE).
+
+Key design choices:
+
+- **Hosted in existing app**: Shares Supabase config, env vars, and Vercel deployment — no new infrastructure
+- **API key auth**: Users generate keys from a settings page; simpler than full OAuth 2.1 while still secure
+- **Service role client**: Used for API key lookup, with explicit `user_id` filtering in all queries
+- **Stateless transport**: Each request is independent — fits Vercel serverless functions perfectly
+- **Markdown conversion**: BlockNote JSONB content is converted to/from Markdown for Claude to read and write
+
+Nine MCP tools are exposed: list_notebooks, list_notes, read_note, search_notes, create_notebook, create_note, update_note, move_note, trash_note. Permanent delete and attachment upload are intentionally excluded.
+
+## Consequences
+
+- **Positive**: Drafto notes are accessible from Claude Desktop, Claude Cowork, claude.ai, and any MCP client. No new infrastructure to maintain.
+- **Positive**: API key auth is simple for users — generate a key, paste it into Claude settings, done.
+- **Negative**: API keys are long-lived and don't auto-expire. Mitigation: revocation UI, `last_used_at` tracking.
+- **Negative**: Service role key required in production environment variables. Mitigation: only used server-side for key lookup, validated via t3-env.
+- **Neutral**: Markdown conversion is lossy for complex formatting (e.g., nested tables, image dimensions) but sufficient for AI interaction.
+
+## Alternatives Considered
+
+1. **Full OAuth 2.1**: Would require authorization server endpoints (`/authorize`, `/token`, PKCE, consent screens). Too much engineering for a personal/small-team app. Could be added later if needed.
+
+2. **Separate MCP service** (`apps/mcp/`): Would require its own Vercel project, duplicate Supabase config, and separate deployment. Unnecessary complexity when a single API route suffices.
+
+3. **Local MCP server only**: Would limit usage to Claude Desktop on the user's machine. Remote MCP works across all Claude clients.
+
+4. **Supabase access tokens as auth**: Tokens expire and require refresh management. API keys are simpler for machine-to-machine auth.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,3 +49,4 @@ Every ADR follows the template in [0000-adr-template.md](./0000-adr-template.md)
 | [0014](./0014-digital-atelier-design-system.md)     | Digital Atelier Design System            | Accepted           | 2026-03-19 |
 | [0015](./0015-desktop-app-technology-choice.md)     | Desktop App Technology Choice            | Accepted           | 2026-03-29 |
 | [0016](./0016-local-fastlane-builds.md)             | Local Fastlane Builds                    | Accepted           | 2026-03-31 |
+| [0017](./0017-mcp-server-for-claude-cowork.md)      | MCP Server for Claude Cowork             | Accepted           | 2026-04-11 |

--- a/packages/shared/src/editor/__tests__/markdown-converter.test.ts
+++ b/packages/shared/src/editor/__tests__/markdown-converter.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect } from "vitest";
+import { blockNoteToMarkdown, markdownToBlockNote } from "../markdown-converter";
+import type { BlockNoteBlock, BlockNoteTableContent } from "../types";
+
+describe("blockNoteToMarkdown", () => {
+  it("converts headings", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "heading",
+        props: { level: 1 },
+        content: [{ type: "text", text: "Title", styles: {} }],
+        children: [],
+      },
+      {
+        type: "heading",
+        props: { level: 3 },
+        content: [{ type: "text", text: "Sub", styles: {} }],
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("# Title\n\n### Sub");
+  });
+
+  it("converts paragraphs", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "Hello world", styles: {} }],
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("Hello world");
+  });
+
+  it("converts bullet list items", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Item 1", styles: {} }],
+        children: [],
+      },
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Item 2", styles: {} }],
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("- Item 1\n\n- Item 2");
+  });
+
+  it("converts numbered list items", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "numberedListItem",
+        content: [{ type: "text", text: "First", styles: {} }],
+        children: [],
+      },
+      {
+        type: "numberedListItem",
+        content: [{ type: "text", text: "Second", styles: {} }],
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("1. First\n\n1. Second");
+  });
+
+  it("converts check list items", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "checkListItem",
+        props: { checked: true },
+        content: [{ type: "text", text: "Done", styles: {} }],
+        children: [],
+      },
+      {
+        type: "checkListItem",
+        props: { checked: false },
+        content: [{ type: "text", text: "Todo", styles: {} }],
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("- [x] Done\n\n- [ ] Todo");
+  });
+
+  it("converts code blocks", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "codeBlock",
+        props: { language: "ts" },
+        content: [{ type: "text", text: "const x = 1;", styles: {} }],
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("```ts\nconst x = 1;\n```");
+  });
+
+  it("converts images", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "image",
+        props: { url: "https://example.com/img.png", caption: "A photo" },
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("![A photo](https://example.com/img.png)");
+  });
+
+  it("converts tables", () => {
+    const tableContent: BlockNoteTableContent = {
+      type: "tableContent",
+      rows: [
+        {
+          cells: [
+            [{ type: "text", text: "A", styles: {} }],
+            [{ type: "text", text: "B", styles: {} }],
+          ],
+        },
+        {
+          cells: [
+            [{ type: "text", text: "1", styles: {} }],
+            [{ type: "text", text: "2", styles: {} }],
+          ],
+        },
+      ],
+    };
+    const blocks: BlockNoteBlock[] = [{ type: "table", content: tableContent, children: [] }];
+    expect(blockNoteToMarkdown(blocks)).toBe("| A | B |\n| --- | --- |\n| 1 | 2 |");
+  });
+
+  it("converts inline styles", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "bold", styles: { bold: true } },
+          { type: "text", text: " and ", styles: {} },
+          { type: "text", text: "italic", styles: { italic: true } },
+          { type: "text", text: " and ", styles: {} },
+          { type: "text", text: "code", styles: { code: true } },
+        ],
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("**bold** and *italic* and `code`");
+  });
+
+  it("converts links", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "Visit ", styles: {} },
+          {
+            type: "link",
+            text: "example",
+            href: "https://example.com",
+            content: [{ type: "text", text: "example", styles: {} }],
+          },
+        ],
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("Visit [example](https://example.com)");
+  });
+
+  it("handles nested children with indent", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "Parent", styles: {} }],
+        children: [
+          {
+            type: "bulletListItem",
+            content: [{ type: "text", text: "Child", styles: {} }],
+            children: [],
+          },
+        ],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("- Parent\n  - Child");
+  });
+
+  it("handles empty blocks", () => {
+    const blocks: BlockNoteBlock[] = [];
+    expect(blockNoteToMarkdown(blocks)).toBe("");
+  });
+});
+
+describe("markdownToBlockNote", () => {
+  it("parses headings", () => {
+    const blocks = markdownToBlockNote("# Hello\n\n## World");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("heading");
+    expect(blocks[0].props?.level).toBe(1);
+    expect(blocks[1].type).toBe("heading");
+    expect(blocks[1].props?.level).toBe(2);
+  });
+
+  it("parses paragraphs", () => {
+    const blocks = markdownToBlockNote("Hello world");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("paragraph");
+    expect(blocks[0].content).toEqual([{ type: "text", text: "Hello world", styles: {} }]);
+  });
+
+  it("parses bullet lists", () => {
+    const blocks = markdownToBlockNote("- Item 1\n- Item 2");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("bulletListItem");
+    expect(blocks[1].type).toBe("bulletListItem");
+  });
+
+  it("parses numbered lists", () => {
+    const blocks = markdownToBlockNote("1. First\n2. Second");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("numberedListItem");
+    expect(blocks[1].type).toBe("numberedListItem");
+  });
+
+  it("parses check lists", () => {
+    const blocks = markdownToBlockNote("- [x] Done\n- [ ] Todo");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("checkListItem");
+    expect(blocks[0].props?.checked).toBe(true);
+    expect(blocks[1].type).toBe("checkListItem");
+    expect(blocks[1].props?.checked).toBe(false);
+  });
+
+  it("parses code blocks", () => {
+    const blocks = markdownToBlockNote("```ts\nconst x = 1;\n```");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("codeBlock");
+    expect(blocks[0].props?.language).toBe("ts");
+    expect(blocks[0].content).toEqual([{ type: "text", text: "const x = 1;", styles: {} }]);
+  });
+
+  it("parses images", () => {
+    const blocks = markdownToBlockNote("![Alt text](https://example.com/img.png)");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("image");
+    expect(blocks[0].props?.url).toBe("https://example.com/img.png");
+    expect(blocks[0].props?.caption).toBe("Alt text");
+  });
+
+  it("parses tables", () => {
+    const md = "| A | B |\n| --- | --- |\n| 1 | 2 |";
+    const blocks = markdownToBlockNote(md);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("table");
+    const tc = blocks[0].content as BlockNoteTableContent;
+    expect(tc.type).toBe("tableContent");
+    expect(tc.rows).toHaveLength(2); // header + data row, separator skipped
+  });
+
+  it("parses inline bold", () => {
+    const blocks = markdownToBlockNote("**bold text**");
+    expect(blocks).toHaveLength(1);
+    const content = blocks[0].content as { styles?: Record<string, boolean> }[];
+    expect(content[0].styles?.bold).toBe(true);
+  });
+
+  it("parses inline code", () => {
+    const blocks = markdownToBlockNote("Use `const` here");
+    expect(blocks).toHaveLength(1);
+    const content = blocks[0].content as {
+      type: string;
+      text: string;
+      styles?: Record<string, boolean>;
+    }[];
+    expect(content).toHaveLength(3);
+    expect(content[0]).toEqual({ type: "text", text: "Use ", styles: {} });
+    expect(content[1]).toEqual({ type: "text", text: "const", styles: { code: true } });
+    expect(content[2]).toEqual({ type: "text", text: " here", styles: {} });
+  });
+
+  it("parses links", () => {
+    const blocks = markdownToBlockNote("[example](https://example.com)");
+    expect(blocks).toHaveLength(1);
+    const content = blocks[0].content as { type: string; href?: string }[];
+    expect(content[0].type).toBe("link");
+    expect(content[0].href).toBe("https://example.com");
+  });
+
+  it("handles empty input", () => {
+    expect(markdownToBlockNote("")).toEqual([]);
+    expect(markdownToBlockNote("  \n\n  ")).toEqual([]);
+  });
+});
+
+describe("round-trip", () => {
+  it("preserves headings through round-trip", () => {
+    const md = "# Hello";
+    const result = blockNoteToMarkdown(markdownToBlockNote(md));
+    expect(result).toBe(md);
+  });
+
+  it("preserves code blocks through round-trip", () => {
+    const md = "```ts\nconst x = 1;\n```";
+    const result = blockNoteToMarkdown(markdownToBlockNote(md));
+    expect(result).toBe(md);
+  });
+
+  it("preserves check lists through round-trip", () => {
+    const md = "- [x] Done";
+    const result = blockNoteToMarkdown(markdownToBlockNote(md));
+    expect(result).toBe(md);
+  });
+});

--- a/packages/shared/src/editor/markdown-converter.ts
+++ b/packages/shared/src/editor/markdown-converter.ts
@@ -1,0 +1,326 @@
+import type { BlockNoteBlock, BlockNoteInlineContent, BlockNoteTableContent } from "./types";
+
+// --- BlockNote -> Markdown ---
+
+function inlineContentToMarkdown(inlineContent: BlockNoteInlineContent[]): string {
+  return inlineContent.map(inlineItemToMarkdown).join("");
+}
+
+function inlineItemToMarkdown(item: BlockNoteInlineContent): string {
+  let text =
+    item.type === "link" && item.content?.length
+      ? item.content.map(inlineItemToMarkdown).join("")
+      : item.text;
+
+  if (item.styles) {
+    if (item.styles.code) text = `\`${text}\``;
+    if (item.styles.bold) text = `**${text}**`;
+    if (item.styles.italic) text = `*${text}*`;
+    if (item.styles.strike) text = `~~${text}~~`;
+    // underline has no standard Markdown — skip
+  }
+
+  if (item.type === "link" && item.href) {
+    text = `[${text}](${item.href})`;
+  }
+
+  return text;
+}
+
+function blockToMarkdown(block: BlockNoteBlock, indent: number): string {
+  const prefix = "  ".repeat(indent);
+  const lines: string[] = [];
+
+  switch (block.type) {
+    case "heading": {
+      const level = (block.props?.level as number) ?? 1;
+      const hashes = "#".repeat(Math.min(level, 6));
+      const text = Array.isArray(block.content) ? inlineContentToMarkdown(block.content) : "";
+      lines.push(`${prefix}${hashes} ${text}`);
+      break;
+    }
+
+    case "paragraph": {
+      const text = Array.isArray(block.content) ? inlineContentToMarkdown(block.content) : "";
+      lines.push(`${prefix}${text}`);
+      break;
+    }
+
+    case "bulletListItem": {
+      const text = Array.isArray(block.content) ? inlineContentToMarkdown(block.content) : "";
+      lines.push(`${prefix}- ${text}`);
+      break;
+    }
+
+    case "numberedListItem": {
+      const text = Array.isArray(block.content) ? inlineContentToMarkdown(block.content) : "";
+      lines.push(`${prefix}1. ${text}`);
+      break;
+    }
+
+    case "checkListItem": {
+      const checked = (block.props?.checked as boolean) ?? false;
+      const text = Array.isArray(block.content) ? inlineContentToMarkdown(block.content) : "";
+      lines.push(`${prefix}- [${checked ? "x" : " "}] ${text}`);
+      break;
+    }
+
+    case "codeBlock": {
+      const language = (block.props?.language as string) ?? "";
+      const text =
+        Array.isArray(block.content) && block.content.length > 0
+          ? block.content.map((c) => c.text).join("")
+          : "";
+      lines.push(`${prefix}\`\`\`${language}`);
+      lines.push(text);
+      lines.push(`${prefix}\`\`\``);
+      break;
+    }
+
+    case "image": {
+      const url = (block.props?.url as string) ?? "";
+      const caption = (block.props?.caption as string) ?? "";
+      lines.push(`${prefix}![${caption}](${url})`);
+      break;
+    }
+
+    case "table": {
+      const tableContent = block.content as BlockNoteTableContent | undefined;
+      if (tableContent?.type === "tableContent" && tableContent.rows.length > 0) {
+        for (let i = 0; i < tableContent.rows.length; i++) {
+          const row = tableContent.rows[i];
+          const cells = row.cells.map((cell) => inlineContentToMarkdown(cell));
+          lines.push(`${prefix}| ${cells.join(" | ")} |`);
+          if (i === 0) {
+            lines.push(`${prefix}| ${cells.map(() => "---").join(" | ")} |`);
+          }
+        }
+      }
+      break;
+    }
+
+    default: {
+      // Unknown block type: render as paragraph to avoid data loss
+      const text = Array.isArray(block.content) ? inlineContentToMarkdown(block.content) : "";
+      if (text) lines.push(`${prefix}${text}`);
+      break;
+    }
+  }
+
+  // Render nested children with increased indent
+  if (block.children && block.children.length > 0) {
+    for (const child of block.children) {
+      lines.push(blockToMarkdown(child, indent + 1));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Convert BlockNote blocks to Markdown text.
+ */
+export function blockNoteToMarkdown(blocks: BlockNoteBlock[]): string {
+  return blocks.map((block) => blockToMarkdown(block, 0)).join("\n\n");
+}
+
+// --- Markdown -> BlockNote ---
+
+interface ParsedLine {
+  indent: number;
+  content: string;
+}
+
+function parseLine(line: string): ParsedLine {
+  const match = line.match(/^(\s*)(.*)/);
+  const raw = match?.[1] ?? "";
+  // Normalize indent: 2 spaces or 1 tab = 1 level
+  const indent = Math.floor(raw.replace(/\t/g, "  ").length / 2);
+  return { indent, content: match?.[2] ?? "" };
+}
+
+function parseInlineMarkdown(text: string): BlockNoteInlineContent[] {
+  const result: BlockNoteInlineContent[] = [];
+  // Regex to match markdown inline patterns: links, bold, italic, code, strikethrough
+  const regex =
+    /(\[([^\]]+)\]\(([^)]+)\))|(`([^`]+)`)|(\*\*(.+?)\*\*)|(\*(.+?)\*)|(\~\~(.+?)\~\~)|([^[`*~]+|[[\`*~])/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match[1]) {
+      // Link: [text](url)
+      const linkText = match[2];
+      const href = match[3];
+      result.push({
+        type: "link",
+        text: linkText,
+        href,
+        content: [{ type: "text", text: linkText, styles: {} }],
+      });
+    } else if (match[4]) {
+      // Inline code: `code`
+      result.push({ type: "text", text: match[5], styles: { code: true } });
+    } else if (match[6]) {
+      // Bold: **text**
+      result.push({ type: "text", text: match[7], styles: { bold: true } });
+    } else if (match[8]) {
+      // Italic: *text*
+      result.push({ type: "text", text: match[9], styles: { italic: true } });
+    } else if (match[10]) {
+      // Strikethrough: ~~text~~
+      result.push({ type: "text", text: match[11], styles: { strike: true } });
+    } else if (match[12]) {
+      // Plain text
+      const plain = match[12];
+      if (plain) {
+        result.push({ type: "text", text: plain, styles: {} });
+      }
+    }
+  }
+
+  if (result.length === 0 && text) {
+    result.push({ type: "text", text, styles: {} });
+  }
+
+  return result;
+}
+
+/**
+ * Convert Markdown text to BlockNote blocks.
+ * Supports headings, paragraphs, bullet/numbered/check lists, code blocks, images, and inline styles.
+ */
+export function markdownToBlockNote(markdown: string): BlockNoteBlock[] {
+  const lines = markdown.split("\n");
+  const blocks: BlockNoteBlock[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Skip empty lines
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // Fenced code block
+    const codeMatch = line.match(/^```(\w*)/);
+    if (codeMatch) {
+      const language = codeMatch[1] || "";
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].match(/^```\s*$/)) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      i++; // skip closing ```
+      const text = codeLines.join("\n");
+      blocks.push({
+        type: "codeBlock",
+        props: { language },
+        content: text ? [{ type: "text", text, styles: {} }] : [],
+        children: [],
+      });
+      continue;
+    }
+
+    const { content } = parseLine(line);
+
+    // Heading
+    const headingMatch = content.match(/^(#{1,6})\s+(.*)/);
+    if (headingMatch) {
+      blocks.push({
+        type: "heading",
+        props: { level: headingMatch[1].length },
+        content: parseInlineMarkdown(headingMatch[2]),
+        children: [],
+      });
+      i++;
+      continue;
+    }
+
+    // Image
+    const imageMatch = content.match(/^!\[([^\]]*)\]\(([^)]+)\)/);
+    if (imageMatch) {
+      const props: Record<string, unknown> = { url: imageMatch[2] };
+      if (imageMatch[1]) props.caption = imageMatch[1];
+      blocks.push({ type: "image", props, children: [] });
+      i++;
+      continue;
+    }
+
+    // Check list item
+    const checkMatch = content.match(/^-\s+\[([ xX])\]\s+(.*)/);
+    if (checkMatch) {
+      blocks.push({
+        type: "checkListItem",
+        props: { checked: checkMatch[1] !== " " },
+        content: parseInlineMarkdown(checkMatch[2]),
+        children: [],
+      });
+      i++;
+      continue;
+    }
+
+    // Bullet list item
+    const bulletMatch = content.match(/^[-*+]\s+(.*)/);
+    if (bulletMatch) {
+      blocks.push({
+        type: "bulletListItem",
+        content: parseInlineMarkdown(bulletMatch[1]),
+        children: [],
+      });
+      i++;
+      continue;
+    }
+
+    // Numbered list item
+    const numberedMatch = content.match(/^\d+\.\s+(.*)/);
+    if (numberedMatch) {
+      blocks.push({
+        type: "numberedListItem",
+        content: parseInlineMarkdown(numberedMatch[1]),
+        children: [],
+      });
+      i++;
+      continue;
+    }
+
+    // Table (starts with |)
+    if (content.startsWith("|")) {
+      const tableRows: BlockNoteInlineContent[][][] = [];
+      while (i < lines.length && lines[i].trim().startsWith("|")) {
+        const rowText = lines[i].trim();
+        // Skip separator rows (| --- | --- |)
+        if (rowText.match(/^\|[\s\-:|]+\|$/)) {
+          i++;
+          continue;
+        }
+        const cells = rowText
+          .split("|")
+          .slice(1, -1) // Remove empty first/last from leading/trailing |
+          .map((cell) => parseInlineMarkdown(cell.trim()));
+        tableRows.push(cells);
+        i++;
+      }
+      if (tableRows.length > 0) {
+        const tableContent: BlockNoteTableContent = {
+          type: "tableContent",
+          rows: tableRows.map((cells) => ({ cells })),
+        };
+        blocks.push({ type: "table", content: tableContent, children: [] });
+      }
+      continue;
+    }
+
+    // Default: paragraph
+    blocks.push({
+      type: "paragraph",
+      content: parseInlineMarkdown(content),
+      children: [],
+    });
+    i++;
+  }
+
+  return blocks;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export type {
   NotebookInsert,
   NoteInsert,
   AttachmentInsert,
+  ApiKeyRow,
   NotebookUpdate,
   NoteUpdate,
 } from "./types/api";
@@ -27,6 +28,7 @@ export {
   contentToBlocknote,
 } from "./editor/format-converter";
 export { extractTextFromContent } from "./editor/extract-text";
+export { blockNoteToMarkdown, markdownToBlockNote } from "./editor/markdown-converter";
 export {
   toAttachmentUrl,
   isAttachmentUrl,

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -4,6 +4,7 @@ export type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
 export type NotebookRow = Database["public"]["Tables"]["notebooks"]["Row"];
 export type NoteRow = Database["public"]["Tables"]["notes"]["Row"];
 export type AttachmentRow = Database["public"]["Tables"]["attachments"]["Row"];
+export type ApiKeyRow = Database["public"]["Tables"]["api_keys"]["Row"];
 
 export type NotebookInsert = Database["public"]["Tables"]["notebooks"]["Insert"];
 export type NoteInsert = Database["public"]["Tables"]["notes"]["Insert"];

--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -169,6 +169,47 @@ export interface Database {
           },
         ];
       };
+      api_keys: {
+        Row: {
+          id: string;
+          user_id: string;
+          key_prefix: string;
+          key_hash: string;
+          name: string;
+          created_at: string;
+          last_used_at: string | null;
+          revoked_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          key_prefix: string;
+          key_hash: string;
+          name?: string;
+          created_at?: string;
+          last_used_at?: string | null;
+          revoked_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          key_prefix?: string;
+          key_hash?: string;
+          name?: string;
+          created_at?: string;
+          last_used_at?: string | null;
+          revoked_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "api_keys_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
     };
     Views: Record<string, never>;
     Functions: Record<string, never>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,7 +190,7 @@ importers:
         version: 2.101.1
       expo:
         specifier: ~55.0.11
-        version: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+        version: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       expo-constants:
         specifier: ~55.0.11
         version: 55.0.11(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(typescript@5.9.3)
@@ -303,6 +303,9 @@ importers:
       '@mantine/core':
         specifier: ^8.3.18
         version: 8.3.18(@mantine/hooks@8.3.15(react@19.1.4))(@types/react@19.2.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@sentry/nextjs':
         specifier: ^10.47.0
         version: 10.47.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.2(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(react@19.1.4)(webpack@5.105.2(esbuild@0.27.4))
@@ -397,9 +400,6 @@ importers:
       typescript:
         specifier: ^6
         version: 6.0.2
-      vite:
-        specifier: ^8.0.5
-        version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: ^6.1.1
         version: 6.1.1(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
@@ -1341,8 +1341,8 @@ packages:
       react-native:
         optional: true
 
-  '@expo/dom-webview@55.0.5':
-    resolution: {integrity: sha512-lt3uxYOCk3wmWvtOOvsC35CKGbDAOx5C2EaY8SH1JVSfBzqmF8Cs0Xp1MPxncDPMyxpMiWx5SvvV/iLF1rJU4A==}
+  '@expo/dom-webview@55.0.3':
+    resolution: {integrity: sha512-bY4/rfcZ0f43DvOtMn8/kmPlmo01tex5hRoc5hKbwBwQjqWQuQt0ACwu7akR9IHI4j0WNG48eL6cZB6dZUFrzg==}
     peerDependencies:
       expo: '*'
       react: 19.1.4
@@ -1513,6 +1513,12 @@ packages:
 
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1816,6 +1822,16 @@ packages:
     resolution: {integrity: sha512-RSKlNZvxhMCkOFZ6slbYvZYbWjHUM+PxDQnupIOxIdsTZQQjx/BFfrfJ7kQFOP+g7MtpOds8weAetEs5obwMOQ==}
     peerDependencies:
       react: 19.1.4
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -4174,6 +4190,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
@@ -4444,6 +4468,10 @@ packages:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -4695,6 +4723,10 @@ packages:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -4715,6 +4747,14 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -4724,6 +4764,10 @@ packages:
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.2.0:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
@@ -5270,6 +5314,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -5461,6 +5513,16 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -5534,6 +5596,10 @@ packages:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-babel-config@2.1.2:
     resolution: {integrity: sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==}
 
@@ -5573,9 +5639,17 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
@@ -5821,6 +5895,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -5883,6 +5961,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   idb@8.0.3:
@@ -5948,6 +6030,14 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -6057,6 +6147,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -6330,6 +6423,9 @@ packages:
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -6381,6 +6477,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -6705,11 +6804,19 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   merge-stream@2.0.0:
@@ -7210,6 +7317,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -7242,6 +7352,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -7514,6 +7628,10 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -7558,6 +7676,10 @@ packages:
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
@@ -7899,6 +8021,10 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -7959,6 +8085,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
@@ -7966,6 +8096,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -8439,6 +8573,10 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
@@ -9020,6 +9158,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -10125,7 +10268,7 @@ snapshots:
 
   '@expo-google-fonts/material-symbols@0.4.28': {}
 
-  '@expo/cli@55.0.21(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-constants@55.0.11)(expo-font@55.0.6)(expo-router@55.0.10)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@expo/cli@55.0.21(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-constants@55.0.11)(expo-font@55.0.6)(expo-router@55.0.10)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 55.0.12(typescript@5.9.3)
@@ -10134,7 +10277,7 @@ snapshots:
       '@expo/env': 2.1.1
       '@expo/image-utils': 0.8.12
       '@expo/json-file': 10.0.13
-      '@expo/log-box': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/log-box': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       '@expo/metro': 55.0.0
       '@expo/metro-config': 55.0.13(expo@55.0.11)(typescript@5.9.3)
       '@expo/osascript': 2.4.2
@@ -10159,7 +10302,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.4
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       expo-server: 55.0.7
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -10256,9 +10399,9 @@ snapshots:
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
 
-  '@expo/dom-webview@55.0.5(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
+  '@expo/dom-webview@55.0.3(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
 
@@ -10309,20 +10452,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/log-box@55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
+  '@expo/log-box@55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@expo/dom-webview': 55.0.5(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/dom-webview': 55.0.3(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       anser: 1.4.10
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
       stacktrace-parser: 0.1.11
 
-  '@expo/log-box@55.0.7(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
+  '@expo/log-box@55.0.7(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@expo/dom-webview': 55.0.5(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/dom-webview': 55.0.3(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       anser: 1.4.10
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
       stacktrace-parser: 0.1.11
@@ -10349,18 +10492,18 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@expo/metro-runtime@55.0.6(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
+  '@expo/metro-runtime@55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@expo/log-box': 55.0.7(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/log-box': 55.0.7(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       anser: 1.4.10
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       pretty-format: 29.7.0
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
@@ -10420,7 +10563,7 @@ snapshots:
       '@expo/json-file': 10.0.13
       '@react-native/normalize-colors': 0.83.4
       debug: 4.4.3
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -10441,13 +10584,13 @@ snapshots:
   '@expo/router-server@55.0.13(@expo/metro-runtime@55.0.6)(expo-constants@55.0.11)(expo-font@55.0.6)(expo-router@55.0.10)(expo-server@55.0.7)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       debug: 4.4.3
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       expo-constants: 55.0.11(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(typescript@5.9.3)
       expo-font: 55.0.6(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       expo-server: 55.0.7
       react: 19.1.4
     optionalDependencies:
-      '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       expo-router: 55.0.10(dee2d36fa3bbf3c60bc0d92a202d711e)
       react-dom: 19.2.4(react@19.1.4)
     transitivePeerDependencies:
@@ -10525,6 +10668,10 @@ snapshots:
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
+
+  '@hono/node-server@1.19.13(hono@4.12.12)':
+    dependencies:
+      hono: 4.12.12
 
   '@humanfs/core@0.19.1': {}
 
@@ -10873,6 +11020,28 @@ snapshots:
   '@mantine/utils@6.0.22(react@19.1.4)':
     dependencies:
       react: 19.1.4
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.12)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -13747,6 +13916,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
       ajv: 8.18.0
@@ -14057,7 +14230,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -14108,6 +14281,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.14.2
+      raw-body: 3.0.2
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -14364,6 +14551,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
 
   conventional-changelog-angular@8.3.0:
@@ -14381,6 +14570,10 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
 
   core-js-compat@3.49.0:
@@ -14388,6 +14581,11 @@ snapshots:
       browserslist: 4.28.2
 
   core-js@3.49.0: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig-typescript-loader@6.2.0(@types/node@25.5.2)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
@@ -15145,6 +15343,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -15172,7 +15376,7 @@ snapshots:
   expo-asset@55.0.12(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.12
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       expo-constants: 55.0.11(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(typescript@5.9.3)
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
@@ -15184,7 +15388,7 @@ snapshots:
     dependencies:
       '@expo/config': 55.0.12(typescript@5.9.3)
       '@expo/env': 2.1.1
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
     transitivePeerDependencies:
       - supports-color
@@ -15192,53 +15396,53 @@ snapshots:
 
   expo-crypto@55.0.12(expo@55.0.11):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
 
   expo-document-picker@55.0.11(expo@55.0.11):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
 
   expo-file-system@55.0.14(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
 
   expo-font@55.0.6(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
 
   expo-glass-effect@55.0.10(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
 
   expo-haptics@55.0.12(expo@55.0.11):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
 
   expo-image-loader@55.0.0(expo@55.0.11):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
 
   expo-image-picker@55.0.16(expo@55.0.11):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       expo-image-loader: 55.0.0(expo@55.0.11)
 
   expo-image@55.0.8(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
       sf-symbols-typescript: 2.2.0
 
   expo-keep-awake@55.0.6(expo@55.0.11)(react@19.1.4):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react: 19.1.4
 
   expo-linking@55.0.11(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3):
@@ -15270,8 +15474,8 @@ snapshots:
 
   expo-router@55.0.10(dee2d36fa3bbf3c60bc0d92a202d711e):
     dependencies:
-      '@expo/log-box': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
-      '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/log-box': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       '@expo/schema-utils': 55.0.2
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.1.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.1.4))(react@19.1.4)
@@ -15281,7 +15485,7 @@ snapshots:
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       expo-constants: 55.0.11(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(typescript@5.9.3)
       expo-glass-effect: 55.0.10(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       expo-image: 55.0.8(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
@@ -15316,7 +15520,7 @@ snapshots:
 
   expo-secure-store@55.0.11(expo@55.0.11):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
 
   expo-server@55.0.7: {}
 
@@ -15329,7 +15533,7 @@ snapshots:
   expo-symbols@55.0.7(expo-font@55.0.6)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.28
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       expo-font: 55.0.6(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
@@ -15337,19 +15541,19 @@ snapshots:
 
   expo-web-browser@55.0.12(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)):
     dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
 
-  expo@55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3):
+  expo@55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.21(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-constants@55.0.11)(expo-font@55.0.6)(expo-router@55.0.10)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@expo/cli': 55.0.21(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-constants@55.0.11)(expo-font@55.0.6)(expo-router@55.0.10)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@expo/config': 55.0.12(typescript@5.9.3)
       '@expo/config-plugins': 55.0.7
       '@expo/devtools': 55.0.2(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       '@expo/fingerprint': 0.16.6
       '@expo/local-build-cache-provider': 55.0.8(typescript@5.9.3)
-      '@expo/log-box': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/log-box': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       '@expo/metro': 55.0.0
       '@expo/metro-config': 55.0.13(expo@55.0.11)(typescript@5.9.3)
       '@expo/vector-icons': 15.1.1(expo-font@55.0.6)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
@@ -15368,8 +15572,8 @@ snapshots:
       react-refresh: 0.14.2
       whatwg-url-minimum: 0.1.1
     optionalDependencies:
-      '@expo/dom-webview': 55.0.5(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
-      '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.5)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/dom-webview': 55.0.3(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       react-native-webview: 13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
     transitivePeerDependencies:
       - '@babel/core'
@@ -15383,6 +15587,44 @@ snapshots:
       - utf-8-validate
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.3.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -15456,6 +15698,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-babel-config@2.1.2:
     dependencies:
       json5: 2.2.3
@@ -15499,7 +15752,11 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  forwarded@0.2.0: {}
+
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@8.1.0:
     dependencies:
@@ -15814,6 +16071,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  hono@4.12.12: {}
+
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -15887,6 +16146,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   idb@8.0.3: {}
 
   ieee754@1.2.1: {}
@@ -15947,6 +16210,10 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -16044,6 +16311,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -16341,7 +16610,7 @@ snapshots:
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
@@ -16615,6 +16884,8 @@ snapshots:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
 
+  jose@6.2.2: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -16698,6 +16969,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -17071,9 +17344,13 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   memoize-one@5.2.1: {}
 
   meow@13.2.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -17770,6 +18047,8 @@ snapshots:
       lru-cache: 11.3.1
       minipass: 7.1.3
 
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   pg-int8@1.0.1: {}
@@ -17793,6 +18072,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -18053,6 +18334,11 @@ snapshots:
       '@types/node': 24.12.2
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   psl@1.15.0:
@@ -18093,6 +18379,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   react-devtools-core@6.1.5:
@@ -18638,6 +18931,16 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -18710,6 +19013,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@2.1.0: {}
 
   serve-static@1.16.3:
@@ -18718,6 +19037,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -19211,6 +19539,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -19847,6 +20181,10 @@ snapshots:
       lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/supabase/migrations/20260411000001_api_keys.sql
+++ b/supabase/migrations/20260411000001_api_keys.sql
@@ -1,0 +1,42 @@
+-- API keys for MCP (Model Context Protocol) server authentication.
+-- Users generate keys from the web UI; only hashed values are stored.
+
+create table public.api_keys (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  key_prefix text not null,        -- first 8 chars, for display identification
+  key_hash text not null,          -- SHA-256 hex digest of the full key
+  name text not null default '',   -- user-provided label
+  created_at timestamptz not null default now(),
+  last_used_at timestamptz,
+  revoked_at timestamptz
+);
+
+-- Fast lookup by hash during authentication
+create unique index idx_api_keys_key_hash on public.api_keys (key_hash);
+
+-- List keys for a user
+create index idx_api_keys_user_id on public.api_keys (user_id);
+
+-- RLS
+alter table public.api_keys enable row level security;
+
+-- Users can read their own keys
+create policy "Users can read own api_keys"
+  on public.api_keys for select
+  using (auth.uid() = user_id and public.is_approved());
+
+-- Users can create their own keys
+create policy "Users can create own api_keys"
+  on public.api_keys for insert
+  with check (auth.uid() = user_id and public.is_approved());
+
+-- Users can update their own keys (for revoking)
+create policy "Users can update own api_keys"
+  on public.api_keys for update
+  using (auth.uid() = user_id and public.is_approved());
+
+-- Users can delete their own keys
+create policy "Users can delete own api_keys"
+  on public.api_keys for delete
+  using (auth.uid() = user_id and public.is_approved());


### PR DESCRIPTION
## Summary
- Add a remote MCP server at `/api/mcp` enabling Claude Desktop, Claude Cowork, and other MCP clients to read, search, create, and update Drafto notes
- 9 MCP tools: list_notebooks, list_notes, read_note, search_notes, create_notebook, create_note, update_note, move_note, trash_note
- API key authentication (SHA-256 hashed, stored in new `api_keys` table) with settings UI at `/settings`
- BlockNote <-> Markdown converter in `packages/shared` for human-readable content exchange
- Stateless Streamable HTTP transport (Vercel serverless compatible)

## Before deploying
1. Apply migration to dev: `pnpm supabase:link:dev && pnpm supabase:push`
2. Add `SUPABASE_SERVICE_ROLE_KEY` to Vercel env vars (dev + prod)
3. Apply migration to prod after verifying on dev

## Test plan
- [x] Unit tests for markdown converter (packages/shared)
- [x] Unit tests for MCP auth utility
- [x] Unit tests for API key endpoints
- [x] All existing tests pass (576 web + 123 shared)
- [x] TypeScript compiles clean
- [x] Lint passes (0 errors)
- [ ] Manual test: generate API key from /settings, configure in Claude Desktop, verify tools work
- [ ] Verify migration applies cleanly on dev Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings page for API key management (create, view, revoke) and “Connect to Claude” configuration.
  * MCP server endpoint for notebook/note tools with API-key authentication.
  * Bidirectional Markdown ↔ BlockNote conversion utilities.
  * Settings entry added to app menu.

* **Documentation**
  * ADR and docs updated describing MCP server design and CI guidance.

* **Tests**
  * Expanded test coverage for API keys, MCP auth/route/tools, integration settings, and markdown converter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->