### PR TITLE
fix: silence nightly-audit false positives for reviewed PRs and idle runs

### DIFF
--- a/scripts/nightly-audit.sh
+++ b/scripts/nightly-audit.sh
@@ -129,9 +129,15 @@ if [[ "$MERGED_COUNT" -gt 0 ]]; then
 fi
 
 # Open PRs from nightly bot with failing CI
-OPEN_PRS=$(gh pr list --repo "$REPO" --state open --json number,title --limit 50 2>/dev/null) || OPEN_PRS="[]"
+OPEN_PRS=$(gh pr list --repo "$REPO" --state open --json number,title,labels --limit 50 2>/dev/null) || OPEN_PRS="[]"
 FAILING_BOT_PRS=()
 for PR_NUM in $(echo "$OPEN_PRS" | jq -r '.[].number'); do
+  # Skip PRs already flagged for manual review — the bot has done its job there,
+  # and re-reporting every night is noise until a human acts.
+  NEEDS_REVIEW=$(echo "$OPEN_PRS" | jq -r ".[] | select(.number == $PR_NUM) | .labels | map(.name) | index(\"needs-review\")")
+  if [[ "$NEEDS_REVIEW" != "null" ]]; then
+    continue
+  fi
   # Check bot marker first (cheaper than fetching check status)
   COMMENTS=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '.[].body' 2>/dev/null || true)
   if echo "$COMMENTS" | grep -Fq '<!-- nightly-bot -->'; then

--- a/scripts/nightly-support.sh
+++ b/scripts/nightly-support.sh
@@ -110,7 +110,8 @@ SKIPPED_COUNT=$(( DEPENDABOT_ALL_COUNT - DEPENDABOT_COUNT ))
 log "Found $DEPENDABOT_ALL_COUNT Dependabot PRs ($SKIPPED_COUNT already labeled needs-review, $DEPENDABOT_COUNT to process), $SUPPORT_COUNT support issues"
 
 if [[ "$DEPENDABOT_COUNT" -eq 0 && "$SUPPORT_COUNT" -eq 0 ]]; then
-  log "No items to process. Exiting."
+  log "No items to process."
+  log "=== Nightly support run completed (no items) ==="
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

After reviewing nightly-audit issues #267–#291, two recurring false-positive patterns show up on almost every run:

- **Bot-processed PRs with failing CI**: The audit repeatedly flags PRs like #271, #273, #278, #289 that are already labeled `needs-review` by the nightly bot (major-version dep bumps awaiting manual decision). The bot has done its job — re-reporting the same PRs nightly is noise until a human acts. Skip any PR with `needs-review` in Section C of `nightly-audit.sh`.
- **Stage 2: Script may not have completed** (seen on #267, #268): On days with nothing to process, `nightly-support.sh` exits with `"No items to process. Exiting."`, which does not contain the word `completed`. The audit's completion check (`nightly-audit.sh:94`) interprets this as an incomplete run. Emit a proper `=== Nightly support run completed (no items) ===` line before the early exit so healthy quiet nights are recognized.

No behavior change for real problems — these edits only suppress known false positives.

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] Verified jq `index("needs-review")` returns `null` when label absent, a numeric index when present — the skip branch triggers only on labeled PRs
- [ ] Observe next nightly run (2026-04-22) produces no audit issue assuming no new real problems

🤖 Generated with [Claude Code](https://claude.com/claude-code)