### PR TITLE
fix: allow /api/webhooks routes to bypass auth middleware

### DIFF
--- a/apps/web/__tests__/unit/middleware.test.ts
+++ b/apps/web/__tests__/unit/middleware.test.ts
@@ -41,6 +41,7 @@ describe("Auth middleware", () => {
       "/forgot-password",
       "/reset-password",
       "/api/health",
+      "/api/webhooks/new-signup",
     ];
 
     for (const route of publicRoutes) {

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -11,6 +11,7 @@ const PUBLIC_ROUTES = [
   "/reset-password",
   "/api/health",
   "/api/mcp",
+  "/api/webhooks",
 ];
 
 function isPublicRoute(pathname: string): boolean {


### PR DESCRIPTION
## Summary

Supabase Database Webhooks call `POST /api/webhooks/new-signup` with a shared `WEBHOOK_SECRET` header — they don't carry a Supabase session. The auth middleware was redirecting these POSTs to `/login` (307), which `pg_net` saw as 405 when following the redirect. Result: the admin signup-notification email never fired in the merged approval flow (#290).

Adding `/api/webhooks` to `PUBLIC_ROUTES` lets the webhook handler's own secret verification authorize the request. Covers current and future webhook receivers under that prefix.

Found while E2E-testing the approval flow: two test signups fired the trigger, pg_net sent the POST, got 307 → /login, zero admin emails delivered.

## Test plan

- [x] `pnpm test` — middleware test now includes `/api/webhooks/new-signup` in the public-routes case
- [x] `pnpm lint && pnpm typecheck`
- [ ] After deploy: re-run E2E signup against prod, verify admin email arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook endpoints are now publicly accessible, enabling external services and third-party integrations to communicate with the platform without authentication.

* **Tests**
  * Updated test suite to verify webhook routes are properly recognized as public routes and can be accessed without user authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->