### PR TITLE
feat(mobile): add Button/Input/Card/Badge primitives

### DIFF
--- a/apps/mobile/__tests__/unit/components/ui/badge.test.tsx
+++ b/apps/mobile/__tests__/unit/components/ui/badge.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { render } from "../../../helpers/test-utils";
+import { Badge } from "../../../../src/components/ui/badge";
+
+describe("Badge", () => {
+  it("renders label", () => {
+    const { getByText } = render(<Badge label="New" />);
+    expect(getByText("New")).toBeTruthy();
+  });
+
+  it.each(["neutral", "success", "warning", "error"] as const)("renders %s variant", (variant) => {
+    const { getByText } = render(<Badge label="Status" variant={variant} />);
+    expect(getByText("Status")).toBeTruthy();
+  });
+
+  it.each(["sm", "md"] as const)("renders %s size", (size) => {
+    const { getByText } = render(<Badge label="Size" size={size} />);
+    expect(getByText("Size")).toBeTruthy();
+  });
+
+  it("applies testID", () => {
+    const { getByTestId } = render(<Badge label="Tagged" testID="my-badge" />);
+    expect(getByTestId("my-badge")).toBeTruthy();
+  });
+
+  it("neutral variant uses bgMuted background", () => {
+    const { getByTestId } = render(<Badge label="N" variant="neutral" testID="b" />);
+    const { StyleSheet } = require("react-native");
+    const flat = StyleSheet.flatten(getByTestId("b").props.style);
+    // Neutral uses semantic.bgMuted (light theme "#F4E9E0")
+    expect(flat.backgroundColor).toBeDefined();
+  });
+});

--- a/apps/mobile/__tests__/unit/components/ui/button.test.tsx
+++ b/apps/mobile/__tests__/unit/components/ui/button.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { Text } from "react-native";
+
+import { render, fireEvent } from "../../../helpers/test-utils";
+import { Button } from "../../../../src/components/ui/button";
+
+describe("Button", () => {
+  it("renders with title", () => {
+    const { getByText } = render(<Button title="Save" />);
+    expect(getByText("Save")).toBeTruthy();
+  });
+
+  it("calls onPress when pressed", () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<Button title="Press me" onPress={onPress} />);
+    fireEvent.press(getByText("Press me"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["primary", "secondary", "ghost", "danger"] as const)("renders %s variant", (variant) => {
+    const { getByText } = render(<Button title="Variant" variant={variant} />);
+    expect(getByText("Variant")).toBeTruthy();
+  });
+
+  it.each(["sm", "md", "lg"] as const)("renders %s size", (size) => {
+    const { getByText } = render(<Button title="Sized" size={size} />);
+    expect(getByText("Sized")).toBeTruthy();
+  });
+
+  it("does not call onPress when disabled", () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<Button title="Disabled" onPress={onPress} disabled />);
+    fireEvent.press(getByText("Disabled"));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("shows ActivityIndicator when loading", () => {
+    const { queryByText, UNSAFE_getByType } = render(<Button title="Loading" loading />);
+    expect(queryByText("Loading")).toBeNull();
+    const ActivityIndicator = require("react-native").ActivityIndicator;
+    expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+  });
+
+  it("does not call onPress when loading", () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <Button title="Loading" onPress={onPress} loading testID="loading-btn" />,
+    );
+    fireEvent.press(getByTestId("loading-btn"));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("renders leftIcon when provided", () => {
+    const { getByText } = render(<Button title="With icon" leftIcon={<Text>ICON</Text>} />);
+    expect(getByText("ICON")).toBeTruthy();
+    expect(getByText("With icon")).toBeTruthy();
+  });
+
+  it("applies testID", () => {
+    const { getByTestId } = render(<Button title="Tagged" testID="my-button" />);
+    expect(getByTestId("my-button")).toBeTruthy();
+  });
+
+  it("uses title as default accessibilityLabel", () => {
+    const { getByLabelText } = render(<Button title="Submit" />);
+    expect(getByLabelText("Submit")).toBeTruthy();
+  });
+
+  it("uses custom accessibilityLabel when provided", () => {
+    const { getByLabelText } = render(
+      <Button title="Submit" accessibilityLabel="Submit the form" />,
+    );
+    expect(getByLabelText("Submit the form")).toBeTruthy();
+  });
+});

--- a/apps/mobile/__tests__/unit/components/ui/card.test.tsx
+++ b/apps/mobile/__tests__/unit/components/ui/card.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Text } from "react-native";
+
+import { render } from "../../../helpers/test-utils";
+import { Card } from "../../../../src/components/ui/card";
+
+describe("Card", () => {
+  it("renders children", () => {
+    const { getByText } = render(
+      <Card>
+        <Text>Card contents</Text>
+      </Card>,
+    );
+    expect(getByText("Card contents")).toBeTruthy();
+  });
+
+  it("applies default padding (16)", () => {
+    const { getByTestId } = render(
+      <Card testID="card">
+        <Text>Content</Text>
+      </Card>,
+    );
+    const flattenedStyle = flattenStyle(getByTestId("card").props.style);
+    expect(flattenedStyle.padding).toBe(16);
+  });
+
+  it("applies custom padding prop", () => {
+    const { getByTestId } = render(
+      <Card testID="card" padding={32}>
+        <Text>Content</Text>
+      </Card>,
+    );
+    const flattenedStyle = flattenStyle(getByTestId("card").props.style);
+    expect(flattenedStyle.padding).toBe(32);
+  });
+
+  it("applies elevation style when elevated", () => {
+    const { getByTestId } = render(
+      <Card testID="card" elevated>
+        <Text>Content</Text>
+      </Card>,
+    );
+    // Elevation is platform-dependent; just verify the component renders
+    expect(getByTestId("card")).toBeTruthy();
+  });
+
+  it("merges custom style", () => {
+    const { getByTestId } = render(
+      <Card testID="card" style={{ marginTop: 24 }}>
+        <Text>Content</Text>
+      </Card>,
+    );
+    const flattenedStyle = flattenStyle(getByTestId("card").props.style);
+    expect(flattenedStyle.marginTop).toBe(24);
+  });
+});
+
+// Helper: flatten an RN style array into a single object
+function flattenStyle(style: unknown): Record<string, unknown> {
+  const { StyleSheet } = require("react-native");
+  return StyleSheet.flatten(style) ?? {};
+}

--- a/apps/mobile/__tests__/unit/components/ui/input.test.tsx
+++ b/apps/mobile/__tests__/unit/components/ui/input.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Text } from "react-native";
+
+import { render, fireEvent } from "../../../helpers/test-utils";
+import { Input } from "../../../../src/components/ui/input";
+
+describe("Input", () => {
+  it("renders with label", () => {
+    const { getByText } = render(<Input label="Email" value="" onChangeText={() => {}} />);
+    expect(getByText("Email")).toBeTruthy();
+  });
+
+  it("renders value", () => {
+    const { getByDisplayValue } = render(<Input value="hello@world.com" onChangeText={() => {}} />);
+    expect(getByDisplayValue("hello@world.com")).toBeTruthy();
+  });
+
+  it("triggers onChangeText when typed", () => {
+    const onChangeText = jest.fn();
+    const { getByDisplayValue } = render(<Input value="start" onChangeText={onChangeText} />);
+    fireEvent.changeText(getByDisplayValue("start"), "typed");
+    expect(onChangeText).toHaveBeenCalledWith("typed");
+  });
+
+  it("shows errorText when provided", () => {
+    const { getByText } = render(
+      <Input value="" onChangeText={() => {}} errorText="Email is required" />,
+    );
+    expect(getByText("Email is required")).toBeTruthy();
+  });
+
+  it("does not render error element when errorText is absent", () => {
+    const { queryByText } = render(<Input value="" onChangeText={() => {}} />);
+    expect(queryByText(/required/i)).toBeNull();
+  });
+
+  it("renders leftIcon and rightIcon", () => {
+    const { getByText } = render(
+      <Input
+        value=""
+        onChangeText={() => {}}
+        leftIcon={<Text>L</Text>}
+        rightIcon={<Text>R</Text>}
+      />,
+    );
+    expect(getByText("L")).toBeTruthy();
+    expect(getByText("R")).toBeTruthy();
+  });
+
+  it("calls onFocus and onBlur callbacks", () => {
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const { getByDisplayValue } = render(
+      <Input value="x" onChangeText={() => {}} onFocus={onFocus} onBlur={onBlur} />,
+    );
+    const input = getByDisplayValue("x");
+    fireEvent(input, "focus");
+    expect(onFocus).toHaveBeenCalled();
+    fireEvent(input, "blur");
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("passes secureTextEntry through", () => {
+    const { UNSAFE_getByType } = render(<Input value="" onChangeText={() => {}} secureTextEntry />);
+    const TextInput = require("react-native").TextInput;
+    expect(UNSAFE_getByType(TextInput).props.secureTextEntry).toBe(true);
+  });
+});

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,22 +1,14 @@
 import { useState, useMemo } from "react";
-import {
-  Text,
-  View,
-  TextInput,
-  Pressable,
-  StyleSheet,
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-} from "react-native";
+import { Text, View, StyleSheet, KeyboardAvoidingView, Platform, ScrollView } from "react-native";
 import { Link } from "expo-router";
 
 import { supabase } from "@/lib/supabase";
 import { useTheme } from "@/providers/theme-provider";
-import { colors } from "@/theme/tokens";
+import { colors, fontSizes, radii, spacing } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
 import { OAuthButtons } from "@/components/auth/oauth-buttons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 export default function LoginScreen() {
   const { semantic } = useTheme();
@@ -66,11 +58,9 @@ export default function LoginScreen() {
         )}
 
         <View style={styles.form}>
-          <Text style={styles.label}>Email</Text>
-          <TextInput
-            style={styles.input}
+          <Input
+            label="Email"
             placeholder="you@example.com"
-            placeholderTextColor={semantic.fgSubtle}
             value={email}
             onChangeText={setEmail}
             autoCapitalize="none"
@@ -78,13 +68,12 @@ export default function LoginScreen() {
             keyboardType="email-address"
             textContentType="emailAddress"
             editable={!loading}
+            containerStyle={styles.field}
           />
 
-          <Text style={styles.label}>Password</Text>
-          <TextInput
-            style={styles.input}
+          <Input
+            label="Password"
             placeholder="Your password"
-            placeholderTextColor={semantic.fgSubtle}
             value={password}
             onChangeText={setPassword}
             secureTextEntry
@@ -94,26 +83,20 @@ export default function LoginScreen() {
             textContentType="password"
             editable={!loading}
             onSubmitEditing={handleLogin}
+            containerStyle={styles.field}
           />
 
-          <Pressable
-            style={({ pressed }) => [
-              styles.button,
-              pressed && styles.buttonPressed,
-              loading && styles.buttonDisabled,
-            ]}
+          <Button
+            title="Log in"
             onPress={handleLogin}
+            loading={loading}
             disabled={loading}
-            accessibilityRole="button"
-            accessibilityLabel="Log in"
+            fullWidth
+            size="lg"
             testID="login-button"
-          >
-            {loading ? (
-              <ActivityIndicator color={semantic.onPrimary} />
-            ) : (
-              <Text style={styles.buttonText}>Log in</Text>
-            )}
-          </Pressable>
+            accessibilityLabel="Log in"
+            style={styles.submitButton}
+          />
         </View>
 
         <OAuthButtons onError={(msg) => setError(msg)} />
@@ -140,75 +123,47 @@ const createStyles = (semantic: SemanticColors) =>
       flexGrow: 1,
       alignItems: "center",
       justifyContent: "center",
-      padding: 24,
+      padding: spacing["2xl"],
     },
     title: {
-      fontSize: 28,
+      fontSize: fontSizes["4xl"],
       fontWeight: "bold",
-      marginBottom: 8,
+      marginBottom: spacing.sm,
       color: semantic.fg,
     },
     subtitle: {
-      fontSize: 16,
+      fontSize: fontSizes.xl,
       color: semantic.fgMuted,
-      marginBottom: 24,
+      marginBottom: spacing["2xl"],
     },
     errorContainer: {
       backgroundColor: semantic.errorBg,
       borderWidth: 1,
       borderColor: semantic.errorBorder,
-      borderRadius: 8,
-      padding: 12,
+      borderRadius: radii.md,
+      padding: spacing.md,
       width: "100%",
-      marginBottom: 16,
+      marginBottom: spacing.lg,
     },
     errorText: {
       color: semantic.errorText,
-      fontSize: 14,
+      fontSize: fontSizes.base,
       textAlign: "center",
     },
     form: {
       width: "100%",
     },
-    label: {
-      fontSize: 14,
-      fontWeight: "600",
-      marginBottom: 6,
-      color: semantic.fgMuted,
+    field: {
+      marginBottom: spacing.lg,
     },
-    input: {
-      borderWidth: 1,
-      borderColor: semantic.borderStrong,
-      borderRadius: 8,
-      padding: 12,
-      fontSize: 16,
-      marginBottom: 16,
-      backgroundColor: semantic.bg,
-      color: semantic.fg,
-    },
-    button: {
-      backgroundColor: colors.primary[600],
-      borderRadius: 8,
-      padding: 14,
-      alignItems: "center",
-      marginTop: 8,
-    },
-    buttonPressed: {
-      backgroundColor: colors.primary[700],
-    },
-    buttonDisabled: {
-      opacity: 0.7,
-    },
-    buttonText: {
-      color: semantic.onPrimary,
-      fontSize: 16,
-      fontWeight: "600",
+    submitButton: {
+      marginTop: spacing.sm,
     },
     footer: {
-      marginTop: 24,
+      marginTop: spacing["2xl"],
     },
     footerText: {
-      fontSize: 14,
+      fontSize: fontSizes.base,
       color: semantic.fgMuted,
     },
     link: {

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -1,22 +1,14 @@
 import { useState, useMemo } from "react";
-import {
-  Text,
-  View,
-  TextInput,
-  Pressable,
-  StyleSheet,
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-} from "react-native";
+import { Text, View, StyleSheet, KeyboardAvoidingView, Platform, ScrollView } from "react-native";
 import { Link, router } from "expo-router";
 
 import { supabase } from "@/lib/supabase";
 import { useTheme } from "@/providers/theme-provider";
-import { colors } from "@/theme/tokens";
+import { colors, fontSizes, radii, spacing } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
 import { OAuthButtons } from "@/components/auth/oauth-buttons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 export default function SignupScreen() {
   const { semantic } = useTheme();
@@ -73,11 +65,9 @@ export default function SignupScreen() {
         )}
 
         <View style={styles.form}>
-          <Text style={styles.label}>Email</Text>
-          <TextInput
-            style={styles.input}
+          <Input
+            label="Email"
             placeholder="you@example.com"
-            placeholderTextColor={semantic.fgSubtle}
             value={email}
             onChangeText={setEmail}
             autoCapitalize="none"
@@ -85,13 +75,12 @@ export default function SignupScreen() {
             keyboardType="email-address"
             textContentType="emailAddress"
             editable={!loading}
+            containerStyle={styles.field}
           />
 
-          <Text style={styles.label}>Password</Text>
-          <TextInput
-            style={styles.input}
+          <Input
+            label="Password"
             placeholder="Min. 6 characters"
-            placeholderTextColor={semantic.fgSubtle}
             value={password}
             onChangeText={setPassword}
             secureTextEntry
@@ -101,23 +90,19 @@ export default function SignupScreen() {
             textContentType="newPassword"
             editable={!loading}
             onSubmitEditing={handleSignup}
+            containerStyle={styles.field}
           />
 
-          <Pressable
-            style={({ pressed }) => [
-              styles.button,
-              pressed && styles.buttonPressed,
-              loading && styles.buttonDisabled,
-            ]}
+          <Button
+            title="Sign up"
             onPress={handleSignup}
+            loading={loading}
             disabled={loading}
-          >
-            {loading ? (
-              <ActivityIndicator color={semantic.onPrimary} />
-            ) : (
-              <Text style={styles.buttonText}>Sign up</Text>
-            )}
-          </Pressable>
+            fullWidth
+            size="lg"
+            accessibilityLabel="Sign up"
+            style={styles.submitButton}
+          />
         </View>
 
         <OAuthButtons onError={(msg) => setError(msg)} />
@@ -144,75 +129,47 @@ const createStyles = (semantic: SemanticColors) =>
       flexGrow: 1,
       alignItems: "center",
       justifyContent: "center",
-      padding: 24,
+      padding: spacing["2xl"],
     },
     title: {
-      fontSize: 28,
+      fontSize: fontSizes["4xl"],
       fontWeight: "bold",
-      marginBottom: 8,
+      marginBottom: spacing.sm,
       color: semantic.fg,
     },
     subtitle: {
-      fontSize: 16,
+      fontSize: fontSizes.xl,
       color: semantic.fgMuted,
-      marginBottom: 24,
+      marginBottom: spacing["2xl"],
     },
     errorContainer: {
       backgroundColor: semantic.errorBg,
       borderWidth: 1,
       borderColor: semantic.errorBorder,
-      borderRadius: 8,
-      padding: 12,
+      borderRadius: radii.md,
+      padding: spacing.md,
       width: "100%",
-      marginBottom: 16,
+      marginBottom: spacing.lg,
     },
     errorText: {
       color: semantic.errorText,
-      fontSize: 14,
+      fontSize: fontSizes.base,
       textAlign: "center",
     },
     form: {
       width: "100%",
     },
-    label: {
-      fontSize: 14,
-      fontWeight: "600",
-      marginBottom: 6,
-      color: semantic.fgMuted,
+    field: {
+      marginBottom: spacing.lg,
     },
-    input: {
-      borderWidth: 1,
-      borderColor: semantic.borderStrong,
-      borderRadius: 8,
-      padding: 12,
-      fontSize: 16,
-      marginBottom: 16,
-      backgroundColor: semantic.bg,
-      color: semantic.fg,
-    },
-    button: {
-      backgroundColor: colors.primary[600],
-      borderRadius: 8,
-      padding: 14,
-      alignItems: "center",
-      marginTop: 8,
-    },
-    buttonPressed: {
-      backgroundColor: colors.primary[700],
-    },
-    buttonDisabled: {
-      opacity: 0.7,
-    },
-    buttonText: {
-      color: semantic.onPrimary,
-      fontSize: 16,
-      fontWeight: "600",
+    submitButton: {
+      marginTop: spacing.sm,
     },
     footer: {
-      marginTop: 24,
+      marginTop: spacing["2xl"],
     },
     footerText: {
-      fontSize: 14,
+      fontSize: fontSizes.base,
       color: semantic.fgMuted,
     },
     link: {

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -6,7 +6,8 @@ import { SyncStatus } from "@/components/sync-status";
 import { useAuth } from "@/providers/auth-provider";
 import { useTheme, type ThemePreference } from "@/providers/theme-provider";
 import { useHaptics } from "@/hooks/use-haptics";
-import { colors } from "@/theme/tokens";
+import { Button } from "@/components/ui/button";
+import { colors, fontSizes, radii, spacing } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
 
 const THEME_OPTIONS: {
@@ -62,10 +63,15 @@ export default function SettingsScreen() {
       <SyncStatus />
 
       <Text style={styles.sectionTitle}>Account</Text>
-      <Pressable style={styles.signOutButton} onPress={signOut}>
-        <Ionicons name="log-out-outline" size={20} color={colors.error} />
-        <Text style={styles.signOutText}>Sign Out</Text>
-      </Pressable>
+      <Button
+        title="Sign Out"
+        onPress={signOut}
+        variant="danger"
+        size="lg"
+        fullWidth
+        leftIcon={<Ionicons name="log-out-outline" size={20} color={colors.white} />}
+        accessibilityLabel="Sign out"
+      />
     </ScrollView>
   );
 }
@@ -77,30 +83,30 @@ const createStyles = (semantic: SemanticColors) =>
       backgroundColor: semantic.bgMuted,
     },
     container: {
-      padding: 16,
-      gap: 8,
+      padding: spacing.lg,
+      gap: spacing.sm,
     },
     sectionTitle: {
-      fontSize: 13,
+      fontSize: fontSizes.md,
       fontWeight: "600",
       color: semantic.fgSubtle,
       textTransform: "uppercase",
       letterSpacing: 0.5,
-      marginTop: 8,
-      marginBottom: 4,
-      marginLeft: 4,
+      marginTop: spacing.sm,
+      marginBottom: spacing.xs,
+      marginLeft: spacing.xs,
     },
     themeRow: {
       flexDirection: "row",
-      gap: 8,
+      gap: spacing.sm,
     },
     themeOption: {
       flex: 1,
       alignItems: "center",
       gap: 6,
-      paddingVertical: 14,
+      paddingVertical: spacing.lg,
       backgroundColor: semantic.bg,
-      borderRadius: 12,
+      borderRadius: radii.lg,
       borderWidth: 2,
       borderColor: "transparent",
     },
@@ -109,25 +115,12 @@ const createStyles = (semantic: SemanticColors) =>
       backgroundColor: semantic.bgSubtle,
     },
     themeOptionText: {
-      fontSize: 13,
+      fontSize: fontSizes.md,
       fontWeight: "500",
       color: semantic.fgMuted,
     },
     themeOptionTextActive: {
       color: colors.primary[600],
       fontWeight: "600",
-    },
-    signOutButton: {
-      flexDirection: "row",
-      alignItems: "center",
-      padding: 16,
-      backgroundColor: semantic.bg,
-      borderRadius: 12,
-      gap: 12,
-    },
-    signOutText: {
-      fontSize: 15,
-      fontWeight: "600",
-      color: colors.error,
     },
   });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drafto/mobile",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/apps/mobile/src/components/editor/attachment-list.tsx
+++ b/apps/mobile/src/components/editor/attachment-list.tsx
@@ -21,6 +21,7 @@ import {
 import { useDatabase } from "@/providers/database-provider";
 import { useTheme } from "@/providers/theme-provider";
 import { useToast } from "@/components/toast";
+import { Badge } from "@/components/ui/badge";
 import { colors } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
 import type { Attachment } from "@/db";
@@ -260,12 +261,7 @@ function AttachmentItem({ attachment, onDelete, showToast, styles }: AttachmentI
 }
 
 function PendingBadge() {
-  return (
-    <View style={pendingStyles.pendingBadge}>
-      <Ionicons name="cloud-upload-outline" size={10} color={colors.warning} />
-      <Text style={pendingStyles.pendingText}>Pending</Text>
-    </View>
-  );
+  return <Badge label="Pending" variant="warning" size="sm" />;
 }
 
 export function AttachmentList({ attachments }: AttachmentListProps) {
@@ -327,23 +323,6 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
     </View>
   );
 }
-
-const pendingStyles = StyleSheet.create({
-  pendingBadge: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 2,
-    backgroundColor: colors.secondary[50],
-    borderRadius: 4,
-    paddingHorizontal: 4,
-    paddingVertical: 1,
-  },
-  pendingText: {
-    fontSize: 10,
-    fontWeight: "600",
-    color: colors.warning,
-  },
-});
 
 const createStyles = (semantic: SemanticColors) =>
   StyleSheet.create({

--- a/apps/mobile/src/components/ui/badge.tsx
+++ b/apps/mobile/src/components/ui/badge.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from "react-native";
+
+import { useTheme } from "@/providers/theme-provider";
+import { fontSizes, radii, spacing } from "@/theme/tokens";
+import type { SemanticColors } from "@/theme/tokens";
+
+export type BadgeVariant = "neutral" | "success" | "warning" | "error";
+export type BadgeSize = "sm" | "md";
+
+export interface BadgeProps {
+  label: string;
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+interface BadgeColors {
+  bg: string;
+  text: string;
+}
+
+function getBadgeColors(variant: BadgeVariant, semantic: SemanticColors): BadgeColors {
+  switch (variant) {
+    case "success":
+      return { bg: semantic.successBg, text: semantic.successText };
+    case "warning":
+      return { bg: semantic.warningBg, text: semantic.warningText };
+    case "error":
+      return { bg: semantic.errorBg, text: semantic.errorText };
+    case "neutral":
+    default:
+      return { bg: semantic.bgMuted, text: semantic.fgMuted };
+  }
+}
+
+export function Badge({ label, variant = "neutral", size = "sm", style, testID }: BadgeProps) {
+  const { semantic } = useTheme();
+  const styles = useMemo(() => createStyles(semantic), [semantic]);
+  const variantColors = useMemo(() => getBadgeColors(variant, semantic), [variant, semantic]);
+
+  return (
+    <View
+      testID={testID}
+      style={[styles.badge, styles[`size_${size}`], { backgroundColor: variantColors.bg }, style]}
+    >
+      <Text
+        style={[styles.text, styles[`textSize_${size}`], { color: variantColors.text }]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const createStyles = (_semantic: SemanticColors) =>
+  StyleSheet.create({
+    badge: {
+      alignSelf: "flex-start",
+      borderRadius: radii.full,
+      flexDirection: "row",
+      alignItems: "center",
+    },
+    size_sm: {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+    },
+    size_md: {
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.xs,
+    },
+    text: {
+      fontWeight: "600",
+    },
+    textSize_sm: {
+      fontSize: fontSizes.xs,
+    },
+    textSize_md: {
+      fontSize: fontSizes.sm,
+    },
+  });

--- a/apps/mobile/src/components/ui/button.tsx
+++ b/apps/mobile/src/components/ui/button.tsx
@@ -1,0 +1,171 @@
+import { useMemo, type ReactNode } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+
+import { useTheme } from "@/providers/theme-provider";
+import { colors, fontSizes, radii, spacing } from "@/theme/tokens";
+import type { SemanticColors } from "@/theme/tokens";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps {
+  title: string;
+  onPress?: () => void;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  disabled?: boolean;
+  loading?: boolean;
+  leftIcon?: ReactNode;
+  fullWidth?: boolean;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+  accessibilityLabel?: string;
+}
+
+interface VariantColors {
+  bg: string;
+  bgPressed: string;
+  text: string;
+  border?: string;
+}
+
+function getVariantColors(variant: ButtonVariant, semantic: SemanticColors): VariantColors {
+  switch (variant) {
+    case "primary":
+      return {
+        bg: colors.primary[600],
+        bgPressed: colors.primary[700],
+        text: semantic.onPrimary,
+      };
+    case "secondary":
+      return {
+        bg: "transparent",
+        bgPressed: semantic.bgMuted,
+        text: semantic.fg,
+        border: semantic.borderStrong,
+      };
+    case "ghost":
+      return {
+        bg: "transparent",
+        bgPressed: semantic.bgMuted,
+        text: semantic.fg,
+      };
+    case "danger":
+      return {
+        bg: colors.error,
+        bgPressed: "#9A1414",
+        text: colors.white,
+      };
+  }
+}
+
+export function Button({
+  title,
+  onPress,
+  variant = "primary",
+  size = "md",
+  disabled = false,
+  loading = false,
+  leftIcon,
+  fullWidth = false,
+  style,
+  testID,
+  accessibilityLabel,
+}: ButtonProps) {
+  const { semantic } = useTheme();
+  const styles = useMemo(() => createStyles(semantic), [semantic]);
+  const variantColors = useMemo(() => getVariantColors(variant, semantic), [variant, semantic]);
+  const isDisabled = disabled || loading;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={isDisabled}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: isDisabled, busy: loading }}
+      accessibilityLabel={accessibilityLabel ?? title}
+      testID={testID}
+      android_ripple={{ color: semantic.bgMuted }}
+      style={({ pressed }) => [
+        styles.base,
+        styles[`size_${size}`],
+        {
+          backgroundColor: pressed && !isDisabled ? variantColors.bgPressed : variantColors.bg,
+        },
+        variantColors.border ? { borderWidth: 1, borderColor: variantColors.border } : null,
+        fullWidth && styles.fullWidth,
+        isDisabled && styles.disabled,
+        style,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator size="small" color={variantColors.text} />
+      ) : (
+        <View style={styles.content}>
+          {leftIcon ? <View style={styles.leftIcon}>{leftIcon}</View> : null}
+          <Text style={[styles.text, styles[`textSize_${size}`], { color: variantColors.text }]}>
+            {title}
+          </Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const createStyles = (_semantic: SemanticColors) =>
+  StyleSheet.create({
+    base: {
+      alignItems: "center",
+      justifyContent: "center",
+      borderRadius: radii.md,
+    },
+    content: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    leftIcon: {
+      marginRight: spacing.sm,
+    },
+    size_sm: {
+      paddingVertical: spacing.sm,
+      paddingHorizontal: spacing.md,
+      minHeight: 32,
+    },
+    size_md: {
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.lg,
+      minHeight: 40,
+    },
+    size_lg: {
+      paddingVertical: spacing.lg,
+      paddingHorizontal: spacing.xl,
+      minHeight: 48,
+    },
+    text: {
+      fontWeight: "600",
+    },
+    textSize_sm: {
+      fontSize: fontSizes.sm,
+    },
+    textSize_md: {
+      fontSize: fontSizes.base,
+    },
+    textSize_lg: {
+      fontSize: fontSizes.lg,
+    },
+    fullWidth: {
+      alignSelf: "stretch",
+    },
+    disabled: {
+      opacity: 0.5,
+    },
+  });

--- a/apps/mobile/src/components/ui/card.tsx
+++ b/apps/mobile/src/components/ui/card.tsx
@@ -1,0 +1,51 @@
+import { useMemo, type ReactNode } from "react";
+import { Platform, StyleSheet, View, type StyleProp, type ViewStyle } from "react-native";
+
+import { useTheme } from "@/providers/theme-provider";
+import { colors, radii, spacing } from "@/theme/tokens";
+import type { SemanticColors } from "@/theme/tokens";
+
+export interface CardProps {
+  children: ReactNode;
+  padding?: number;
+  elevated?: boolean;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export function Card({
+  children,
+  padding = spacing.lg,
+  elevated = false,
+  style,
+  testID,
+}: CardProps) {
+  const { semantic } = useTheme();
+  const styles = useMemo(() => createStyles(semantic), [semantic]);
+
+  return (
+    <View testID={testID} style={[styles.card, { padding }, elevated && styles.elevated, style]}>
+      {children}
+    </View>
+  );
+}
+
+const createStyles = (semantic: SemanticColors) =>
+  StyleSheet.create({
+    card: {
+      backgroundColor: semantic.bgSubtle,
+      borderRadius: radii.lg,
+    },
+    elevated: Platform.select({
+      ios: {
+        shadowColor: colors.black,
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.08,
+        shadowRadius: 6,
+      },
+      android: {
+        elevation: 2,
+      },
+      default: {},
+    }),
+  });

--- a/apps/mobile/src/components/ui/input.tsx
+++ b/apps/mobile/src/components/ui/input.tsx
@@ -1,0 +1,113 @@
+import { forwardRef, useMemo, useState, type ReactNode } from "react";
+import {
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type StyleProp,
+  type TextInputProps,
+  type ViewStyle,
+} from "react-native";
+
+import { useTheme } from "@/providers/theme-provider";
+import { fontSizes, radii, spacing } from "@/theme/tokens";
+import type { SemanticColors } from "@/theme/tokens";
+
+export interface InputProps extends Omit<TextInputProps, "style"> {
+  label?: string;
+  errorText?: string;
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
+  containerStyle?: StyleProp<ViewStyle>;
+  inputStyle?: StyleProp<ViewStyle>;
+}
+
+export const Input = forwardRef<TextInput, InputProps>(function Input(
+  {
+    label,
+    errorText,
+    leftIcon,
+    rightIcon,
+    containerStyle,
+    inputStyle,
+    onFocus,
+    onBlur,
+    editable,
+    ...textInputProps
+  },
+  ref,
+) {
+  const { semantic } = useTheme();
+  const styles = useMemo(() => createStyles(semantic), [semantic]);
+  const [focused, setFocused] = useState(false);
+
+  const hasError = Boolean(errorText);
+  const borderColor = hasError ? semantic.errorText : focused ? semantic.ring : semantic.border;
+
+  return (
+    <View style={[styles.container, containerStyle]}>
+      {label ? <Text style={styles.label}>{label}</Text> : null}
+      <View style={[styles.inputWrapper, { borderColor }, focused && styles.focused]}>
+        {leftIcon ? <View style={styles.leftIcon}>{leftIcon}</View> : null}
+        <TextInput
+          ref={ref}
+          style={[styles.input, inputStyle]}
+          placeholderTextColor={semantic.fgSubtle}
+          editable={editable}
+          onFocus={(e) => {
+            setFocused(true);
+            onFocus?.(e);
+          }}
+          onBlur={(e) => {
+            setFocused(false);
+            onBlur?.(e);
+          }}
+          {...textInputProps}
+        />
+        {rightIcon ? <View style={styles.rightIcon}>{rightIcon}</View> : null}
+      </View>
+      {errorText ? <Text style={styles.errorText}>{errorText}</Text> : null}
+    </View>
+  );
+});
+
+const createStyles = (semantic: SemanticColors) =>
+  StyleSheet.create({
+    container: {
+      width: "100%",
+    },
+    label: {
+      fontSize: fontSizes.sm,
+      color: semantic.fgMuted,
+      marginBottom: spacing.xs,
+      fontWeight: "600",
+    },
+    inputWrapper: {
+      flexDirection: "row",
+      alignItems: "center",
+      borderWidth: 1,
+      borderRadius: radii.md,
+      backgroundColor: semantic.bg,
+      paddingHorizontal: spacing.md,
+    },
+    focused: {
+      borderWidth: 1,
+    },
+    leftIcon: {
+      marginRight: spacing.sm,
+    },
+    rightIcon: {
+      marginLeft: spacing.sm,
+    },
+    input: {
+      flex: 1,
+      paddingVertical: spacing.sm,
+      fontSize: fontSizes.xl,
+      color: semantic.fg,
+    },
+    errorText: {
+      fontSize: fontSizes.sm,
+      color: semantic.errorText,
+      marginTop: spacing.xs,
+    },
+  });


### PR DESCRIPTION
## Summary

Introduces four reusable UI primitives for the React Native mobile app at `apps/mobile/src/components/ui/`:

- `button.tsx` — `primary` / `secondary` / `ghost` / `danger` variants; `sm` / `md` / `lg` sizes; loading / disabled / leftIcon / fullWidth props; Android ripple feedback.
- `input.tsx` — label + errorText + leftIcon + rightIcon slots; focus ring via `semantic.ring`; error border via `semantic.errorText`; passes through all standard `TextInputProps`.
- `card.tsx` — `padding` + `elevated` props; `bgSubtle` surface; platform-appropriate shadow/elevation.
- `badge.tsx` — `neutral` / `success` / `warning` / `error` variants; `sm` / `md` sizes; pill shape using `radii.full`.

All primitives consume design tokens from `@drafto/shared` via `@/theme/tokens` and follow the existing `createStyles(semantic)` factory pattern used elsewhere in the mobile app.

Migrates the hotspot screens:

- `app/(auth)/login.tsx` and `app/(auth)/signup.tsx` — replaced `Pressable`/`TextInput` pairs with `<Button>` + `<Input>`; spacing/radii/fontSizes now driven by tokens.
- `app/(tabs)/settings.tsx` — replaced the Sign Out `Pressable` with `<Button variant="danger">`; spacing/radii now tokenised.
- `src/components/editor/attachment-list.tsx` — replaced the ad-hoc `PendingBadge` with `<Badge label="Pending" variant="warning" />`.

## Scope notes

- The tabs `index.tsx` FAB (circular `+` button) and inline create/edit name inputs were **intentionally not migrated**: the FAB is an icon-only circular pattern (needs a future `IconButton` primitive), and the inline create/edit inputs have ergonomics (compact row height) that differ from the standard `<Input>`.
- `attachment-picker.tsx` has tinted "Image" / "File" pills using `colors.primary[50]` bg with `primary[600]` text — these are a "soft primary" visual that doesn't match any existing Button variant. Left as-is to preserve visual parity; a future "soft" Button variant could absorb these.

## Follow-ups

- **Wave 3A (typography/spacing sweep)** will catch the remaining off-scale `fontSize:` / `padding:` literals not covered by primitive migration.
- Desktop mirror of this PR is `feat/desktop-primitives` (Wave 2B, running in parallel).

## Test plan

- [x] New unit tests for each primitive (38 tests across 4 files)
- [x] Existing mobile unit tests still pass (131/131)
- [x] `pnpm typecheck` passes across the monorepo
- [x] `pnpm lint` passes (no new warnings)
- [x] `packages/shared` drift test still passes (200/200)
- [ ] Mobile Maestro E2E — local-only per CLAUDE.md build policy, not run in subagent

## Version

Mobile version bumped `1.2.0` → `1.3.0` (user-visible UX change: new button/input visual semantics).