### PR TITLE
feat: add Google and Apple OAuth login

### DIFF
--- a/apps/desktop/jest.config.js
+++ b/apps/desktop/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: "react-native",
   setupFilesAfterEnv: ["./jest.setup.js"],
-  testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/__tests__/helpers/"],
+  testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/__tests__/helpers/", "test-utils"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
     // Mock TurboModuleRegistry to provide stubs for all native TurboModules

--- a/apps/desktop/jest.setup.js
+++ b/apps/desktop/jest.setup.js
@@ -124,6 +124,21 @@ jest.mock("@/providers/theme-provider", () => {
   };
 });
 
+// Mock react-native-svg
+jest.mock("react-native-svg", () => {
+  const { View, Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: View,
+    Svg: View,
+    Path: View,
+    Circle: View,
+    Rect: View,
+    G: View,
+    Text: Text,
+  };
+});
+
 // Silence console.error for act warnings in tests
 const originalError = console.error;
 console.error = (...args) => {

--- a/apps/desktop/macos/Drafto-macOS/Info.plist
+++ b/apps/desktop/macos/Drafto-macOS/Info.plist
@@ -32,6 +32,17 @@
 	<true/>
 	<key>NSSupportsSuddenTermination</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>eu.drafto.desktop</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>eu.drafto.desktop</string>
+			</array>
+		</dict>
+	</array>
 	<key>RCTNewArchEnabled</key>
 	<true/>
 </dict>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,7 @@
     "react-native-macos": "^0.81.6",
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "^4.11.1",
+    "react-native-svg": "^15.15.4",
     "react-native-url-polyfill": "^3.0.0",
     "react-native-webview": "^13.12.5"
   },

--- a/apps/desktop/src/components/auth/oauth-buttons.tsx
+++ b/apps/desktop/src/components/auth/oauth-buttons.tsx
@@ -1,0 +1,160 @@
+import { useState, useMemo } from "react";
+import { View, Text, Pressable, StyleSheet, ActivityIndicator } from "react-native";
+import Svg, { Path } from "react-native-svg";
+
+import { useTheme } from "@/providers/theme-provider";
+import type { SemanticColors } from "@/theme/tokens";
+import { signInWithOAuthBrowser } from "@/lib/oauth";
+
+type OAuthProvider = "google" | "apple";
+
+function GoogleIcon() {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 24 24">
+      <Path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <Path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <Path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <Path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </Svg>
+  );
+}
+
+function AppleIcon({ color }: { color: string }) {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 24 24" fill={color}>
+      <Path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+    </Svg>
+  );
+}
+
+interface OAuthButtonsProps {
+  onError?: (error: string) => void;
+}
+
+export function OAuthButtons({ onError }: OAuthButtonsProps) {
+  const { semantic } = useTheme();
+  const styles = useMemo(() => createStyles(semantic), [semantic]);
+  const [loadingProvider, setLoadingProvider] = useState<OAuthProvider | null>(null);
+
+  const handleOAuth = async (provider: OAuthProvider) => {
+    setLoadingProvider(provider);
+
+    const result = await signInWithOAuthBrowser(provider);
+
+    if (result.error) {
+      onError?.(result.error);
+    }
+
+    setLoadingProvider(null);
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.dividerRow}>
+        <View style={styles.dividerLine} />
+        <Text style={styles.dividerText}>or continue with</Text>
+        <View style={styles.dividerLine} />
+      </View>
+
+      <Pressable
+        style={({ pressed }) => [
+          styles.oauthButton,
+          pressed && styles.oauthButtonPressed,
+          loadingProvider !== null && styles.oauthButtonDisabled,
+        ]}
+        onPress={() => handleOAuth("google")}
+        disabled={loadingProvider !== null}
+        accessibilityRole="button"
+        accessibilityLabel="Sign in with Google"
+      >
+        {loadingProvider === "google" ? (
+          <ActivityIndicator color={semantic.fg} size="small" />
+        ) : (
+          <>
+            <GoogleIcon />
+            <Text style={styles.oauthButtonText}>Google</Text>
+          </>
+        )}
+      </Pressable>
+
+      <Pressable
+        style={({ pressed }) => [
+          styles.oauthButton,
+          pressed && styles.oauthButtonPressed,
+          loadingProvider !== null && styles.oauthButtonDisabled,
+        ]}
+        onPress={() => handleOAuth("apple")}
+        disabled={loadingProvider !== null}
+        accessibilityRole="button"
+        accessibilityLabel="Sign in with Apple"
+      >
+        {loadingProvider === "apple" ? (
+          <ActivityIndicator color={semantic.fg} size="small" />
+        ) : (
+          <>
+            <AppleIcon color={semantic.fg} />
+            <Text style={styles.oauthButtonText}>Apple</Text>
+          </>
+        )}
+      </Pressable>
+    </View>
+  );
+}
+
+const createStyles = (semantic: SemanticColors) =>
+  StyleSheet.create({
+    container: {
+      width: "100%",
+      marginTop: 16,
+      gap: 12,
+    },
+    dividerRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      marginBottom: 4,
+    },
+    dividerLine: {
+      flex: 1,
+      height: 1,
+      backgroundColor: semantic.border,
+    },
+    dividerText: {
+      marginHorizontal: 12,
+      fontSize: 13,
+      color: semantic.fgMuted,
+    },
+    oauthButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 12,
+      borderWidth: 1,
+      borderColor: semantic.borderStrong,
+      borderRadius: 8,
+      padding: 14,
+      backgroundColor: semantic.bg,
+    },
+    oauthButtonPressed: {
+      backgroundColor: semantic.bgMuted,
+    },
+    oauthButtonDisabled: {
+      opacity: 0.5,
+    },
+    oauthButtonText: {
+      fontSize: 16,
+      fontWeight: "500",
+      color: semantic.fg,
+    },
+  });

--- a/apps/desktop/src/lib/oauth.ts
+++ b/apps/desktop/src/lib/oauth.ts
@@ -1,0 +1,63 @@
+import { Linking } from "react-native";
+
+import { supabase } from "./supabase";
+
+const REDIRECT_URL = "eu.drafto.desktop://auth/callback";
+
+type OAuthProvider = "google" | "apple";
+
+export async function signInWithOAuthBrowser(
+  provider: OAuthProvider,
+): Promise<{ error: string | null }> {
+  try {
+    const { data, error: oauthError } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: {
+        redirectTo: REDIRECT_URL,
+        skipBrowserRedirect: true,
+      },
+    });
+
+    if (oauthError || !data.url) {
+      return { error: oauthError?.message ?? "Failed to start sign-in." };
+    }
+
+    await Linking.openURL(data.url);
+    return { error: null };
+  } catch {
+    return { error: "Failed to open sign-in. Please try again." };
+  }
+}
+
+export function handleOAuthCallback(url: string): void {
+  try {
+    const parsed = new URL(url);
+
+    if (!parsed.pathname.includes("auth/callback")) {
+      return;
+    }
+
+    // Handle fragment-based tokens (implicit flow) or code-based (PKCE)
+    const params = new URLSearchParams(parsed.hash ? parsed.hash.substring(1) : parsed.search);
+
+    const code = params.get("code");
+    if (code) {
+      supabase.auth.exchangeCodeForSession(code).catch((err) => {
+        console.error("[oauth] Failed to exchange code for session:", err);
+      });
+      return;
+    }
+
+    const accessToken = params.get("access_token");
+    const refreshToken = params.get("refresh_token");
+    if (accessToken && refreshToken) {
+      supabase.auth
+        .setSession({ access_token: accessToken, refresh_token: refreshToken })
+        .catch((err) => {
+          console.error("[oauth] Failed to set session:", err);
+        });
+    }
+  } catch (err) {
+    console.error("[oauth] Failed to parse callback URL:", err);
+  }
+}

--- a/apps/desktop/src/navigation/app-navigator.tsx
+++ b/apps/desktop/src/navigation/app-navigator.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
-import { ActivityIndicator, View, StyleSheet } from "react-native";
+import { useState, useEffect } from "react";
+import { ActivityIndicator, View, StyleSheet, Linking } from "react-native";
 
 import { useAuth } from "@/providers/auth-provider";
+import { handleOAuthCallback } from "@/lib/oauth";
 import { colors } from "@/theme/tokens";
 import { useTheme } from "@/providers/theme-provider";
 import { LoginScreen } from "@/screens/login";
@@ -15,6 +16,20 @@ export function RootNavigator() {
   const { user, isApproved, isLoading, isCheckingApproval } = useAuth();
   const { semantic } = useTheme();
   const [authRoute, setAuthRoute] = useState<AuthRoute>("Login");
+
+  useEffect(() => {
+    // Handle OAuth callback deep links (eu.drafto.desktop://auth/callback)
+    const subscription = Linking.addEventListener("url", ({ url }) => {
+      handleOAuthCallback(url);
+    });
+
+    // Check if the app was opened via a deep link
+    Linking.getInitialURL().then((url) => {
+      if (url) handleOAuthCallback(url);
+    });
+
+    return () => subscription.remove();
+  }, []);
 
   if (isLoading || isCheckingApproval) {
     return (

--- a/apps/desktop/src/screens/login.tsx
+++ b/apps/desktop/src/screens/login.tsx
@@ -4,6 +4,7 @@ import { supabase } from "@/lib/supabase";
 import { useTheme } from "@/providers/theme-provider";
 import { colors } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
+import { OAuthButtons } from "@/components/auth/oauth-buttons";
 
 interface LoginScreenProps {
   onNavigateToSignup?: () => void;
@@ -92,6 +93,8 @@ export function LoginScreen({ onNavigateToSignup }: LoginScreenProps) {
           color={colors.primary[600]}
         />
       </View>
+
+      <OAuthButtons onError={(msg) => setError(msg)} />
 
       <View style={styles.footer}>
         <Pressable onPress={onNavigateToSignup} disabled={!onNavigateToSignup}>

--- a/apps/desktop/src/screens/signup.tsx
+++ b/apps/desktop/src/screens/signup.tsx
@@ -4,6 +4,7 @@ import { supabase } from "@/lib/supabase";
 import { useTheme } from "@/providers/theme-provider";
 import { colors } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
+import { OAuthButtons } from "@/components/auth/oauth-buttons";
 
 interface SignupScreenProps {
   onNavigateToLogin?: () => void;
@@ -97,6 +98,8 @@ export function SignupScreen({ onNavigateToLogin }: SignupScreenProps) {
           color={colors.primary[600]}
         />
       </View>
+
+      <OAuthButtons onError={(msg) => setError(msg)} />
 
       <View style={styles.footer}>
         <Pressable onPress={onNavigateToLogin} disabled={!onNavigateToLogin}>

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -20,6 +20,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     supportsTablet: true,
     bundleIdentifier: "eu.drafto.mobile",
     associatedDomains: ["applinks:drafto.eu", "applinks:www.drafto.eu"],
+    usesAppleSignIn: true,
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
     },
@@ -56,6 +57,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   extra: {
     supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL,
     supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY,
+    googleWebClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
+    googleIosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
     eas: {
       projectId: "6cf2a8f0-c2a6-410c-89dc-3e49aa4119a5",
     },
@@ -67,6 +70,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     "expo-router",
     "expo-secure-store",
     "expo-font",
+    "expo-apple-authentication",
+    [
+      "@react-native-google-signin/google-signin",
+      {
+        iosUrlScheme: process.env.EXPO_PUBLIC_GOOGLE_IOS_URL_SCHEME,
+      },
+    ],
     "./plugins/with-android-optimizations",
     "./plugins/with-android-signing",
     "./plugins/with-ios-swift-concurrency",

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -16,6 +16,7 @@ import { supabase } from "@/lib/supabase";
 import { useTheme } from "@/providers/theme-provider";
 import { colors } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
+import { OAuthButtons } from "@/components/auth/oauth-buttons";
 
 export default function LoginScreen() {
   const { semantic } = useTheme();
@@ -114,6 +115,8 @@ export default function LoginScreen() {
             )}
           </Pressable>
         </View>
+
+        <OAuthButtons onError={(msg) => setError(msg)} />
 
         <View style={styles.footer}>
           <Text style={styles.footerText}>

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -16,6 +16,7 @@ import { supabase } from "@/lib/supabase";
 import { useTheme } from "@/providers/theme-provider";
 import { colors } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
+import { OAuthButtons } from "@/components/auth/oauth-buttons";
 
 export default function SignupScreen() {
   const { semantic } = useTheme();
@@ -118,6 +119,8 @@ export default function SignupScreen() {
             )}
           </Pressable>
         </View>
+
+        <OAuthButtons onError={(msg) => setError(msg)} />
 
         <View style={styles.footer}>
           <Text style={styles.footerText}>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -7,6 +7,7 @@ import { StatusBar } from "expo-status-bar";
 
 import { AuthProvider, useAuth } from "@/providers/auth-provider";
 import { DatabaseProvider } from "@/providers/database-provider";
+import { configureGoogleSignIn } from "@/lib/oauth";
 import { ThemeProvider, useTheme } from "@/providers/theme-provider";
 import { OfflineBanner } from "@/components/offline-banner";
 import { ToastProvider } from "@/components/toast";
@@ -14,6 +15,7 @@ import { colors } from "@/theme/tokens";
 import { markStartupBegin, markStartupEnd } from "@/lib/performance";
 
 markStartupBegin();
+configureGoogleSignIn();
 
 const PUBLIC_AUTH_SCREENS = new Set(["login", "signup"]);
 

--- a/apps/mobile/jest.setup.js
+++ b/apps/mobile/jest.setup.js
@@ -74,6 +74,57 @@ jest.mock("@expo/vector-icons", () => {
   };
 });
 
+// Mock @react-native-google-signin/google-signin
+jest.mock("@react-native-google-signin/google-signin", () => ({
+  GoogleSignin: {
+    configure: jest.fn(),
+    hasPlayServices: jest.fn().mockResolvedValue(true),
+    signIn: jest.fn().mockResolvedValue({ data: { idToken: "mock-id-token" } }),
+    signOut: jest.fn().mockResolvedValue(null),
+  },
+  statusCodes: {
+    SIGN_IN_CANCELLED: "SIGN_IN_CANCELLED",
+    IN_PROGRESS: "IN_PROGRESS",
+    PLAY_SERVICES_NOT_AVAILABLE: "PLAY_SERVICES_NOT_AVAILABLE",
+  },
+  isErrorWithCode: jest.fn(() => false),
+}));
+
+// Mock expo-apple-authentication
+jest.mock("expo-apple-authentication", () => ({
+  signInAsync: jest.fn().mockResolvedValue({
+    identityToken: "mock-apple-token",
+    fullName: { givenName: "Test", familyName: "User" },
+    email: "test@example.com",
+  }),
+  isAvailableAsync: jest.fn().mockResolvedValue(true),
+  AppleAuthenticationScope: {
+    FULL_NAME: 0,
+    EMAIL: 1,
+  },
+}));
+
+// Mock expo-web-browser
+jest.mock("expo-web-browser", () => ({
+  openAuthSessionAsync: jest.fn().mockResolvedValue({ type: "cancel" }),
+  maybeCompleteAuthSession: jest.fn(),
+}));
+
+// Mock react-native-svg
+jest.mock("react-native-svg", () => {
+  const { View, Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: View,
+    Svg: View,
+    Path: View,
+    Circle: View,
+    Rect: View,
+    G: View,
+    Text: Text,
+  };
+});
+
 // Silence console.error for act warnings in tests
 const originalError = console.error;
 console.error = (...args) => {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -26,8 +26,10 @@
     "@nozbe/watermelondb": "^0.28.0",
     "@nozbe/with-observables": "^1.6.0",
     "@react-native-community/netinfo": "^11.5.2",
+    "@react-native-google-signin/google-signin": "^16.1.2",
     "@supabase/supabase-js": "^2.101.1",
     "expo": "~55.0.11",
+    "expo-apple-authentication": "^55.0.13",
     "expo-constants": "~55.0.11",
     "expo-crypto": "^55.0.12",
     "expo-document-picker": "^55.0.11",
@@ -44,6 +46,7 @@
     "react-native": "0.83.2",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.24.0",
+    "react-native-svg": "^15.15.4",
     "react-native-webview": "^13.16.0"
   },
   "devDependencies": {

--- a/apps/mobile/src/components/auth/oauth-buttons.tsx
+++ b/apps/mobile/src/components/auth/oauth-buttons.tsx
@@ -1,0 +1,172 @@
+import { useState, useMemo } from "react";
+import { View, Text, Pressable, StyleSheet, ActivityIndicator, Platform } from "react-native";
+import * as AppleAuthentication from "expo-apple-authentication";
+import Svg, { Path } from "react-native-svg";
+
+import { useTheme } from "@/providers/theme-provider";
+import { colors } from "@/theme/tokens";
+import type { SemanticColors } from "@/theme/tokens";
+import { signInWithGoogle, signInWithApple } from "@/lib/oauth";
+
+type OAuthProvider = "google" | "apple";
+
+function GoogleIcon() {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 24 24">
+      <Path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <Path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <Path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <Path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </Svg>
+  );
+}
+
+function AppleIcon({ color }: { color: string }) {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 24 24" fill={color}>
+      <Path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+    </Svg>
+  );
+}
+
+interface OAuthButtonsProps {
+  onError?: (error: string) => void;
+}
+
+export function OAuthButtons({ onError }: OAuthButtonsProps) {
+  const { semantic } = useTheme();
+  const styles = useMemo(() => createStyles(semantic), [semantic]);
+  const [loadingProvider, setLoadingProvider] = useState<OAuthProvider | null>(null);
+  const [showAppleButton, setShowAppleButton] = useState(true);
+
+  // On iOS, check if Apple Sign-In is available
+  if (Platform.OS === "ios" && showAppleButton) {
+    AppleAuthentication.isAvailableAsync().then((available) => {
+      if (!available) setShowAppleButton(false);
+    });
+  }
+
+  const handleOAuth = async (provider: OAuthProvider) => {
+    setLoadingProvider(provider);
+
+    const result = provider === "google" ? await signInWithGoogle() : await signInWithApple();
+
+    if (result.error) {
+      onError?.(result.error);
+    }
+
+    setLoadingProvider(null);
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.dividerRow}>
+        <View style={styles.dividerLine} />
+        <Text style={styles.dividerText}>or continue with</Text>
+        <View style={styles.dividerLine} />
+      </View>
+
+      <Pressable
+        style={({ pressed }) => [
+          styles.oauthButton,
+          pressed && styles.oauthButtonPressed,
+          loadingProvider !== null && styles.oauthButtonDisabled,
+        ]}
+        onPress={() => handleOAuth("google")}
+        disabled={loadingProvider !== null}
+        accessibilityRole="button"
+        accessibilityLabel="Sign in with Google"
+      >
+        {loadingProvider === "google" ? (
+          <ActivityIndicator color={semantic.fg} size="small" />
+        ) : (
+          <>
+            <GoogleIcon />
+            <Text style={styles.oauthButtonText}>Google</Text>
+          </>
+        )}
+      </Pressable>
+
+      {showAppleButton && (
+        <Pressable
+          style={({ pressed }) => [
+            styles.oauthButton,
+            pressed && styles.oauthButtonPressed,
+            loadingProvider !== null && styles.oauthButtonDisabled,
+          ]}
+          onPress={() => handleOAuth("apple")}
+          disabled={loadingProvider !== null}
+          accessibilityRole="button"
+          accessibilityLabel="Sign in with Apple"
+        >
+          {loadingProvider === "apple" ? (
+            <ActivityIndicator color={semantic.fg} size="small" />
+          ) : (
+            <>
+              <AppleIcon color={semantic.fg} />
+              <Text style={styles.oauthButtonText}>Apple</Text>
+            </>
+          )}
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+const createStyles = (semantic: SemanticColors) =>
+  StyleSheet.create({
+    container: {
+      width: "100%",
+      marginTop: 16,
+      gap: 12,
+    },
+    dividerRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      marginBottom: 4,
+    },
+    dividerLine: {
+      flex: 1,
+      height: 1,
+      backgroundColor: semantic.border,
+    },
+    dividerText: {
+      marginHorizontal: 12,
+      fontSize: 13,
+      color: semantic.fgMuted,
+    },
+    oauthButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 12,
+      borderWidth: 1,
+      borderColor: semantic.borderStrong,
+      borderRadius: 8,
+      padding: 14,
+      backgroundColor: semantic.bg,
+    },
+    oauthButtonPressed: {
+      backgroundColor: semantic.bgMuted,
+    },
+    oauthButtonDisabled: {
+      opacity: 0.5,
+    },
+    oauthButtonText: {
+      fontSize: 16,
+      fontWeight: "500",
+      color: semantic.fg,
+    },
+  });

--- a/apps/mobile/src/lib/oauth.ts
+++ b/apps/mobile/src/lib/oauth.ts
@@ -1,0 +1,127 @@
+import { Platform } from "react-native";
+import * as AppleAuthentication from "expo-apple-authentication";
+import * as WebBrowser from "expo-web-browser";
+import {
+  GoogleSignin,
+  isErrorWithCode,
+  statusCodes,
+} from "@react-native-google-signin/google-signin";
+import Constants from "expo-constants";
+
+import { supabase } from "./supabase";
+
+const googleWebClientId = Constants.expoConfig?.extra?.googleWebClientId as string;
+
+export function configureGoogleSignIn() {
+  if (!googleWebClientId) {
+    console.warn("Missing EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID — Google Sign-In will not work");
+    return;
+  }
+  GoogleSignin.configure({
+    webClientId: googleWebClientId,
+    iosClientId: Constants.expoConfig?.extra?.googleIosClientId as string | undefined,
+  });
+}
+
+export async function signInWithGoogle(): Promise<{ error: string | null }> {
+  try {
+    await GoogleSignin.hasPlayServices();
+    const response = await GoogleSignin.signIn();
+
+    if (!response.data?.idToken) {
+      return { error: "Google Sign-In did not return an ID token." };
+    }
+
+    const { error } = await supabase.auth.signInWithIdToken({
+      provider: "google",
+      token: response.data.idToken,
+    });
+
+    if (error) {
+      return { error: error.message };
+    }
+
+    return { error: null };
+  } catch (err) {
+    if (isErrorWithCode(err)) {
+      if (err.code === statusCodes.SIGN_IN_CANCELLED || err.code === statusCodes.IN_PROGRESS) {
+        return { error: null };
+      }
+    }
+    return { error: "Google Sign-In failed. Please try again." };
+  }
+}
+
+export async function signInWithApple(): Promise<{ error: string | null }> {
+  if (Platform.OS === "ios") {
+    return signInWithAppleNative();
+  }
+  return signInWithAppleBrowser();
+}
+
+async function signInWithAppleNative(): Promise<{ error: string | null }> {
+  try {
+    const credential = await AppleAuthentication.signInAsync({
+      requestedScopes: [
+        AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+        AppleAuthentication.AppleAuthenticationScope.EMAIL,
+      ],
+    });
+
+    if (!credential.identityToken) {
+      return { error: "Apple Sign-In did not return an identity token." };
+    }
+
+    const { error } = await supabase.auth.signInWithIdToken({
+      provider: "apple",
+      token: credential.identityToken,
+    });
+
+    if (error) {
+      return { error: error.message };
+    }
+
+    return { error: null };
+  } catch (err) {
+    if ((err as { code?: string }).code === "ERR_REQUEST_CANCELED") {
+      return { error: null };
+    }
+    return { error: "Apple Sign-In failed. Please try again." };
+  }
+}
+
+async function signInWithAppleBrowser(): Promise<{ error: string | null }> {
+  try {
+    const { data, error: oauthError } = await supabase.auth.signInWithOAuth({
+      provider: "apple",
+      options: {
+        redirectTo: "drafto://auth/callback",
+        skipBrowserRedirect: true,
+      },
+    });
+
+    if (oauthError || !data.url) {
+      return { error: oauthError?.message ?? "Failed to start Apple Sign-In." };
+    }
+
+    const result = await WebBrowser.openAuthSessionAsync(data.url, "drafto://auth/callback");
+
+    if (result.type === "success" && result.url) {
+      const url = new URL(result.url);
+      const code = url.searchParams.get("code");
+
+      if (code) {
+        const { error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error) {
+          return { error: error.message };
+        }
+        return { error: null };
+      }
+    }
+
+    // User cancelled or dismissed
+    return { error: null };
+  } catch {
+    return { error: "Apple Sign-In failed. Please try again." };
+  }
+}

--- a/apps/web/__tests__/integration/login.test.tsx
+++ b/apps/web/__tests__/integration/login.test.tsx
@@ -11,9 +11,13 @@ vi.mock("next/navigation", () => ({
 
 // Mock Supabase client
 const mockSignIn = vi.fn();
+const mockSignInWithOAuth = vi.fn();
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
-    auth: { signInWithPassword: mockSignIn },
+    auth: {
+      signInWithPassword: mockSignIn,
+      signInWithOAuth: mockSignInWithOAuth,
+    },
   }),
 }));
 
@@ -31,7 +35,7 @@ describe("Login page", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the login form", async () => {
+  it("renders the login form with OAuth buttons", async () => {
     await act(async () => {
       render(<LoginPage />);
     });
@@ -40,6 +44,9 @@ describe("Login page", () => {
     expect(screen.getByLabelText("Email")).toBeInTheDocument();
     expect(screen.getByLabelText("Password")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Log in" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Google" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apple" })).toBeInTheDocument();
+    expect(screen.getByText("or continue with")).toBeInTheDocument();
   });
 
   it("has links to signup and forgot password", async () => {
@@ -113,6 +120,53 @@ describe("Login page", () => {
     await act(async () => {
       resolveSignIn!({ error: null });
     });
+  });
+
+  it("calls signInWithOAuth when Google button is clicked", async () => {
+    mockSignInWithOAuth.mockResolvedValueOnce({ error: null });
+    const user = userEvent.setup();
+
+    await act(async () => {
+      render(<LoginPage />);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Google" }));
+
+    expect(mockSignInWithOAuth).toHaveBeenCalledWith({
+      provider: "google",
+      options: { redirectTo: expect.stringContaining("/auth/callback") },
+    });
+  });
+
+  it("calls signInWithOAuth when Apple button is clicked", async () => {
+    mockSignInWithOAuth.mockResolvedValueOnce({ error: null });
+    const user = userEvent.setup();
+
+    await act(async () => {
+      render(<LoginPage />);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Apple" }));
+
+    expect(mockSignInWithOAuth).toHaveBeenCalledWith({
+      provider: "apple",
+      options: { redirectTo: expect.stringContaining("/auth/callback") },
+    });
+  });
+
+  it("displays error when OAuth sign-in fails", async () => {
+    mockSignInWithOAuth.mockResolvedValueOnce({
+      error: { message: "OAuth provider error" },
+    });
+    const user = userEvent.setup();
+
+    await act(async () => {
+      render(<LoginPage />);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Google" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("OAuth provider error");
   });
 
   it("clears previous error on new submission", async () => {

--- a/apps/web/__tests__/integration/signup.test.tsx
+++ b/apps/web/__tests__/integration/signup.test.tsx
@@ -11,9 +11,13 @@ vi.mock("next/navigation", () => ({
 
 // Mock Supabase client
 const mockSignUp = vi.fn();
+const mockSignInWithOAuth = vi.fn();
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
-    auth: { signUp: mockSignUp },
+    auth: {
+      signUp: mockSignUp,
+      signInWithOAuth: mockSignInWithOAuth,
+    },
   }),
 }));
 
@@ -32,7 +36,7 @@ describe("Signup page", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the signup form", async () => {
+  it("renders the signup form with OAuth buttons", async () => {
     await act(async () => {
       render(<SignupPage />);
     });
@@ -41,6 +45,8 @@ describe("Signup page", () => {
     expect(screen.getByLabelText("Email")).toBeInTheDocument();
     expect(screen.getByLabelText("Password")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Sign up" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Google" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apple" })).toBeInTheDocument();
   });
 
   it("has a link to the login page", async () => {

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { OAuthButtons } from "@/components/auth/oauth-buttons";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -75,6 +76,8 @@ export default function LoginPage() {
           {loading ? "Logging in..." : "Log in"}
         </Button>
       </form>
+
+      <OAuthButtons />
 
       <div className="text-fg-muted mt-4 text-center text-sm">
         <p>

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { OAuthButtons } from "@/components/auth/oauth-buttons";
 
 export default function SignupPage() {
   const [email, setEmail] = useState("");
@@ -83,6 +84,8 @@ export default function SignupPage() {
           {loading ? "Creating account..." : "Sign up"}
         </Button>
       </form>
+
+      <OAuthButtons />
 
       <p className="text-fg-muted mt-4 text-center text-sm">
         Already have an account?{" "}

--- a/apps/web/src/components/auth/oauth-buttons.tsx
+++ b/apps/web/src/components/auth/oauth-buttons.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { cn } from "@/lib/cn";
+
+type OAuthProvider = "google" | "apple";
+
+function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}
+
+function AppleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+    </svg>
+  );
+}
+
+interface OAuthButtonsProps {
+  className?: string;
+}
+
+export function OAuthButtons({ className }: OAuthButtonsProps) {
+  const [loadingProvider, setLoadingProvider] = useState<OAuthProvider | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleOAuthSignIn(provider: OAuthProvider) {
+    setError(null);
+    setLoadingProvider(provider);
+
+    try {
+      const supabase = createClient();
+      const { error: oauthError } = await supabase.auth.signInWithOAuth({
+        provider,
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+        },
+      });
+
+      if (oauthError) {
+        setError(oauthError.message);
+        setLoadingProvider(null);
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+      setLoadingProvider(null);
+    }
+  }
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="relative my-4">
+        <div className="absolute inset-0 flex items-center">
+          <div className="border-border w-full border-t" />
+        </div>
+        <div className="relative flex justify-center text-sm">
+          <span className="bg-bg-card text-fg-muted px-2">or continue with</span>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        disabled={loadingProvider !== null}
+        onClick={() => handleOAuthSignIn("google")}
+        className={cn(
+          "border-border bg-bg text-fg hover:bg-bg-muted inline-flex w-full items-center justify-center gap-3 rounded-md border px-4 py-2 text-sm font-medium transition-colors duration-[var(--transition-fast)]",
+          "focus-visible:ring-primary-500 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+          loadingProvider !== null && "pointer-events-none opacity-50",
+        )}
+      >
+        <GoogleIcon className="h-5 w-5" />
+        {loadingProvider === "google" ? "Redirecting..." : "Google"}
+      </button>
+
+      <button
+        type="button"
+        disabled={loadingProvider !== null}
+        onClick={() => handleOAuthSignIn("apple")}
+        className={cn(
+          "border-border bg-bg text-fg hover:bg-bg-muted inline-flex w-full items-center justify-center gap-3 rounded-md border px-4 py-2 text-sm font-medium transition-colors duration-[var(--transition-fast)]",
+          "focus-visible:ring-primary-500 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+          loadingProvider !== null && "pointer-events-none opacity-50",
+        )}
+      >
+        <AppleIcon className="h-5 w-5" />
+        {loadingProvider === "apple" ? "Redirecting..." : "Apple"}
+      </button>
+
+      {error && (
+        <div role="alert" className="text-error bg-error-bg rounded-md p-3 text-sm">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/adr/0018-oauth-google-apple.md
+++ b/docs/adr/0018-oauth-google-apple.md
@@ -1,0 +1,54 @@
+# 0018 — OAuth Authentication with Google and Apple
+
+- **Status**: Accepted
+- **Date**: 2026-04-12
+
+## Context
+
+Drafto currently supports only email+password authentication via Supabase Auth across all four platforms (web, iOS, Android, macOS). Social login was explicitly scoped out of v1. Users now expect frictionless sign-in options, and Apple requires "Sign in with Apple" if any other third-party login is offered on iOS/macOS (App Store Review Guideline 4.8). Adding Google OAuth necessitates adding Apple OAuth simultaneously.
+
+The app has an approval gating flow — new users land in `is_approved=false` state regardless of how they sign up. The existing `handle_new_user()` trigger fires on `auth.users` INSERT, so OAuth-created users automatically get a profile row. No database changes are needed.
+
+## Decision
+
+### Web (Next.js)
+
+Use Supabase `signInWithOAuth()` with PKCE flow. This redirects to Google/Apple, then returns to the existing `/auth/callback` route which already calls `exchangeCodeForSession()`.
+
+### Mobile (iOS)
+
+Use native SDKs — `expo-apple-authentication` for Apple Sign In and `@react-native-google-signin/google-signin` for Google — then pass the identity token to Supabase via `signInWithIdToken()`. This provides native UI (Apple's system sheet, Google's One Tap) and avoids opening a web browser.
+
+### Mobile (Android)
+
+Use `@react-native-google-signin/google-signin` for Google, and Supabase `signInWithOAuth()` via `expo-web-browser` for Apple (Apple does not provide a native Android SDK).
+
+### Desktop (macOS)
+
+Open the system browser via `Linking.openURL()` with the Supabase OAuth URL. Register a custom URL scheme (`eu.drafto.desktop`) in Info.plist for the callback. Listen for the URL scheme callback via React Native's `Linking.addEventListener`.
+
+### Account Linking
+
+Use Supabase automatic linking (default behavior). When a user signs up with email+password and later attempts OAuth with the same email, Supabase automatically links the identities if the email is verified on both sides. The user ends up with one account regardless of sign-in method.
+
+## Consequences
+
+**Positive:**
+
+- Native feel on iOS/macOS with system authentication sheets
+- No web browser popup on iOS
+- Single identity for users who use both email and OAuth
+- Approval flow is unaffected — OAuth users still require admin approval
+
+**Negative:**
+
+- Three distinct OAuth flows to maintain (web PKCE, native `signInWithIdToken`, desktop system browser)
+- Native SDKs add build complexity on mobile (requires `expo prebuild` after adding plugins)
+
+## Alternatives Considered
+
+1. **`signInWithOAuth()` everywhere (web browser flow on all platforms)**: Simpler code but poor UX on mobile — opens Safari/Chrome, breaks the native feel. Rejected for iOS/Android.
+
+2. **Native SDKs on desktop too**: macOS does not have well-supported React Native bindings for Google Sign-In. `Linking.openURL` with URL scheme callback is the standard macOS approach. Rejected as unnecessary complexity.
+
+3. **Skip Apple, only add Google**: Violates App Store Guideline 4.8 — any app offering third-party login must also offer Sign in with Apple. Rejected.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,3 +50,4 @@ Every ADR follows the template in [0000-adr-template.md](./0000-adr-template.md)
 | [0015](./0015-desktop-app-technology-choice.md)     | Desktop App Technology Choice            | Accepted           | 2026-03-29 |
 | [0016](./0016-local-fastlane-builds.md)             | Local Fastlane Builds                    | Accepted           | 2026-03-31 |
 | [0017](./0017-mcp-server-for-claude-cowork.md)      | MCP Server for Claude Cowork             | Accepted           | 2026-04-11 |
+| [0018](./0018-oauth-google-apple.md)                | OAuth with Google and Apple              | Accepted           | 2026-04-12 |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       react-native-screens:
         specifier: ^4.11.1
         version: 4.24.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@6.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      react-native-svg:
+        specifier: ^15.15.4
+        version: 15.15.4(react-native@0.81.6(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@6.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       react-native-url-polyfill:
         specifier: ^3.0.0
         version: 3.0.0(react-native@0.81.6(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@6.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))
@@ -185,12 +188,18 @@ importers:
       '@react-native-community/netinfo':
         specifier: ^11.5.2
         version: 11.5.2(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@react-native-google-signin/google-signin':
+        specifier: ^16.1.2
+        version: 16.1.2(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       '@supabase/supabase-js':
         specifier: ^2.101.1
         version: 2.101.1
       expo:
         specifier: ~55.0.11
         version: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      expo-apple-authentication:
+        specifier: ^55.0.13
+        version: 55.0.13(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))
       expo-constants:
         specifier: ~55.0.11
         version: 55.0.11(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(typescript@5.9.3)
@@ -239,6 +248,9 @@ importers:
       react-native-screens:
         specifier: ~4.24.0
         version: 4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      react-native-svg:
+        specifier: ^15.15.4
+        version: 15.15.4(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       react-native-webview:
         specifier: ^13.16.0
         version: 13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
@@ -1514,8 +1526,8 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -2523,6 +2535,16 @@ packages:
     peerDependencies:
       react: 19.1.4
       react-native: '>=0.59'
+
+  '@react-native-google-signin/google-signin@16.1.2':
+    resolution: {integrity: sha512-1hf4pRmpnS5t0dHtqU72Q1FmWzsCZR2Sm3uVQbbfMKeNPl5TKjpAsP6F8QTZ9L+Q6Cnn9tL9BXpDCb1nyutdCQ==}
+    peerDependencies:
+      expo: '>=52.0.40'
+      react: 19.1.4
+      react-native: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
 
   '@react-native-macos/virtualized-lists@0.81.6':
     resolution: {integrity: sha512-zxRPKQCtrBoSXFrkVENmsx3VIzbVBrHphpNOuwn3acCZNBBmCwKE8HRlsnJqsq5rSR/Gq6/Pprv8bbJC3X3ZqQ==}
@@ -4801,6 +4823,10 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -5337,6 +5363,12 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  expo-apple-authentication@55.0.13:
+    resolution: {integrity: sha512-Qvh3DmhXqhtWOe7BC9e7UVApR3XS1qE7+68tVLqb3KI/sET7QV9KT5JgOJogWmmCJVxA/kaot0M136yvW1pdWA==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
 
   expo-asset@55.0.12:
     resolution: {integrity: sha512-Ad5RzNqn/dzIrQ+HIrQFSVZ/bZJ24523pV1LnpbruPnIiuhq5DgygmTKiXoK1InelqOoVyY7GIVZ8f07MvxCCQ==}
@@ -6794,6 +6826,9 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -7772,6 +7807,12 @@ packages:
 
   react-native-screens@4.24.0:
     resolution: {integrity: sha512-SyoiGaDofiyGPFrUkn1oGsAzkRuX1JUvTD9YQQK3G1JGQ5VWkvHgYSsc1K9OrLsDQxN7NmV71O0sHCAh8cBetA==}
+    peerDependencies:
+      react: 19.1.4
+      react-native: '*'
+
+  react-native-svg@15.15.4:
+    resolution: {integrity: sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A==}
     peerDependencies:
       react: 19.1.4
       react-native: '*'
@@ -10669,7 +10710,7 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.14(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
 
@@ -11023,7 +11064,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.14(hono@4.12.12)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -11890,6 +11931,13 @@ snapshots:
     dependencies:
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
+
+  '@react-native-google-signin/google-signin@16.1.2(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      react: 19.1.4
+      react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
+    optionalDependencies:
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
 
   '@react-native-macos/virtualized-lists@0.81.6(@types/react@19.2.14)(react-native@0.81.6(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@6.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
@@ -14659,6 +14707,11 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -15372,6 +15425,11 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  expo-apple-authentication@55.0.13(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)):
+    dependencies:
+      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
 
   expo-asset@55.0.12(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3):
     dependencies:
@@ -17338,6 +17396,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  mdn-data@2.0.14: {}
+
   mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
@@ -18517,6 +18577,22 @@ snapshots:
     dependencies:
       react: 19.1.4
       react-freeze: 1.0.4(react@19.1.4)
+      react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
+      warn-once: 0.1.1
+
+  react-native-svg@15.15.4(react-native@0.81.6(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@6.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 19.1.4
+      react-native: 0.81.6(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@6.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
+      warn-once: 0.1.1
+
+  react-native-svg@15.15.4(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
       warn-once: 0.1.1
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -151,6 +151,8 @@ additional_redirect_urls = [
   "http://127.0.0.1:3000/**",
   "https://drafto.eu/**",
   "https://*-jakubanderwalds-projects.vercel.app/**",
+  "drafto://auth/callback",
+  "eu.drafto.desktop://auth/callback",
 ]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
@@ -300,20 +302,25 @@ max_frequency = "5s"
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
 # `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.google]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
+redirect_uri = ""
+url = ""
+# Required for native mobile sign-in with Google (signInWithIdToken uses an ID token, not a code).
+skip_nonce_check = true
+
 [auth.external.apple]
-enabled = false
-client_id = ""
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_APPLE_CLIENT_ID)"
 # DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
 secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
-# Overrides the default auth redirectUrl.
 redirect_uri = ""
-# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
-# or any other third-party OIDC providers.
 url = ""
-# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
-skip_nonce_check = false
-# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
-email_optional = false
+# Required for native mobile sign-in with Apple (signInWithIdToken uses an ID token, not a code).
+skip_nonce_check = true
 
 # Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
 # You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.


### PR DESCRIPTION
## Summary

- Add Google and Apple OAuth sign-in across all 4 platforms (web, iOS, Android, macOS)
- Web: Supabase PKCE flow via `signInWithOAuth()`, reuses existing `/auth/callback` route
- Mobile iOS: Native SDKs (`expo-apple-authentication`, `@react-native-google-signin`) with `signInWithIdToken()` for native UI
- Mobile Android: Native Google Sign-In + browser fallback for Apple (no native Apple SDK on Android)
- Desktop macOS: System browser via `Linking.openURL()` + custom URL scheme (`eu.drafto.desktop://`) callback
- Existing approval flow works unchanged — OAuth users still require admin approval
- Account linking: Supabase auto-links when verified email matches across methods
- ADR 0017 documents the architecture decision

## Prerequisites (completed)

- [x] Google Cloud Console: Web, iOS, Android OAuth client IDs created
- [x] Apple Developer Portal: Services ID + Sign in with Apple key created
- [x] Supabase Dashboard: Google and Apple providers enabled (dev + prod)
- [x] Mobile `.env` files updated with Google client IDs

## Test plan

- [ ] Web: Test Google/Apple login on localhost — verify redirect, callback, session, approval flow
- [ ] iOS: Test native Apple Sign-In sheet + Google One Tap
- [ ] Android: Test native Google Sign-In + Apple via browser fallback
- [ ] macOS: Test system browser OAuth flow for both providers
- [ ] Account linking: Sign up with email, then OAuth with same email — verify merge
- [ ] New OAuth user lands on waiting-for-approval screen on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)