### PR TITLE
chore: add account-approval E2E regression runbook

### DIFF
--- a/apps/web/e2e/regression/account-approval/01-signup.mjs
+++ b/apps/web/e2e/regression/account-approval/01-signup.mjs
@@ -58,9 +58,16 @@ if (last.status !== 200) {
 
 let testUserId;
 try {
-  testUserId = JSON.parse(last.body).id;
+  const parsed = JSON.parse(last.body);
+  testUserId = parsed?.id ?? parsed?.user?.id;
 } catch {
-  console.error("FAIL: could not parse signup response body");
+  console.error(`FAIL: could not parse signup response body:\n${last.body}`);
+  process.exit(1);
+}
+if (typeof testUserId !== "string" || testUserId.length === 0) {
+  console.error(
+    `FAIL: signup response did not contain a user id (neither .id nor .user.id):\n${last.body}`,
+  );
   process.exit(1);
 }
 

--- a/apps/web/e2e/regression/account-approval/01-signup.mjs
+++ b/apps/web/e2e/regression/account-approval/01-signup.mjs
@@ -1,0 +1,78 @@
+// Signup a fresh test user on https://drafto.eu via the public UI.
+// Writes /tmp/e2e-approval/state.json with testEmail + testUserId for
+// downstream scripts to pick up.
+//
+// Usage: node 01-signup.mjs
+// Requires: Playwright's chromium installed (`pnpm exec playwright install chromium`)
+
+import { chromium } from "playwright";
+import fs from "node:fs";
+import path from "node:path";
+
+const STATE_DIR = "/tmp/e2e-approval";
+fs.mkdirSync(STATE_DIR, { recursive: true });
+
+const stamp = Date.now();
+const testEmail = `jakub+draftoe2e-${stamp}@anderwald.info`;
+const testPassword = `Regression-${stamp}-pw`;
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext();
+const page = await context.newPage();
+
+const signupResponses = [];
+page.on("response", async (resp) => {
+  if (resp.url().includes("/auth/v1/signup")) {
+    const body = await resp.text().catch(() => "");
+    signupResponses.push({
+      status: resp.status(),
+      body: body.slice(0, 800),
+    });
+  }
+});
+
+await page.goto("https://drafto.eu/signup", { waitUntil: "networkidle", timeout: 45000 });
+await page.waitForSelector("#email", { timeout: 15000 });
+await page.locator("#email").fill(testEmail);
+await page.locator("#password").fill(testPassword);
+await page.locator("form").evaluate((f) => f.requestSubmit());
+
+await Promise.race([
+  page.waitForURL(/waiting-for-approval|login/, { timeout: 20000 }).catch(() => null),
+  page.waitForTimeout(20000),
+]);
+await page.waitForTimeout(2000);
+
+const finalUrl = page.url();
+await browser.close();
+
+if (signupResponses.length === 0) {
+  console.error("FAIL: no POST to /auth/v1/signup was observed");
+  process.exit(1);
+}
+const last = signupResponses[signupResponses.length - 1];
+if (last.status !== 200) {
+  console.error(`FAIL: signup returned ${last.status}\n${last.body}`);
+  process.exit(1);
+}
+
+let testUserId;
+try {
+  testUserId = JSON.parse(last.body).id;
+} catch {
+  console.error("FAIL: could not parse signup response body");
+  process.exit(1);
+}
+
+const state = {
+  testEmail,
+  testPassword,
+  testUserId,
+  finalUrl,
+  createdAt: new Date().toISOString(),
+};
+fs.writeFileSync(path.join(STATE_DIR, "state.json"), JSON.stringify(state, null, 2));
+console.log(`OK signup`);
+console.log(`  testEmail=${testEmail}`);
+console.log(`  testUserId=${testUserId}`);
+console.log(`  finalUrl=${finalUrl}`);

--- a/apps/web/e2e/regression/account-approval/02-verify-webhook.mjs
+++ b/apps/web/e2e/regression/account-approval/02-verify-webhook.mjs
@@ -1,0 +1,78 @@
+// Verify that the new-signup webhook fired successfully.
+// Polls auth.users + profiles for the new row, then net._http_response
+// for a 200 from the webhook.
+//
+// Usage: node 02-verify-webhook.mjs
+// Requires: `supabase link --project-ref tbmjbxxseonkciqovnpl` (prod) already done.
+
+import fs from "node:fs";
+import { execSync } from "node:child_process";
+
+const state = JSON.parse(fs.readFileSync("/tmp/e2e-approval/state.json", "utf8"));
+
+function sbQuery(sql) {
+  const raw = execSync(`supabase db query --linked --output json ${JSON.stringify(sql)}`, {
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  // supabase CLI emits a JSON envelope with rows[]; strip stderr warnings
+  const jsonStart = raw.indexOf("{");
+  if (jsonStart < 0) throw new Error(`unexpected CLI output:\n${raw}`);
+  return JSON.parse(raw.slice(jsonStart)).rows ?? [];
+}
+
+async function pollUntil(label, predicate, attempts = 15, delayMs = 2000) {
+  for (let i = 0; i < attempts; i++) {
+    const result = predicate();
+    if (result) return result;
+    if (i < attempts - 1) await new Promise((r) => setTimeout(r, delayMs));
+  }
+  throw new Error(`timeout waiting for: ${label}`);
+}
+
+const startedAt = new Date(state.createdAt).toISOString();
+
+// 1. profile row auto-created
+const profileRow = await pollUntil("profiles row for test user", () => {
+  const rows = sbQuery(
+    `select id, is_approved from public.profiles where id = '${state.testUserId}';`,
+  );
+  return rows[0] ?? null;
+});
+if (profileRow.is_approved !== false) {
+  console.error(`FAIL: profile already is_approved=true (should be false)`);
+  process.exit(1);
+}
+console.log("OK profile row created with is_approved=false");
+
+// 2. webhook response in pg_net
+const webhookResp = await pollUntil(
+  "pg_net webhook response",
+  () => {
+    const rows = sbQuery(
+      `select status_code, substring(content, 1, 200) as body
+       from net._http_response
+       where created > '${startedAt}'::timestamptz
+       order by created desc
+       limit 1;`,
+    );
+    return rows[0] ?? null;
+  },
+  20,
+);
+
+if (webhookResp.status_code !== 200) {
+  console.error(`FAIL: webhook returned ${webhookResp.status_code}\n  body: ${webhookResp.body}`);
+  process.exit(1);
+}
+if (!webhookResp.body?.includes('"emailSent":true')) {
+  console.error(`FAIL: webhook body did not indicate emailSent=true\n  body: ${webhookResp.body}`);
+  process.exit(1);
+}
+console.log(`OK webhook returned 200 with emailSent=true`);
+console.log("");
+console.log("Now check Gmail (via Claude Code): admin notification should be in your inbox.");
+console.log(`  Search query: from:hello@drafto.eu subject:"New Drafto signup" newer_than:10m`);
+console.log(
+  `  Expected recipient: jakub@anderwald.info (plus test user ${state.testEmail} got the Supabase confirmation email)`,
+);

--- a/apps/web/e2e/regression/account-approval/03-verify-approved.mjs
+++ b/apps/web/e2e/regression/account-approval/03-verify-approved.mjs
@@ -13,6 +13,7 @@ function sbQuery(sql) {
     encoding: "utf8",
   });
   const jsonStart = raw.indexOf("{");
+  if (jsonStart < 0) throw new Error(`unexpected CLI output:\n${raw}`);
   return JSON.parse(raw.slice(jsonStart)).rows ?? [];
 }
 

--- a/apps/web/e2e/regression/account-approval/03-verify-approved.mjs
+++ b/apps/web/e2e/regression/account-approval/03-verify-approved.mjs
@@ -1,0 +1,37 @@
+// Poll profiles.is_approved until it flips to true, which happens after
+// the admin clicks the approve link from the notification email.
+//
+// Usage: node 03-verify-approved.mjs
+
+import fs from "node:fs";
+import { execSync } from "node:child_process";
+
+const state = JSON.parse(fs.readFileSync("/tmp/e2e-approval/state.json", "utf8"));
+
+function sbQuery(sql) {
+  const raw = execSync(`supabase db query --linked --output json ${JSON.stringify(sql)}`, {
+    encoding: "utf8",
+  });
+  const jsonStart = raw.indexOf("{");
+  return JSON.parse(raw.slice(jsonStart)).rows ?? [];
+}
+
+const deadline = Date.now() + 120_000;
+while (Date.now() < deadline) {
+  const rows = sbQuery(
+    `select is_approved, updated_at from public.profiles where id = '${state.testUserId}';`,
+  );
+  if (rows[0]?.is_approved === true) {
+    console.log(`OK approved at ${rows[0].updated_at}`);
+    console.log("");
+    console.log("Now check Gmail (via Claude Code):");
+    console.log(
+      `  Search query: from:hello@drafto.eu subject:"account is approved" newer_than:10m`,
+    );
+    console.log(`  Expected recipient: ${state.testEmail}`);
+    process.exit(0);
+  }
+  await new Promise((r) => setTimeout(r, 3000));
+}
+console.error("TIMEOUT: is_approved did not flip within 2 min — did the admin click the link?");
+process.exit(1);

--- a/apps/web/e2e/regression/account-approval/99-cleanup.mjs
+++ b/apps/web/e2e/regression/account-approval/99-cleanup.mjs
@@ -1,0 +1,15 @@
+// Delete all regression test users from prod.
+//
+// Usage: node 99-cleanup.mjs
+
+import { execSync } from "node:child_process";
+
+const raw = execSync(
+  `supabase db query --linked --output json "delete from auth.users where email like 'jakub+draftoe2e-%@anderwald.info' returning id, email;"`,
+  { encoding: "utf8" },
+);
+const jsonStart = raw.indexOf("{");
+const rows = JSON.parse(raw.slice(jsonStart)).rows ?? [];
+
+console.log(`Deleted ${rows.length} test user(s):`);
+for (const r of rows) console.log(`  ${r.email}`);

--- a/apps/web/e2e/regression/account-approval/99-cleanup.mjs
+++ b/apps/web/e2e/regression/account-approval/99-cleanup.mjs
@@ -9,6 +9,7 @@ const raw = execSync(
   { encoding: "utf8" },
 );
 const jsonStart = raw.indexOf("{");
+if (jsonStart < 0) throw new Error(`unexpected CLI output:\n${raw}`);
 const rows = JSON.parse(raw.slice(jsonStart)).rows ?? [];
 
 console.log(`Deleted ${rows.length} test user(s):`);

--- a/apps/web/e2e/regression/account-approval/README.md
+++ b/apps/web/e2e/regression/account-approval/README.md
@@ -62,8 +62,8 @@ Test emails use the form `jakub+draftoe2e-<timestamp>@anderwald.info`. Gmail-sty
 ## What each script does
 
 - **`01-signup.mjs`** — Launches headless Chromium, navigates to `https://drafto.eu/signup`, fills `jakub+draftoe2e-<ts>@anderwald.info` + a random password, submits the form via `form.requestSubmit()` (more reliable than button click), captures the Supabase signup response, and saves state to `/tmp/e2e-approval/state.json`.
-- **`02-verify-webhook.mjs`** — Polls `auth.users` + `public.profiles` for the new row, then polls `net._http_response` for a 200 response from the webhook. Fails loudly if the response is 307/401/405 or if it doesn't show up within 30s.
-- **`03-verify-approved.mjs`** — Polls `profiles.is_approved` until it flips to `true` (fails after 60s if the admin hasn't clicked yet).
+- **`02-verify-webhook.mjs`** — Polls `auth.users` + `public.profiles` for the new row, then polls `net._http_response` for a 200 response from the webhook. Fails loudly if the response is 307/401/405 or if it doesn't show up within ~40s.
+- **`03-verify-approved.mjs`** — Polls `profiles.is_approved` until it flips to `true` (fails after 2 min if the admin hasn't clicked yet).
 - **`99-cleanup.mjs`** — `DELETE FROM auth.users WHERE email LIKE 'jakub+draftoe2e-%@anderwald.info';` — relies on the FK cascade to clean `profiles`.
 
 ## Known gotchas (lessons from the first run)

--- a/apps/web/e2e/regression/account-approval/README.md
+++ b/apps/web/e2e/regression/account-approval/README.md
@@ -1,0 +1,85 @@
+# Account Approval — End-to-End Regression Test
+
+Semi-automated regression runbook for the full signup → admin-notification → one-click-approve → user-confirmed flow introduced in PR #290 and fixed in PR #292.
+
+**Why not a Playwright test in CI?** Verifying that emails actually leave the system and land in the admin's inbox requires a real Gmail account. CI can't read it. These scripts are designed to be run locally via Claude Code, which has a Gmail MCP tool for email assertions.
+
+## What this test covers
+
+1. Public signup form submission (`/signup` → Supabase Auth `/auth/v1/signup`)
+2. `handle_new_user` trigger → `public.profiles` INSERT
+3. `notify_admin_new_signup` trigger → `net.http_post` → `/api/webhooks/new-signup`
+4. Webhook endpoint (bypasses auth middleware, verifies `WEBHOOK_SECRET`)
+5. Admin notification email delivery (Resend → admin inbox)
+6. One-click approve link (signed token + admin-session guard)
+7. User-approved email delivery
+8. Pending-state gate (idempotent re-clicks don't re-email)
+9. Cleanup of the test user
+
+## Prerequisites
+
+| Requirement                                          | How                                                                                                                                              |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Linked prod Supabase project                         | `pnpm supabase:link:prod`                                                                                                                        |
+| Vault secrets populated on prod                      | `select count(*) from vault.decrypted_secrets where name in ('webhook_url','webhook_secret');` → must return 2                                   |
+| `main` deployed to Vercel with middleware fix (#292) | `curl -sw '%{http_code}' -X POST -H 'x-webhook-secret: wrong' https://drafto.eu/api/webhooks/new-signup -d '{}'` → must return **401** (not 307) |
+| Admin email is `jakub@anderwald.info`                | `select email from auth.users where id in (select id from profiles where is_admin=true);`                                                        |
+| Node + Playwright installed                          | `pnpm install` + `pnpm exec playwright install chromium`                                                                                         |
+
+## Running the test
+
+From this directory:
+
+```bash
+# 1. Sign up a fresh test user via the public UI
+node 01-signup.mjs
+# → writes /tmp/e2e-approval/state.json with testEmail + testUserId
+
+# 2. Poll pg_net + Supabase until webhook returns 200 and user row exists
+node 02-verify-webhook.mjs
+
+# 3. Ask Claude Code to read Gmail and confirm the admin email arrived:
+#    "Search for 'from:hello@drafto.eu subject:\"New Drafto signup\" newer_than:5m'"
+
+# 4. Extract the approve URL from that email and open it in the admin's
+#    signed-in browser. Claude Code can paste the URL for you; you click.
+#    Expected: redirect to /admin?approved=approved, green flash banner.
+
+# 5. Poll the profile row to confirm the flip
+node 03-verify-approved.mjs
+
+# 6. Ask Claude Code: "Search Gmail for 'Your Drafto account is approved newer_than:5m'"
+#    Must arrive at jakub+<stamp>@anderwald.info
+
+# 7. Cleanup
+node 99-cleanup.mjs
+```
+
+## Test email addressing
+
+Test emails use the form `jakub+draftoe2e-<timestamp>@anderwald.info`. Gmail-style plus-addressing routes these to `jakub@anderwald.info`'s inbox, so Supabase auth confirmations, the admin notification, and the user-approved email all land where Claude Code can read them via the Gmail MCP tool.
+
+## What each script does
+
+- **`01-signup.mjs`** — Launches headless Chromium, navigates to `https://drafto.eu/signup`, fills `jakub+draftoe2e-<ts>@anderwald.info` + a random password, submits the form via `form.requestSubmit()` (more reliable than button click), captures the Supabase signup response, and saves state to `/tmp/e2e-approval/state.json`.
+- **`02-verify-webhook.mjs`** — Polls `auth.users` + `public.profiles` for the new row, then polls `net._http_response` for a 200 response from the webhook. Fails loudly if the response is 307/401/405 or if it doesn't show up within 30s.
+- **`03-verify-approved.mjs`** — Polls `profiles.is_approved` until it flips to `true` (fails after 60s if the admin hasn't clicked yet).
+- **`99-cleanup.mjs`** — `DELETE FROM auth.users WHERE email LIKE 'jakub+draftoe2e-%@anderwald.info';` — relies on the FK cascade to clean `profiles`.
+
+## Known gotchas (lessons from the first run)
+
+- **Middleware must exempt `/api/webhooks`** or the trigger gets 307 → /login (redirected) → pg_net follows as GET → 405. Verified in prerequisites.
+- **Supabase vault secrets can be wiped across sessions** in edge cases (exact cause unknown — possibly a Supabase-internal rekey after migrations). Always run the vault `count(*)` prerequisite check first. Re-insert with `select vault.create_secret(...)` if missing; values are in `~/drafto-secrets/account-approval-secrets.env`.
+- **Supabase rate-limits signups to 30 per 5 min per IP**. Don't run this test in a tight loop.
+- **The `+` in plus-addressing is valid** — Supabase accepts it, Resend delivers it. Don't be tempted to strip it "just in case".
+- **Query the right Supabase project** before asserting DB state. `pnpm supabase:link:prod` returns silently on success; `supabase projects list` shows the `●` marker next to the currently-linked project.
+
+## Failure modes + triage
+
+| Symptom                                               | Check                                                                                                                                                            |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `02-verify-webhook.mjs` reports 307/401/405           | Middleware fix rolled back, or `WEBHOOK_SECRET` drifted between Vercel and vault                                                                                 |
+| No admin email in Gmail but webhook returned 200      | Resend delivery logs (resend.com → Logs). DKIM/SPF records may have been removed.                                                                                |
+| User row created but trigger didn't fire              | `select tgenabled from pg_trigger where tgname = 'on_profile_insert_notify_admin';` — must be `O` (enabled)                                                      |
+| Approve link returns `error=invalid_or_expired_token` | `APPROVAL_LINK_SECRET` drifted between the signing deploy and the verifying deploy — happens if someone rotated the secret without also rotating the server side |
+| Approve link returns `error=forbidden`                | Admin profile doesn't have `is_admin=true`, or the admin isn't signed in at the moment of click                                                                  |


### PR DESCRIPTION
## Summary

Captures the semi-automated flow used to verify the account approval feature end-to-end on prod (after PRs #290 + #292), so future changes to any link in the chain can be re-verified without reinventing the orchestration.

Lives under `apps/web/e2e/regression/account-approval/`:

- `README.md` — prerequisites, run steps, failure-mode triage
- `01-signup.mjs` — Playwright: public signup form submit on drafto.eu with proper plus-addressed test email
- `02-verify-webhook.mjs` — polls `auth.users` + `public.profiles` + `net._http_response` for the trigger chain: profile auto-created, webhook returned **200** with `emailSent:true`
- `03-verify-approved.mjs` — polls `profiles.is_approved` until the admin clicks the emailed approve link
- `99-cleanup.mjs` — deletes all `jakub+draftoe2e-%@anderwald.info` users (cascade handles the profile row)

## Why not a CI Playwright test

Verifying emails actually leave the system and land in the admin's inbox requires a real Gmail account. CI can't read it. Meant to be run manually via Claude Code (Gmail MCP) after meaningful changes to the approval flow, the webhook endpoint, the pg_net trigger, or Resend/SMTP config.

## Test plan

- [x] All `.mjs` scripts pass `node --check`
- [x] `99-cleanup.mjs` smoke-tested against prod — returns 0 deleted when nothing matches
- [x] README includes triage table for every failure mode encountered during the first live run (middleware 307, vault-wipe, rate limit, wrong-project queries, email aliasing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end testing suite for the account approval workflow, including signup validation, webhook verification, approval status checks, and test cleanup utilities.

* **Documentation**
  * Added detailed runbook documentation for executing account approval regression tests, including prerequisites, step-by-step procedures, state management, polling strategies, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->