### PR TITLE
fix: use semantic design tokens on privacy/support pages and oauth divider

### DIFF
--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -8,12 +8,12 @@ export const metadata: Metadata = {
 export default function PrivacyPolicyPage() {
   return (
     <main className="mx-auto max-w-2xl px-6 py-16">
-      <h1 className="mb-2 text-3xl font-bold text-stone-900 dark:text-stone-100">Privacy Policy</h1>
-      <p className="mb-8 text-sm text-stone-500 dark:text-stone-400">
+      <h1 className="text-fg mb-2 text-3xl font-bold">Privacy Policy</h1>
+      <p className="text-fg-muted mb-8 text-sm">
         Effective date: March 8, 2026 &middot; Last updated: March 8, 2026
       </p>
 
-      <div className="prose prose-stone dark:prose-invert max-w-none">
+      <div className="prose dark:prose-invert max-w-none">
         <p>
           Drafto (&ldquo;we&rdquo;, &ldquo;our&rdquo;, &ldquo;us&rdquo;) operates the Drafto mobile
           application and the drafto.eu website (collectively, the &ldquo;Service&rdquo;). This

--- a/apps/web/src/app/support/page.tsx
+++ b/apps/web/src/app/support/page.tsx
@@ -8,12 +8,10 @@ export const metadata: Metadata = {
 export default function SupportPage() {
   return (
     <main className="mx-auto max-w-2xl px-6 py-16">
-      <h1 className="mb-2 text-3xl font-bold text-stone-900 dark:text-stone-100">Support</h1>
-      <p className="mb-8 text-stone-600 dark:text-stone-400">
-        Need help with Drafto? We&apos;re here for you.
-      </p>
+      <h1 className="text-fg mb-2 text-3xl font-bold">Support</h1>
+      <p className="text-fg-muted mb-8">Need help with Drafto? We&apos;re here for you.</p>
 
-      <div className="prose prose-stone dark:prose-invert max-w-none">
+      <div className="prose dark:prose-invert max-w-none">
         <h2>Contact Us</h2>
         <p>
           For questions, bug reports, or feature requests, email us at{" "}

--- a/apps/web/src/components/auth/oauth-buttons.tsx
+++ b/apps/web/src/components/auth/oauth-buttons.tsx
@@ -75,7 +75,7 @@ export function OAuthButtons({ className }: OAuthButtonsProps) {
           <div className="border-border w-full border-t" />
         </div>
         <div className="relative flex justify-center text-sm">
-          <span className="bg-bg-card text-fg-muted px-2">or continue with</span>
+          <span className="bg-bg text-fg-muted px-2">or continue with</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Wave 1A of design system remediation. Fixes three web-side violations flagged by a design-token audit:

- **OAuth divider** (`apps/web/src/components/auth/oauth-buttons.tsx`): the floating "or continue with" label used `bg-bg-card`, which is **not defined** in `apps/web/src/app/globals.css` (grep confirms only `--color-bg`, `--color-bg-subtle`, `--color-bg-muted`). The label was therefore rendered transparent on top of the divider line. Swapped to `bg-bg` so it sits opaque on the card surface.
- **Privacy page** (`apps/web/src/app/privacy/page.tsx`) and **support page** (`apps/web/src/app/support/page.tsx`): both used raw Tailwind `stone-*` palette classes (`text-stone-900 dark:text-stone-100`, `text-stone-500 dark:text-stone-400`, etc.) instead of the semantic tokens enforced by CLAUDE.md's design-system rules. Replaced with `text-fg` / `text-fg-muted`. Also dropped `prose-stone` from the prose wrapper (kept `prose dark:prose-invert`) to match the rest of the app — the `/design-system` showcase page doesn't use `prose-stone` either.

## Out of scope / follow-up

`apps/web/src/components/ui/button.tsx` uses `text-white` for `primary`/`danger`/`success` variants. This is visually correct (white text on colored backgrounds) but bypasses the semantic color system. Left as-is for now; a future PR could introduce a `text-fg-on-primary` semantic token (or equivalent) if we want true token purity on button variants. Keeping this PR minimal.

## Test plan

- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm typecheck` passes
- [x] `cd apps/web && pnpm test` — 678 tests pass
- [ ] Visual check `/login` in light + dark — "or continue with" label now opaque over divider
- [ ] Visual check `/privacy` in light + dark — headings and subtext use foreground tokens, no palette shift
- [ ] Visual check `/support` in light + dark — same as above

## Audit references

- Undefined token `bg-bg-card` in `oauth-buttons.tsx:78`
- Raw `stone-*` classes + `prose-stone` on `privacy/page.tsx` and `support/page.tsx`