### PR TITLE
feat: rebrand transactional emails with design system palette

### DIFF
--- a/apps/web/__tests__/unit/email-templates.test.ts
+++ b/apps/web/__tests__/unit/email-templates.test.ts
@@ -37,6 +37,32 @@ describe("email templates", () => {
       const out = newSignupAdminEmail({ ...baseInput, userDisplayName: null });
       expect(out.html).not.toContain("Name");
     });
+
+    it("uses Drafto design system colors (indigo primary, warm neutrals)", () => {
+      const out = newSignupAdminEmail(baseInput);
+      // Uses Drafto primary indigo
+      expect(out.html).toContain("#3525cd");
+      // Uses warm neutral backgrounds
+      expect(out.html).toContain("#fff8f5");
+      expect(out.html).toContain("#fcf2eb");
+      // Does not use the previous generic palette
+      expect(out.html).not.toContain("#2563eb");
+      expect(out.html).not.toContain("#f4f4f5");
+      expect(out.html).not.toContain("#fafafa");
+      expect(out.html).not.toContain("#18181b");
+    });
+
+    it("includes a non-empty plaintext alternative", () => {
+      const out = newSignupAdminEmail(baseInput);
+      expect(out.text.length).toBeGreaterThan(0);
+      expect(out.text).toContain("New Drafto signup");
+    });
+
+    it("renders the shared Drafto footer", () => {
+      const out = newSignupAdminEmail(baseInput);
+      expect(out.html).toContain("drafto.eu");
+      expect(out.html).toContain("Drafto");
+    });
   });
 
   describe("userApprovedEmail", () => {
@@ -66,6 +92,37 @@ describe("email templates", () => {
       });
       expect(out.html).not.toContain("<b>x</b>");
       expect(out.html).toContain("&lt;b&gt;x&lt;/b&gt;");
+    });
+
+    it("uses Drafto design system colors (indigo primary, warm neutrals)", () => {
+      const out = userApprovedEmail({
+        displayName: "Jane",
+        loginUrl: "https://drafto.eu/login",
+      });
+      expect(out.html).toContain("#3525cd");
+      expect(out.html).toContain("#fff8f5");
+      expect(out.html).not.toContain("#2563eb");
+      expect(out.html).not.toContain("#f4f4f5");
+      expect(out.html).not.toContain("#fafafa");
+      expect(out.html).not.toContain("#18181b");
+    });
+
+    it("includes a non-empty plaintext alternative", () => {
+      const out = userApprovedEmail({
+        displayName: "Jane",
+        loginUrl: "https://drafto.eu/login",
+      });
+      expect(out.text.length).toBeGreaterThan(0);
+      expect(out.text).toContain("Jane");
+      expect(out.text).toContain("https://drafto.eu/login");
+    });
+
+    it("renders the shared Drafto footer", () => {
+      const out = userApprovedEmail({
+        displayName: "Jane",
+        loginUrl: "https://drafto.eu/login",
+      });
+      expect(out.html).toContain("drafto.eu");
     });
   });
 });

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -82,6 +82,7 @@
 }
 
 @theme inline {
+  /* Palette — kept in sync manually with apps/web/src/lib/email/templates.ts (EMAIL_COLORS). See ADR 0020. */
   /* Primary (Indigo) */
   --color-primary-50: #ede8ff;
   --color-primary-100: #dbd1ff;

--- a/apps/web/src/lib/email/SUPABASE_TEMPLATES.md
+++ b/apps/web/src/lib/email/SUPABASE_TEMPLATES.md
@@ -1,0 +1,205 @@
+# Supabase Auth Email Templates — Branding Runbook
+
+The Supabase Auth email templates (Confirm signup, Reset password, Magic link, Reauthentication) live in the Supabase Dashboard and are **not** checked into this repository. They therefore cannot be updated via a PR. This file is the canonical runbook for keeping them visually consistent with Drafto's code-rendered transactional emails (`apps/web/src/lib/email/templates.ts`).
+
+See [ADR 0020 — Email Design Tokens](../../../../../docs/adr/0020-email-design-tokens.md) for rationale.
+
+## Which templates need Drafto branding
+
+Supabase Auth fires these four templates when users take the corresponding auth action:
+
+1. **Confirm signup** — sent after a new email+password signup (sign-up confirmation link).
+2. **Reset password** — sent when a user requests a password reset.
+3. **Magic link** — sent when a user requests a passwordless sign-in link.
+4. **Reauthentication** — sent when Supabase needs to verify an in-session identity (e.g. sensitive setting changes).
+
+Each template supports `{{ .ConfirmationURL }}`, `{{ .Token }}`, `{{ .TokenHash }}`, `{{ .Email }}`, and `{{ .SiteURL }}` variables depending on the type.
+
+## Canonical palette (copy into each template)
+
+These hex values mirror `EMAIL_COLORS` in `templates.ts`. Do **not** invent new shades in the dashboard.
+
+| Role       | Hex       | Use for                                  |
+| ---------- | --------- | ---------------------------------------- |
+| Primary    | `#3525cd` | Button background, link color            |
+| Foreground | `#1f1b17` | Body text                                |
+| FG muted   | `#6b6360` | Muted body copy, footer link color       |
+| FG subtle  | `#9c9590` | Smallest secondary text (footer caption) |
+| Background | `#fff8f5` | Body/page background                     |
+| BG subtle  | `#fcf2eb` | Tables, highlighted callouts             |
+| Border     | `#eae1da` | Horizontal rules, table borders          |
+
+## Step-by-step application
+
+Perform these steps **on dev first**, verify by triggering the relevant auth flow, then repeat on prod only after explicit user confirmation.
+
+1. Open the Supabase Dashboard.
+2. Select the project:
+   - **Development** — ref `huhzactreblzcogqkbsd` (`drafto-dev`)
+   - **Production** — ref `tbmjbxxseonkciqovnpl` (`drafto.eu`)
+3. Navigate to **Authentication → Emails → Templates** (URL: `https://supabase.com/dashboard/project/<ref>/auth/templates`).
+4. For each of the four template types (Confirm signup, Reset password, Magic link, Reauthentication):
+   - Click the template.
+   - Replace the HTML body with the corresponding paste-block below.
+   - Leave the **Subject** line intact (or align it with the subject defaults below).
+   - Click **Save template**.
+5. Verify:
+   - **Dev**: sign up a throwaway account; trigger password reset; trigger magic link; trigger reauthentication. Confirm each email renders with the Drafto palette.
+   - **Prod**: only after user confirmation, repeat using a test account.
+
+## Paste blocks
+
+Each block is self-contained HTML with inline styles mirroring the code templates. Titles, body copy, and CTAs are already filled in — adjust wording to taste.
+
+### Confirm signup
+
+**Subject**: `Confirm your Drafto account`
+
+```html
+<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#fff8f5;">
+    <div
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+    >
+      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+        Confirm your Drafto account
+      </h1>
+      <p style="margin:0 0 16px;">
+        Tap the button below to confirm your email address and finish setting up your Drafto
+        account.
+      </p>
+      <p style="margin:24px 0;">
+        <a
+          href="{{ .ConfirmationURL }}"
+          style="display:inline-block;background:#3525cd;color:#ffffff !important;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:16px;"
+          >Confirm email</a
+        >
+      </p>
+      <p style="margin:0 0 8px;color:#6b6360;font-size:14px;">
+        Or copy this link into your browser:
+      </p>
+      <p style="margin:0 0 16px;word-break:break-all;color:#3525cd;font-size:14px;">
+        {{ .ConfirmationURL }}
+      </p>
+      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
+      <p style="margin:0;font-size:12px;color:#9c9590;">
+        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      </p>
+    </div>
+  </body>
+</html>
+```
+
+### Reset password
+
+**Subject**: `Reset your Drafto password`
+
+```html
+<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#fff8f5;">
+    <div
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+    >
+      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+        Reset your Drafto password
+      </h1>
+      <p style="margin:0 0 16px;">
+        We received a request to reset the password for your Drafto account. If this was you, tap
+        the button below to choose a new one.
+      </p>
+      <p style="margin:24px 0;">
+        <a
+          href="{{ .ConfirmationURL }}"
+          style="display:inline-block;background:#3525cd;color:#ffffff !important;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:16px;"
+          >Reset password</a
+        >
+      </p>
+      <p style="margin:0 0 8px;color:#6b6360;font-size:14px;">
+        If you didn't request a reset, you can safely ignore this email — your password will not
+        change.
+      </p>
+      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
+      <p style="margin:0;font-size:12px;color:#9c9590;">
+        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      </p>
+    </div>
+  </body>
+</html>
+```
+
+### Magic link
+
+**Subject**: `Your Drafto sign-in link`
+
+```html
+<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#fff8f5;">
+    <div
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+    >
+      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+        Sign in to Drafto
+      </h1>
+      <p style="margin:0 0 16px;">
+        Use the button below to sign in to Drafto. This link is single-use and expires shortly.
+      </p>
+      <p style="margin:24px 0;">
+        <a
+          href="{{ .ConfirmationURL }}"
+          style="display:inline-block;background:#3525cd;color:#ffffff !important;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:16px;"
+          >Sign in</a
+        >
+      </p>
+      <p style="margin:0 0 8px;color:#6b6360;font-size:14px;">
+        Or enter this code: <strong style="color:#1f1b17;">{{ .Token }}</strong>
+      </p>
+      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
+      <p style="margin:0;font-size:12px;color:#9c9590;">
+        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      </p>
+    </div>
+  </body>
+</html>
+```
+
+### Reauthentication
+
+**Subject**: `Confirm your Drafto identity`
+
+```html
+<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#fff8f5;">
+    <div
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+    >
+      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+        Confirm your identity
+      </h1>
+      <p style="margin:0 0 16px;">
+        For a sensitive change on your Drafto account we need to reconfirm it's you. Enter this code
+        in the browser window that prompted you:
+      </p>
+      <p
+        style="margin:24px 0;font-size:24px;font-weight:700;letter-spacing:2px;color:#1f1b17;background:#fcf2eb;border:1px solid #eae1da;border-radius:8px;padding:16px 20px;display:inline-block;"
+      >
+        {{ .Token }}
+      </p>
+      <p style="margin:16px 0 0;color:#6b6360;font-size:14px;">
+        If you did not request this, you can safely ignore the email and no change will be made.
+      </p>
+      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
+      <p style="margin:0;font-size:12px;color:#9c9590;">
+        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      </p>
+    </div>
+  </body>
+</html>
+```
+
+## Final note
+
+**Apply to dev first, verify, then require explicit user confirmation before applying to prod.** Supabase email templates affect real user flows and are not versioned by this repository — a bad change cannot be rolled back via `git revert`.

--- a/apps/web/src/lib/email/templates.ts
+++ b/apps/web/src/lib/email/templates.ts
@@ -17,6 +17,20 @@ interface EmailContent {
   text: string;
 }
 
+// Inline palette for transactional emails. Values mirror the tokens defined in
+// apps/web/src/app/globals.css (warm neutrals + primary indigo). HTML email
+// clients strip <style> tags and cannot resolve CSS variables, so these must
+// be kept in sync with globals.css manually. See ADR 0020.
+const EMAIL_COLORS = {
+  primary: "#3525cd", // --color-primary-600
+  fg: "#1f1b17", // --color-neutral-900
+  fgMuted: "#6b6360", // --color-neutral-500
+  fgSubtle: "#9c9590", // --color-neutral-400
+  bg: "#fff8f5", // --color-neutral-50
+  bgSubtle: "#fcf2eb", // --color-neutral-100
+  border: "#eae1da", // --color-neutral-300
+} as const;
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, "&amp;")
@@ -32,7 +46,7 @@ function sanitizePlaintext(value: string): string {
 
 const baseStyles = `
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  color: #18181b;
+  color: ${EMAIL_COLORS.fg};
   line-height: 1.5;
   max-width: 560px;
   margin: 0 auto;
@@ -41,7 +55,7 @@ const baseStyles = `
 
 const primaryButtonStyles = `
   display: inline-block;
-  background: #2563eb;
+  background: ${EMAIL_COLORS.primary};
   color: #ffffff !important;
   text-decoration: none;
   padding: 12px 24px;
@@ -52,10 +66,25 @@ const primaryButtonStyles = `
 
 const secondaryLinkStyles = `
   display: inline-block;
-  color: #2563eb;
+  color: ${EMAIL_COLORS.primary};
   text-decoration: underline;
   font-size: 14px;
 `;
+
+function renderEmailLayout(args: { title: string; bodyHtml: string }): string {
+  const { title, bodyHtml } = args;
+  return `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:${EMAIL_COLORS.bg};">
+    <div style="${baseStyles}">
+      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:${EMAIL_COLORS.fg};">${title}</h1>
+      ${bodyHtml}
+      <hr style="margin:32px 0 16px;border:0;border-top:1px solid ${EMAIL_COLORS.border};" />
+      <p style="margin:0;font-size:12px;color:${EMAIL_COLORS.fgSubtle};">Drafto · <a href="https://drafto.eu" style="color:${EMAIL_COLORS.fgMuted};">drafto.eu</a></p>
+    </div>
+  </body>
+</html>`;
+}
 
 export function newSignupAdminEmail(input: NewSignupAdminEmailInput): EmailContent {
   const { userEmail, userDisplayName, signupAt, approveUrl, adminUrl } = input;
@@ -65,29 +94,24 @@ export function newSignupAdminEmail(input: NewSignupAdminEmailInput): EmailConte
   const safeName = plainName ? escapeHtml(plainName) : null;
   const signupAtFormatted = signupAt.toUTCString();
 
-  const html = `
-<!doctype html>
-<html>
-  <body style="margin:0;padding:0;background:#f4f4f5;">
-    <div style="${baseStyles}">
-      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;">New Drafto signup</h1>
-      <p style="margin:0 0 8px;color:#52525b;">Someone just signed up and is waiting for your approval.</p>
-      <table role="presentation" style="margin:24px 0;border-collapse:collapse;width:100%;background:#fafafa;border-radius:8px;">
+  const bodyHtml = `
+      <p style="margin:0 0 8px;color:${EMAIL_COLORS.fgMuted};">Someone just signed up and is waiting for your approval.</p>
+      <table role="presentation" style="margin:24px 0;border-collapse:collapse;width:100%;background:${EMAIL_COLORS.bgSubtle};border-radius:8px;">
         <tr>
-          <td style="padding:12px 16px;color:#71717a;font-size:14px;">Email</td>
+          <td style="padding:12px 16px;color:${EMAIL_COLORS.fgMuted};font-size:14px;">Email</td>
           <td style="padding:12px 16px;font-weight:600;">${safeEmail}</td>
         </tr>
         ${
           safeName
             ? `<tr>
-          <td style="padding:12px 16px;color:#71717a;font-size:14px;border-top:1px solid #e4e4e7;">Name</td>
-          <td style="padding:12px 16px;border-top:1px solid #e4e4e7;">${safeName}</td>
+          <td style="padding:12px 16px;color:${EMAIL_COLORS.fgMuted};font-size:14px;border-top:1px solid ${EMAIL_COLORS.border};">Name</td>
+          <td style="padding:12px 16px;border-top:1px solid ${EMAIL_COLORS.border};">${safeName}</td>
         </tr>`
             : ""
         }
         <tr>
-          <td style="padding:12px 16px;color:#71717a;font-size:14px;border-top:1px solid #e4e4e7;">Signed up</td>
-          <td style="padding:12px 16px;border-top:1px solid #e4e4e7;">${signupAtFormatted}</td>
+          <td style="padding:12px 16px;color:${EMAIL_COLORS.fgMuted};font-size:14px;border-top:1px solid ${EMAIL_COLORS.border};">Signed up</td>
+          <td style="padding:12px 16px;border-top:1px solid ${EMAIL_COLORS.border};">${signupAtFormatted}</td>
         </tr>
       </table>
       <p style="margin:0 0 24px;">
@@ -96,12 +120,11 @@ export function newSignupAdminEmail(input: NewSignupAdminEmailInput): EmailConte
       <p style="margin:0 0 8px;">
         <a href="${adminUrl}" style="${secondaryLinkStyles}">Review all pending signups</a>
       </p>
-      <p style="margin:32px 0 0;color:#a1a1aa;font-size:12px;">
+      <p style="margin:32px 0 0;color:${EMAIL_COLORS.fgSubtle};font-size:12px;">
         This one-click approval link expires in 72 hours. You must be signed in to Drafto as an admin for it to work.
-      </p>
-    </div>
-  </body>
-</html>`;
+      </p>`;
+
+  const html = renderEmailLayout({ title: "New Drafto signup", bodyHtml });
 
   const text = [
     "New Drafto signup",
@@ -130,12 +153,7 @@ export function userApprovedEmail(input: UserApprovedEmailInput): EmailContent {
   const plainName = displayName ? sanitizePlaintext(displayName) : null;
   const greetingName = plainName ? escapeHtml(plainName) : "there";
 
-  const html = `
-<!doctype html>
-<html>
-  <body style="margin:0;padding:0;background:#f4f4f5;">
-    <div style="${baseStyles}">
-      <h1 style="margin:0 0 16px;font-size:22px;font-weight:700;">You&rsquo;re in 🎉</h1>
+  const bodyHtml = `
       <p style="margin:0 0 16px;">Hi ${greetingName},</p>
       <p style="margin:0 0 16px;">
         Your Drafto account has been approved. You can sign in now and start taking notes.
@@ -143,12 +161,11 @@ export function userApprovedEmail(input: UserApprovedEmailInput): EmailContent {
       <p style="margin:24px 0;">
         <a href="${loginUrl}" style="${primaryButtonStyles}">Open Drafto</a>
       </p>
-      <p style="margin:32px 0 0;color:#a1a1aa;font-size:12px;">
+      <p style="margin:32px 0 0;color:${EMAIL_COLORS.fgSubtle};font-size:12px;">
         Drafto runs on the web (drafto.eu), iOS, Android, and macOS. Download the app from the App Store or Google Play with the same account.
-      </p>
-    </div>
-  </body>
-</html>`;
+      </p>`;
+
+  const html = renderEmailLayout({ title: "You&rsquo;re in 🎉", bodyHtml });
 
   const text = [
     `Hi ${plainName ?? "there"},`,
@@ -156,7 +173,7 @@ export function userApprovedEmail(input: UserApprovedEmailInput): EmailContent {
     "Your Drafto account has been approved. Sign in and start taking notes:",
     loginUrl,
     "",
-    "Drafto runs on the web, iOS, Android, and macOS \u2014 sign in with the same account from any platform.",
+    "Drafto runs on the web, iOS, Android, and macOS — sign in with the same account from any platform.",
   ].join("\n");
 
   return {

--- a/docs/adr/0020-email-design-tokens.md
+++ b/docs/adr/0020-email-design-tokens.md
@@ -1,0 +1,48 @@
+# 0020 — Email Design Tokens
+
+- **Status**: Accepted
+- **Date**: 2026-04-21
+- **Authors**: Jakub Anderwald
+
+## Context
+
+Drafto sends transactional emails through Resend (see [ADR 0019](./0019-email-infrastructure-and-approval-flow.md)). The HTML for these emails is assembled in `apps/web/src/lib/email/templates.ts` and rendered with inline styles because email clients (Gmail, Outlook, Apple Mail) strip `<style>` blocks and cannot resolve CSS custom properties — Drafto's design tokens live in `apps/web/src/app/globals.css` as CSS variables and therefore cannot be referenced directly from email HTML.
+
+Before this decision, email templates used a generic palette: a blue accent (`#2563eb`), cool-grey surfaces (`#f4f4f5`, `#fafafa`), and Zinc-style muted text colors (`#52525b`, `#71717a`, `#a1a1aa`). None of these matched the [Digital Atelier Design System](./0014-digital-atelier-design-system.md), which defines Drafto's brand as warm neutrals (stone) with an indigo primary (`#3525cd`). This mismatch meant the first touchpoint a new user saw — the approval email — did not look like the product.
+
+We also lacked a shared layout for emails: each template duplicated its own `<!doctype>`, `<body>`, and container scaffolding, and there was no footer branding.
+
+## Decision
+
+Introduce two patterns in `apps/web/src/lib/email/templates.ts`:
+
+1. **`EMAIL_COLORS` constant** — a single source of truth for the email palette. Values are hard-coded hex strings that mirror the corresponding tokens in `globals.css`:
+
+   | Role       | Hex       | CSS token             |
+   | ---------- | --------- | --------------------- |
+   | `primary`  | `#3525cd` | `--color-primary-600` |
+   | `fg`       | `#1f1b17` | `--color-neutral-900` |
+   | `fgMuted`  | `#6b6360` | `--color-neutral-500` |
+   | `fgSubtle` | `#9c9590` | `--color-neutral-400` |
+   | `bg`       | `#fff8f5` | `--color-neutral-50`  |
+   | `bgSubtle` | `#fcf2eb` | `--color-neutral-100` |
+   | `border`   | `#eae1da` | `--color-neutral-300` |
+
+2. **`renderEmailLayout({ title, bodyHtml })` helper** — all email templates route their outer shell through this helper. It emits the `<!doctype>`, warm-neutral body background, container, title `<h1>`, slot for body HTML, horizontal rule, and a branded footer (`Drafto · drafto.eu`). Individual templates only compose the inner body.
+
+A comment in `globals.css` (above the palette definitions) points readers to `EMAIL_COLORS` as a downstream manually-synced consumer of these tokens.
+
+Out-of-code Supabase Auth email templates (Confirm signup, Reset password, Magic link, Reauthentication), which live in the Supabase Dashboard and cannot be edited from this repo, are covered by a companion runbook at `apps/web/src/lib/email/SUPABASE_TEMPLATES.md`.
+
+## Consequences
+
+- **Positive**: Email rendering now matches Drafto's brand (indigo primary, warm neutrals). A single `EMAIL_COLORS` object is the one place to change when the palette evolves. New email templates inherit a consistent header and footer via `renderEmailLayout`, cutting boilerplate. Snapshot/regression tests can assert on known hex values.
+- **Negative**: `EMAIL_COLORS` must be updated by hand whenever `globals.css` palette tokens change — there is no automatic link between the two. The comment in `globals.css` is the mitigation, but it still relies on human discipline. Supabase Dashboard templates remain out-of-code and must be updated via the runbook.
+- **Neutral**: Code-rendered email templates gain a footer that did not previously exist; plaintext alternatives are unchanged.
+
+## Alternatives Considered
+
+1. **React Email / MJML** — rich email framework with components, responsive layouts, and a preview server. Rejected for now: it adds a non-trivial dependency (and build-time rendering) for only two code-rendered templates. Worth revisiting if we grow past 5+ distinct templates.
+2. **Build-time codegen from CSS** — parse `globals.css` at build time and emit a TS constant. Rejected: brittle (depends on the CSS file shape), adds tooling, and the synchronisation problem is small enough that a code comment suffices.
+3. **`<style>` tag with CSS classes** — would let us reuse the same token names. Rejected: Gmail and Outlook on Windows strip or rewrite `<style>` blocks, so inline styles are the only reliable approach for transactional email.
+4. **Embed a web view / iframe pointing at drafto.eu** — rejected outright; email clients do not execute JS and iframe support is inconsistent, and this breaks accessibility and deliverability.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,3 +52,4 @@ Every ADR follows the template in [0000-adr-template.md](./0000-adr-template.md)
 | [0017](./0017-mcp-server-for-claude-cowork.md)           | MCP Server for Claude Cowork                   | Accepted           | 2026-04-11 |
 | [0018](./0018-oauth-google-apple.md)                     | OAuth with Google and Apple                    | Accepted           | 2026-04-12 |
 | [0019](./0019-email-infrastructure-and-approval-flow.md) | Email Infrastructure and Account Approval Flow | Accepted           | 2026-04-20 |
+| [0020](./0020-email-design-tokens.md)                    | Email Design Tokens                            | Accepted           | 2026-04-21 |


### PR DESCRIPTION
## Summary

- Unify transactional email templates with Drafto's indigo + warm-neutral brand: replace the generic blue (`#2563eb`) and cool-grey (`#f4f4f5`, `#fafafa`) palette with the indigo primary (`#3525cd`) and stone neutrals used everywhere else.
- Introduce an `EMAIL_COLORS` constant and a `renderEmailLayout({ title, bodyHtml })` helper in `apps/web/src/lib/email/templates.ts` so the palette has a single source of truth and every template inherits the same container, background, and branded footer.
- Add ADR 0020 documenting the rationale and the manual-sync relationship with `globals.css`.
- Add `apps/web/src/lib/email/SUPABASE_TEMPLATES.md` runbook with paste-ready HTML for the four Supabase Dashboard auth templates (Confirm signup, Reset password, Magic link, Reauthentication), since those are out-of-code and cannot be updated via this PR.

## Audit context

Wave 1B design system remediation — finding: email templates used `#2563eb` (generic blue) instead of Drafto's indigo `#3525cd`, and cool-grey surfaces instead of the warm-neutral brand.

## Follow-up (manual)

The four Supabase Auth Dashboard templates still need to be updated by hand using the runbook in `SUPABASE_TEMPLATES.md`. Apply to dev (`huhzactreblzcogqkbsd`) first, verify, then apply to prod (`tbmjbxxseonkciqovnpl`) with explicit confirmation.

## Test plan

- [x] Unit tests assert new colors (`#3525cd`, `#fff8f5`, `#fcf2eb`) are present and old colors (`#2563eb`, `#f4f4f5`, `#fafafa`, `#18181b`) are absent.
- [x] Unit tests assert plaintext alternative is still non-empty.
- [x] All existing email-template unit tests still pass (HTML escaping, display-name fallback, URL inclusion).
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, and `cd apps/web && pnpm test` all pass locally.
- [ ] Manual verification: trigger a signup on dev and eyeball the rendered email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)