### PR TITLE
fix: import Evernote lists/tasks + allow notebook deletion after trash

### DIFF
--- a/apps/web/__tests__/unit/enex-parser.test.ts
+++ b/apps/web/__tests__/unit/enex-parser.test.ts
@@ -115,4 +115,51 @@ describe("parseEnexFile", () => {
     const notes = parseEnexFile(xml);
     expect(notes[0].resources[0].fileName).toBe("attachment.jpg");
   });
+
+  it("parses task elements from notes", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<en-export>
+  <note>
+    <title>Note with tasks</title>
+    <content><![CDATA[<en-note><p>Tasks below</p></en-note>]]></content>
+    <created>20230101T000000Z</created>
+    <task>
+      <title>Buy milk</title>
+      <taskStatus>open</taskStatus>
+      <taskGroupNoteLevelID>group-1</taskGroupNoteLevelID>
+      <sortWeight>B</sortWeight>
+    </task>
+    <task>
+      <title>Clean house</title>
+      <taskStatus>completed</taskStatus>
+      <taskGroupNoteLevelID>group-1</taskGroupNoteLevelID>
+      <sortWeight>J</sortWeight>
+    </task>
+  </note>
+</en-export>`;
+
+    const notes = parseEnexFile(xml);
+    expect(notes).toHaveLength(1);
+    expect(notes[0].tasks).toHaveLength(2);
+    expect(notes[0].tasks[0].title).toBe("Buy milk");
+    expect(notes[0].tasks[0].checked).toBe(false);
+    expect(notes[0].tasks[0].groupId).toBe("group-1");
+    expect(notes[0].tasks[0].sortWeight).toBe("B");
+    expect(notes[0].tasks[1].title).toBe("Clean house");
+    expect(notes[0].tasks[1].checked).toBe(true);
+  });
+
+  it("returns empty tasks array when note has no tasks", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<en-export>
+  <note>
+    <title>No tasks</title>
+    <content><![CDATA[<en-note><p>Plain note</p></en-note>]]></content>
+    <created>20230101T000000Z</created>
+  </note>
+</en-export>`;
+
+    const notes = parseEnexFile(xml);
+    expect(notes[0].tasks).toEqual([]);
+  });
 });

--- a/apps/web/__tests__/unit/enml-to-blocknote.test.ts
+++ b/apps/web/__tests__/unit/enml-to-blocknote.test.ts
@@ -66,13 +66,15 @@ describe("convertEnmlToBlocks", () => {
     expect(blocks[0].type).toBe("numberedListItem");
   });
 
-  it("converts en-todo checkboxes", () => {
+  it("converts en-todo checkboxes with text content", () => {
     const enml = '<en-note><en-todo checked="true"/>Task done</en-note>';
     const blocks = convertEnmlToBlocks(enml, emptyMap);
 
     const checkbox = blocks.find((b) => b.type === "checkListItem");
     expect(checkbox).toBeDefined();
     expect(checkbox?.props?.checked).toBe(true);
+    const content = checkbox?.content as Array<{ text: string }>;
+    expect(content[0].text).toBe("Task done");
   });
 
   it("converts en-media images with URL from map", () => {
@@ -252,5 +254,94 @@ describe("convertEnmlToBlocks", () => {
     const content = blocks[0].content as Array<{ text: string; styles: Record<string, boolean> }>;
     expect(content.find((c) => c.text === "bold")?.styles.bold).toBe(true);
     expect(content.find((c) => c.text === "italic")?.styles.italic).toBe(true);
+  });
+
+  it("extracts text from li > div (Evernote list format)", () => {
+    const enml =
+      "<en-note><ul><li><div>Item text</div></li><li><div>Second item</div></li></ul></en-note>";
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("bulletListItem");
+    const content0 = blocks[0].content as Array<{ text: string }>;
+    expect(content0[0].text).toBe("Item text");
+    const content1 = blocks[1].content as Array<{ text: string }>;
+    expect(content1[0].text).toBe("Second item");
+  });
+
+  it("extracts styled text from li > div", () => {
+    const enml = "<en-note><ul><li><div><b>Bold item</b> text</div></li></ul></en-note>";
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    expect(blocks).toHaveLength(1);
+    const content = blocks[0].content as Array<{
+      text: string;
+      styles: Record<string, boolean>;
+    }>;
+    expect(content[0].text).toBe("Bold item");
+    expect(content[0].styles.bold).toBe(true);
+  });
+
+  it("extracts text from ol > li > div (Evernote ordered list format)", () => {
+    const enml =
+      "<en-note><ol><li><div>First item</div></li><li><div>Second item</div></li></ol></en-note>";
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("numberedListItem");
+    const content0 = blocks[0].content as Array<{ text: string }>;
+    expect(content0[0].text).toBe("First item");
+    const content1 = blocks[1].content as Array<{ text: string }>;
+    expect(content1[0].text).toBe("Second item");
+  });
+
+  it("captures sibling text after en-todo in a div", () => {
+    const enml = '<en-note><div><en-todo checked="false"/>Buy groceries</div></en-note>';
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    const checkbox = blocks.find((b) => b.type === "checkListItem");
+    expect(checkbox).toBeDefined();
+    expect(checkbox?.props?.checked).toBe(false);
+    const content = checkbox?.content as Array<{ text: string }>;
+    expect(content[0].text).toBe("Buy groceries");
+  });
+
+  it("captures styled text after en-todo", () => {
+    const enml = '<en-note><div><en-todo checked="true"/><b>Important task</b></div></en-note>';
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    const checkbox = blocks.find((b) => b.type === "checkListItem");
+    expect(checkbox?.props?.checked).toBe(true);
+    const content = checkbox?.content as Array<{
+      text: string;
+      styles: Record<string, boolean>;
+    }>;
+    expect(content[0].text).toBe("Important task");
+    expect(content[0].styles.bold).toBe(true);
+  });
+
+  it("converts modern task group placeholders to checkListItems", () => {
+    const enml =
+      '<en-note><div style="--en-task-group:true; --en-id:group-abc123;"></div></en-note>';
+    const tasks = [
+      { title: "Task one", checked: false, groupId: "group-abc123" },
+      { title: "Task two", checked: true, groupId: "group-abc123" },
+    ];
+    const blocks = convertEnmlToBlocks(enml, emptyMap, tasks);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("checkListItem");
+    expect(blocks[0].props?.checked).toBe(false);
+    expect((blocks[0].content as Array<{ text: string }>)[0].text).toBe("Task one");
+    expect(blocks[1].props?.checked).toBe(true);
+    expect((blocks[1].content as Array<{ text: string }>)[0].text).toBe("Task two");
+  });
+
+  it("skips task group div when no matching tasks exist", () => {
+    const enml =
+      '<en-note><p>Before</p><div style="--en-task-group:true; --en-id:no-match;"></div><p>After</p></en-note>';
+    const blocks = convertEnmlToBlocks(enml, emptyMap, []);
+
+    expect(blocks.every((b) => b.type === "paragraph")).toBe(true);
   });
 });

--- a/apps/web/__tests__/unit/enml-to-blocknote.test.ts
+++ b/apps/web/__tests__/unit/enml-to-blocknote.test.ts
@@ -344,4 +344,31 @@ describe("convertEnmlToBlocks", () => {
 
     expect(blocks.every((b) => b.type === "paragraph")).toBe(true);
   });
+
+  it("sorts tasks within a group by sortWeight", () => {
+    const enml = '<en-note><div style="--en-task-group:true; --en-id:grp1;"></div></en-note>';
+    const tasks = [
+      { title: "Third", checked: false, groupId: "grp1", sortWeight: "R" },
+      { title: "First", checked: false, groupId: "grp1", sortWeight: "B" },
+      { title: "Second", checked: false, groupId: "grp1", sortWeight: "J" },
+    ];
+    const blocks = convertEnmlToBlocks(enml, emptyMap, tasks);
+
+    expect(blocks).toHaveLength(3);
+    expect((blocks[0].content as Array<{ text: string }>)[0].text).toBe("First");
+    expect((blocks[1].content as Array<{ text: string }>)[0].text).toBe("Second");
+    expect((blocks[2].content as Array<{ text: string }>)[0].text).toBe("Third");
+  });
+
+  it("appends orphan tasks without groupId at the end", () => {
+    const enml = "<en-note><p>Note content</p></en-note>";
+    const tasks = [{ title: "Orphan task", checked: true, groupId: "" }];
+    const blocks = convertEnmlToBlocks(enml, emptyMap, tasks);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("paragraph");
+    expect(blocks[1].type).toBe("checkListItem");
+    expect(blocks[1].props?.checked).toBe(true);
+    expect((blocks[1].content as Array<{ text: string }>)[0].text).toBe("Orphan task");
+  });
 });

--- a/apps/web/__tests__/unit/enml-to-blocknote.test.ts
+++ b/apps/web/__tests__/unit/enml-to-blocknote.test.ts
@@ -282,6 +282,25 @@ describe("convertEnmlToBlocks", () => {
     expect(content[0].styles.bold).toBe(true);
   });
 
+  it("extracts links and br from li content", () => {
+    const enml =
+      '<en-note><ul><li><a href="https://example.com">Link text</a><br/><b>bold</b></li></ul></en-note>';
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    expect(blocks).toHaveLength(1);
+    const content = blocks[0].content as Array<{
+      type: string;
+      text: string;
+      href?: string;
+      styles: Record<string, boolean>;
+    }>;
+    expect(content[0].type).toBe("link");
+    expect(content[0].href).toBe("https://example.com");
+    expect(content[1].text).toBe("\n");
+    expect(content[2].text).toBe("bold");
+    expect(content[2].styles.bold).toBe(true);
+  });
+
   it("extracts text from ol > li > div (Evernote ordered list format)", () => {
     const enml =
       "<en-note><ol><li><div>First item</div></li><li><div>Second item</div></li></ol></en-note>";

--- a/apps/web/__tests__/unit/import-evernote-api.test.ts
+++ b/apps/web/__tests__/unit/import-evernote-api.test.ts
@@ -106,6 +106,7 @@ describe("POST /api/import/evernote", () => {
       created: "2023-01-01T00:00:00.000Z",
       updated: "2023-01-01T00:00:00.000Z",
       resources: [],
+      tasks: [],
     }));
 
     const req = new Request("http://localhost/api/import/evernote", {
@@ -138,6 +139,7 @@ describe("POST /api/import/evernote", () => {
           created: "2023-01-01T00:00:00.000Z",
           updated: "2023-01-01T00:00:00.000Z",
           resources: [],
+          tasks: [],
         },
       ],
     };
@@ -184,6 +186,7 @@ describe("POST /api/import/evernote", () => {
           created: "2023-01-01T00:00:00.000Z",
           updated: "2023-01-01T00:00:00.000Z",
           resources: [],
+          tasks: [],
         },
         {
           title: "Bad Note",
@@ -191,6 +194,7 @@ describe("POST /api/import/evernote", () => {
           created: "2023-01-01T00:00:00.000Z",
           updated: "2023-01-01T00:00:00.000Z",
           resources: [],
+          tasks: [],
         },
       ],
     };
@@ -240,6 +244,7 @@ describe("POST /api/import/evernote", () => {
           created: "2023-01-01T00:00:00.000Z",
           updated: "2023-01-01T00:00:00.000Z",
           resources: [],
+          tasks: [],
         },
       ],
     };
@@ -273,6 +278,7 @@ describe("POST /api/import/evernote", () => {
           created: "2023-01-01T00:00:00.000Z",
           updated: "2023-01-01T00:00:00.000Z",
           resources: [],
+          tasks: [],
         },
       ],
     };
@@ -326,6 +332,7 @@ describe("POST /api/import/evernote", () => {
               fileName: "photo.png",
             },
           ],
+          tasks: [],
         },
       ],
     };
@@ -340,7 +347,7 @@ describe("POST /api/import/evernote", () => {
 
     expect(mockUpload).toHaveBeenCalled();
     expect(mockCreateSignedUrl).toHaveBeenCalled();
-    expect(mockConvertEnmlToBlocks).toHaveBeenCalledWith(expect.any(String), expect.any(Map));
+    expect(mockConvertEnmlToBlocks).toHaveBeenCalledWith(expect.any(String), expect.any(Map), []);
     expect(mockSuccessResponse).toHaveBeenCalledWith(
       expect.objectContaining({ notesImported: 1 }),
       200,
@@ -377,6 +384,7 @@ describe("POST /api/import/evernote", () => {
               fileName: "bad.png",
             },
           ],
+          tasks: [],
         },
       ],
     };
@@ -432,6 +440,7 @@ describe("POST /api/import/evernote", () => {
               fileName: "file.png",
             },
           ],
+          tasks: [],
         },
       ],
     };
@@ -476,6 +485,7 @@ describe("POST /api/import/evernote", () => {
           created: "2023-01-01T00:00:00.000Z",
           updated: "2023-01-01T00:00:00.000Z",
           resources: [],
+          tasks: [],
         },
       ],
     };

--- a/apps/web/__tests__/unit/notebooks-id-api.test.ts
+++ b/apps/web/__tests__/unit/notebooks-id-api.test.ts
@@ -132,7 +132,9 @@ describe("DELETE /api/notebooks/[id]", () => {
       return {
         select: () => ({
           eq: () => ({
-            eq: () => Promise.resolve({ count: 3, error: null }),
+            eq: () => ({
+              eq: () => Promise.resolve({ count: 3, error: null }),
+            }),
           }),
         }),
       };
@@ -157,7 +159,9 @@ describe("DELETE /api/notebooks/[id]", () => {
         return {
           select: () => ({
             eq: () => ({
-              eq: () => Promise.resolve({ count: 0, error: null }),
+              eq: () => ({
+                eq: () => Promise.resolve({ count: 0, error: null }),
+              }),
             }),
           }),
         };

--- a/apps/web/src/app/api/import/evernote/route.ts
+++ b/apps/web/src/app/api/import/evernote/route.ts
@@ -107,7 +107,7 @@ async function importNote(
   }
 
   // Convert ENML to BlockNote blocks
-  const blocks = convertEnmlToBlocks(note.content, attachmentUrlMap);
+  const blocks = convertEnmlToBlocks(note.content, attachmentUrlMap, note.tasks);
 
   // Update note with converted content
   const { error: updateError } = await supabase

--- a/apps/web/src/app/api/notebooks/[id]/route.ts
+++ b/apps/web/src/app/api/notebooks/[id]/route.ts
@@ -46,12 +46,13 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   const { supabase, user } = auth;
   const { id } = await params;
 
-  // Check if notebook has notes
+  // Check if notebook has non-trashed notes
   const { count, error: countError } = await supabase
     .from("notes")
     .select("id", { count: "exact", head: true })
     .eq("notebook_id", id)
-    .eq("user_id", user.id);
+    .eq("user_id", user.id)
+    .eq("is_trashed", false);
 
   if (countError) {
     return errorResponse("Failed to check notebook contents", 500);

--- a/apps/web/src/lib/import/enex-parser.ts
+++ b/apps/web/src/lib/import/enex-parser.ts
@@ -1,4 +1,4 @@
-import type { EnexNote, EnexResource } from "@/lib/import/types";
+import type { EnexNote, EnexResource, EnexTask } from "@/lib/import/types";
 
 /**
  * Parse an Evernote .enex XML string into structured notes.
@@ -39,7 +39,29 @@ function parseNoteElement(noteEl: Element): EnexNote {
     }
   }
 
-  return { title, content, created, updated, resources };
+  const taskElements = noteEl.querySelectorAll("task");
+  const tasks: EnexTask[] = [];
+
+  for (const taskEl of taskElements) {
+    const task = parseTaskElement(taskEl);
+    if (task) {
+      tasks.push(task);
+    }
+  }
+
+  return { title, content, created, updated, resources, tasks };
+}
+
+function parseTaskElement(taskEl: Element): EnexTask | null {
+  const title = taskEl.querySelector("title")?.textContent?.trim() || "";
+  if (!title) return null;
+
+  const taskStatus = taskEl.querySelector("taskStatus")?.textContent?.trim() || "";
+  const checked = taskStatus === "completed";
+  const groupId = taskEl.querySelector("taskGroupNoteLevelID")?.textContent?.trim() || "";
+  const sortWeight = taskEl.querySelector("sortWeight")?.textContent?.trim() || undefined;
+
+  return { title, checked, groupId, sortWeight };
 }
 
 function parseResourceElement(resEl: Element): EnexResource | null {

--- a/apps/web/src/lib/import/enml-to-blocknote.ts
+++ b/apps/web/src/lib/import/enml-to-blocknote.ts
@@ -1,5 +1,7 @@
 import { parseHTML } from "linkedom";
 
+import type { EnexTask } from "@/lib/import/types";
+
 interface InlineContent {
   type: "text" | "link";
   text: string;
@@ -23,9 +25,25 @@ interface TableContent {
  * Convert ENML (Evernote Markup Language) to BlockNote blocks.
  * Uses linkedom for server-side DOM parsing.
  */
-export function convertEnmlToBlocks(enml: string, attachmentUrlMap: Map<string, string>): Block[] {
+export function convertEnmlToBlocks(
+  enml: string,
+  attachmentUrlMap: Map<string, string>,
+  tasks?: EnexTask[],
+): Block[] {
   if (!enml.trim()) {
     return [createParagraph([])];
+  }
+
+  // Build task group map for modern Evernote task format
+  const taskMap = new Map<string, EnexTask[]>();
+  if (tasks) {
+    for (const task of tasks) {
+      if (task.groupId) {
+        const group = taskMap.get(task.groupId) || [];
+        group.push(task);
+        taskMap.set(task.groupId, group);
+      }
+    }
   }
 
   // Strip XML declaration and DOCTYPE
@@ -37,12 +55,16 @@ export function convertEnmlToBlocks(enml: string, attachmentUrlMap: Map<string, 
   const { document } = parseHTML(`<body>${cleaned}</body>`);
   const root = document.querySelector("en-note") || document.body;
 
-  const blocks = processChildren(root, attachmentUrlMap);
+  const blocks = processChildren(root, attachmentUrlMap, taskMap);
 
   return blocks.length > 0 ? blocks : [createParagraph([])];
 }
 
-function processChildren(parent: Element, attachmentUrlMap: Map<string, string>): Block[] {
+function processChildren(
+  parent: Element,
+  attachmentUrlMap: Map<string, string>,
+  taskMap: Map<string, EnexTask[]>,
+): Block[] {
   const blocks: Block[] = [];
 
   for (const node of Array.from(parent.childNodes)) {
@@ -56,7 +78,7 @@ function processChildren(parent: Element, attachmentUrlMap: Map<string, string>)
       const el = node as Element;
       const tag = el.tagName.toLowerCase();
 
-      const converted = convertElement(el, tag, attachmentUrlMap);
+      const converted = convertElement(el, tag, attachmentUrlMap, taskMap);
       if (converted) {
         if (Array.isArray(converted)) {
           blocks.push(...converted);
@@ -74,15 +96,39 @@ function convertElement(
   el: Element,
   tag: string,
   attachmentUrlMap: Map<string, string>,
+  taskMap: Map<string, EnexTask[]>,
 ): Block | Block[] | null {
   switch (tag) {
-    case "div":
+    case "div": {
+      // Check for Evernote task group placeholder
+      const style = el.getAttribute("style") || "";
+      if (style.includes("--en-task-group:true")) {
+        const idMatch = style.match(/--en-id:\s*([^;]+)/);
+        const groupId = idMatch?.[1]?.trim() || "";
+        const groupTasks = taskMap.get(groupId) || [];
+        if (groupTasks.length > 0) {
+          return groupTasks.map((task) => ({
+            type: "checkListItem",
+            props: { checked: task.checked },
+            content: [{ type: "text", text: task.title, styles: {} }],
+          }));
+        }
+        return null; // empty task group, skip
+      }
+      // Fall through to standard block handling
+      const inline = extractInlineContent(el);
+      if (inline.length === 0) {
+        const childBlocks = processChildren(el, attachmentUrlMap, taskMap);
+        return childBlocks.length > 0 ? childBlocks : null;
+      }
+      return createParagraph(inline);
+    }
+
     case "p":
     case "span": {
       const inline = extractInlineContent(el);
       if (inline.length === 0) {
-        // Check for child block elements
-        const childBlocks = processChildren(el, attachmentUrlMap);
+        const childBlocks = processChildren(el, attachmentUrlMap, taskMap);
         return childBlocks.length > 0 ? childBlocks : null;
       }
       return createParagraph(inline);
@@ -96,17 +142,18 @@ function convertElement(
       return createHeading(extractInlineContent(el), 3);
 
     case "ul":
-      return convertList(el, "bulletListItem", attachmentUrlMap);
+      return convertList(el, "bulletListItem", attachmentUrlMap, taskMap);
     case "ol":
-      return convertList(el, "numberedListItem", attachmentUrlMap);
+      return convertList(el, "numberedListItem", attachmentUrlMap, taskMap);
 
     case "en-todo": {
+      // Linkedom parses <en-todo/> as non-void, so text content is inside the element
       const checked = el.getAttribute("checked") === "true";
-      // The text content follows the en-todo tag in the parent
+      const content = extractInlineContent(el);
       return {
         type: "checkListItem",
         props: { checked },
-        content: [],
+        content: content.length > 0 ? content : [{ type: "text", text: "", styles: {} }],
       };
     }
 
@@ -133,7 +180,7 @@ function convertElement(
       if (inline.length > 0) {
         return createParagraph(inline);
       }
-      return processChildren(el, attachmentUrlMap);
+      return processChildren(el, attachmentUrlMap, taskMap);
     }
   }
 }
@@ -142,13 +189,14 @@ function convertList(
   listEl: Element,
   blockType: string,
   attachmentUrlMap: Map<string, string>,
+  taskMap: Map<string, EnexTask[]>,
 ): Block[] {
   const items: Block[] = [];
 
   for (const child of Array.from(listEl.children)) {
     if (child.tagName.toLowerCase() === "li") {
-      const inline = extractInlineContent(child);
-      const nestedBlocks = processNestedLists(child, attachmentUrlMap);
+      const inline = extractListItemContent(child);
+      const nestedBlocks = processNestedLists(child, attachmentUrlMap, taskMap);
 
       items.push({
         type: blockType,
@@ -161,16 +209,64 @@ function convertList(
   return items;
 }
 
-function processNestedLists(li: Element, attachmentUrlMap: Map<string, string>): Block[] {
+function processNestedLists(
+  li: Element,
+  attachmentUrlMap: Map<string, string>,
+  taskMap: Map<string, EnexTask[]>,
+): Block[] {
   const nested: Block[] = [];
   for (const child of Array.from(li.children)) {
     const tag = child.tagName.toLowerCase();
     if (tag === "ul" || tag === "ol") {
       const type = tag === "ul" ? "bulletListItem" : "numberedListItem";
-      nested.push(...convertList(child, type, attachmentUrlMap));
+      nested.push(...convertList(child, type, attachmentUrlMap, taskMap));
     }
   }
   return nested;
+}
+
+/**
+ * Extract inline content from a list item element.
+ * Unlike extractInlineContent, this treats <div> children as inline containers
+ * because Evernote wraps list item text in <div> tags: <li><div>text</div></li>
+ */
+function extractListItemContent(li: Element): InlineContent[] {
+  const result: InlineContent[] = [];
+
+  for (const node of Array.from(li.childNodes)) {
+    if (node.nodeType === 3) {
+      const text = (node as Text).textContent || "";
+      if (text) {
+        result.push({ type: "text", text, styles: {} });
+      }
+    } else if (node.nodeType === 1) {
+      const childEl = node as Element;
+      const tag = childEl.tagName.toLowerCase();
+
+      if (tag === "div") {
+        // Evernote wraps li text in <div> — extract inline content from within
+        result.push(...extractInlineContent(childEl));
+      } else if (["ul", "ol", "table", "en-media"].includes(tag)) {
+        continue; // handled by processNestedLists
+      } else {
+        const styles = getInlineStyles(childEl);
+        if (tag === "a") {
+          const href = childEl.getAttribute("href") || "";
+          const text = childEl.textContent || "";
+          result.push({ type: "link", text, href, styles });
+        } else if (tag === "br") {
+          result.push({ type: "text", text: "\n", styles: {} });
+        } else {
+          const innerContent = extractInlineContent(childEl);
+          for (const item of innerContent) {
+            result.push({ ...item, styles: { ...item.styles, ...styles } });
+          }
+        }
+      }
+    }
+  }
+
+  return result;
 }
 
 function convertEnMedia(el: Element, attachmentUrlMap: Map<string, string>): Block | null {
@@ -241,8 +337,8 @@ function extractInlineContent(el: Element): InlineContent[] {
       const childEl = node as Element;
       const tag = childEl.tagName.toLowerCase();
 
-      // Skip block-level elements in inline extraction
-      if (["ul", "ol", "div", "table", "en-media"].includes(tag)) {
+      // Skip block-level elements and en-todo in inline extraction
+      if (["ul", "ol", "div", "table", "en-media", "en-todo"].includes(tag)) {
         continue;
       }
 

--- a/apps/web/src/lib/import/enml-to-blocknote.ts
+++ b/apps/web/src/lib/import/enml-to-blocknote.ts
@@ -36,13 +36,20 @@ export function convertEnmlToBlocks(
 
   // Build task group map for modern Evernote task format
   const taskMap = new Map<string, EnexTask[]>();
+  const orphanTasks: EnexTask[] = [];
   if (tasks) {
     for (const task of tasks) {
       if (task.groupId) {
         const group = taskMap.get(task.groupId) || [];
         group.push(task);
         taskMap.set(task.groupId, group);
+      } else {
+        orphanTasks.push(task);
       }
+    }
+    // Sort tasks within each group by sortWeight
+    for (const group of taskMap.values()) {
+      group.sort((a, b) => (a.sortWeight ?? "").localeCompare(b.sortWeight ?? ""));
     }
   }
 
@@ -56,6 +63,15 @@ export function convertEnmlToBlocks(
   const root = document.querySelector("en-note") || document.body;
 
   const blocks = processChildren(root, attachmentUrlMap, taskMap);
+
+  // Append orphan tasks (tasks without a groupId) at the end
+  for (const task of orphanTasks) {
+    blocks.push({
+      type: "checkListItem",
+      props: { checked: task.checked },
+      content: [{ type: "text", text: task.title, styles: {} }],
+    });
+  }
 
   return blocks.length > 0 ? blocks : [createParagraph([])];
 }

--- a/apps/web/src/lib/import/types.ts
+++ b/apps/web/src/lib/import/types.ts
@@ -5,12 +5,20 @@ export interface EnexResource {
   fileName: string;
 }
 
+export interface EnexTask {
+  title: string;
+  checked: boolean; // derived from taskStatus === "completed"
+  groupId: string; // taskGroupNoteLevelID — matches placeholder div in ENML
+  sortWeight?: string; // for ordering within a group
+}
+
 export interface EnexNote {
   title: string;
   content: string; // raw ENML string
   created: string; // ISO timestamp
   updated: string; // ISO timestamp
   resources: EnexResource[];
+  tasks: EnexTask[];
 }
 
 export interface ImportBatchRequest {


### PR DESCRIPTION
## Summary
- **Evernote import**: Lists (`<li><div>text</div></li>`) and tasks (both legacy `<en-todo>` and modern `<task>` elements) are now imported correctly as numbered/bullet list items and checkboxes
- **Notebook deletion**: Fixed "Cannot delete notebook with notes" error showing after all notes were trashed — the count query now excludes soft-deleted notes

## Test plan
- [ ] Import a `.enex` file with ordered/unordered lists — verify list text appears
- [ ] Import a `.enex` file with tasks/checkboxes — verify they appear as check list items with correct checked state
- [ ] Delete all notes in a notebook (trash them), then delete the notebook — verify it succeeds
- [ ] Existing import tests pass (616 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task import from Evernote files now supported, preserving task status and group organization

* **Bug Fixes**
  * Notebook deletion now correctly excludes trashed notes during validation

* **Tests**
  * Added unit tests for task parsing and conversion workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->