### PR TITLE
chore: add design system lint guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,12 @@ All UI code must use the design system defined in `apps/web/src/app/globals.css`
 - When adding a new token, add an example to the showcase page (`apps/web/src/app/design-system/page.tsx`)
 - When adding a new UI primitive, add it to the showcase page with all variants
 
+**Lint guardrails** enforce these rules automatically:
+
+- Web (`apps/web/eslint.config.mjs`) — blocks raw Tailwind greys (`bg-gray-*`, `text-slate-*`, …), arbitrary color values (`bg-[#...]`), and arbitrary shadow/radius values (`shadow-[...]`, `rounded-[...]`) inside `className`.
+- Mobile + desktop (`apps/{mobile,desktop}/eslint.config.mjs`) — blocks numeric `fontSize` literals and hex color strings assigned to `color`/`backgroundColor`/`borderColor` inside `src/`, `app/`, and `components/`.
+- Suppress legitimate exceptions with `// eslint-disable-next-line no-restricted-syntax -- <reason>` and explain why (e.g. an emoji glyph sized as a visual, not typography). See `docs/features/design-system.md` → "Lint guardrails" for the full rule set.
+
 ## Testing Requirements
 
 Every feature needs unit tests (`__tests__/unit/`), integration tests (`__tests__/integration/`), and E2E tests (`e2e/`). The full per-platform matrix of commands lives in [`docs/architecture/testing.md`](./docs/architecture/testing.md).

--- a/apps/desktop/eslint.config.mjs
+++ b/apps/desktop/eslint.config.mjs
@@ -1,12 +1,49 @@
 import tseslint from "typescript-eslint";
 import prettier from "eslint-config-prettier";
 
+// Design system guardrails for React Native (desktop — macOS).
+// Forbid hardcoded typography scale (fontSize: <number>) and hex color string
+// literals assigned to color/backgroundColor/borderColor props — forces code
+// through the shared tokens in apps/desktop/src/theme/tokens.ts.
+// To suppress for a legitimate exception (e.g. an emoji glyph sized as a
+// visual, not typography), add:
+//   // eslint-disable-next-line no-restricted-syntax -- <reason>
+// on the preceding line.
+const designSystemRestrictedSyntax = [
+  {
+    // Matches numeric Literal nodes (value is a number) assigned to fontSize.
+    // esquery treats Literal.value as its JS type, so we target the `raw`
+    // string representation to catch integer and decimal literals.
+    selector: "Property[key.name='fontSize'] > Literal[raw=/^[0-9]+(?:\\.[0-9]+)?$/]",
+    message:
+      "Use fontSizes tokens from @/theme/tokens (fontSizes.md, fontSizes.xl, ...) instead of raw numeric fontSize values. See docs/features/design-system.md.",
+  },
+  {
+    // Note: `shadowColor` is intentionally excluded — React Native's native
+    // shadow API takes a bare color (typically `"#000"`) and separates the
+    // intensity via `shadowOpacity`/`shadowRadius`, so there is no semantic
+    // shadow-color token to swap in.
+    selector:
+      "Property[key.name=/^(backgroundColor|color|borderColor|borderTopColor|borderBottomColor|borderLeftColor|borderRightColor|tintColor)$/] > Literal[value=/^#[0-9a-fA-F]{3,8}$/]",
+    message:
+      "Use semantic or palette tokens from @/theme/tokens (semantic.fg, colors.primary[500], ...) instead of raw hex color values. See docs/features/design-system.md.",
+  },
+];
+
 /** @type {import("eslint").Linter.Config[]} */
 const eslintConfig = [
   ...tseslint.configs.recommended,
   prettier,
   {
     ignores: ["node_modules/**", "macos/**"],
+  },
+  {
+    // Scope guardrails to UI source trees; keep tests, configs, jest setup
+    // out to avoid false positives on mock values.
+    files: ["src/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-syntax": ["error", ...designSystemRestrictedSyntax],
+    },
   },
 ];
 

--- a/apps/desktop/src/components/editor/attachment-list.tsx
+++ b/apps/desktop/src/components/editor/attachment-list.tsx
@@ -297,10 +297,12 @@ const createStyles = (semantic: SemanticColors) =>
     },
     placeholderIcon: {
       // Emoji icon sized as a visual, not typography
+      // eslint-disable-next-line no-restricted-syntax -- emoji glyph, not typography
       fontSize: 24,
     },
     retryIcon: {
       // Emoji icon sized as a visual, not typography
+      // eslint-disable-next-line no-restricted-syntax -- emoji glyph, not typography
       fontSize: 24,
       color: colors.neutral[400],
     },
@@ -340,6 +342,7 @@ const createStyles = (semantic: SemanticColors) =>
     },
     fileIcon: {
       // Emoji icon sized as a visual, not typography
+      // eslint-disable-next-line no-restricted-syntax -- emoji glyph, not typography
       fontSize: 20,
     },
     fileInfo: {

--- a/apps/desktop/src/components/ui/empty-state.tsx
+++ b/apps/desktop/src/components/ui/empty-state.tsx
@@ -46,6 +46,7 @@ const createStyles = (semantic: SemanticColors) =>
     },
     icon: {
       // Emoji icon sized as a visual, not typography
+      // eslint-disable-next-line no-restricted-syntax -- emoji glyph, not typography
       fontSize: 24,
     },
     title: {

--- a/apps/desktop/src/screens/waiting-for-approval.tsx
+++ b/apps/desktop/src/screens/waiting-for-approval.tsx
@@ -96,6 +96,7 @@ const createStyles = (semantic: SemanticColors) =>
     },
     icon: {
       // Hero emoji — intentionally large, no font-size token at 48px
+      // eslint-disable-next-line no-restricted-syntax -- emoji hero glyph, not typography
       fontSize: 48,
       marginBottom: spacing.lg,
     },

--- a/apps/mobile/app/(auth)/waiting-for-approval.tsx
+++ b/apps/mobile/app/(auth)/waiting-for-approval.tsx
@@ -100,6 +100,7 @@ const createStyles = (semantic: SemanticColors) =>
     },
     icon: {
       // 48pt emoji glyph — intentionally outside the text scale for visual prominence.
+      // eslint-disable-next-line no-restricted-syntax -- emoji hero glyph, not typography
       fontSize: 48,
       marginBottom: spacing.lg,
     },

--- a/apps/mobile/eslint.config.mjs
+++ b/apps/mobile/eslint.config.mjs
@@ -1,12 +1,49 @@
 import expoFlat from "eslint-config-expo/flat.js";
 import prettier from "eslint-config-prettier";
 
+// Design system guardrails for React Native (mobile).
+// Forbid hardcoded typography scale (fontSize: <number>) and hex color string
+// literals assigned to color/backgroundColor/borderColor props — forces code
+// through the shared tokens in apps/mobile/src/theme/tokens.ts.
+// To suppress for a legitimate exception (e.g. an emoji glyph sized as a
+// visual, not typography), add:
+//   // eslint-disable-next-line no-restricted-syntax -- <reason>
+// on the preceding line.
+const designSystemRestrictedSyntax = [
+  {
+    // Matches numeric Literal nodes (value is a number) assigned to fontSize.
+    // esquery treats Literal.value as its JS type, so we target the `raw`
+    // string representation to catch integer and decimal literals.
+    selector: "Property[key.name='fontSize'] > Literal[raw=/^[0-9]+(?:\\.[0-9]+)?$/]",
+    message:
+      "Use fontSizes tokens from @/theme/tokens (fontSizes.md, fontSizes.xl, ...) instead of raw numeric fontSize values. See docs/features/design-system.md.",
+  },
+  {
+    // Note: `shadowColor` is intentionally excluded — React Native's native
+    // shadow API takes a bare color (typically `"#000"`) and separates the
+    // intensity via `shadowOpacity`/`shadowRadius`, so there is no semantic
+    // shadow-color token to swap in.
+    selector:
+      "Property[key.name=/^(backgroundColor|color|borderColor|borderTopColor|borderBottomColor|borderLeftColor|borderRightColor|tintColor)$/] > Literal[value=/^#[0-9a-fA-F]{3,8}$/]",
+    message:
+      "Use semantic or palette tokens from @/theme/tokens (semantic.fg, colors.primary[500], ...) instead of raw hex color values. See docs/features/design-system.md.",
+  },
+];
+
 /** @type {import("eslint").Linter.Config[]} */
 const eslintConfig = [
   ...expoFlat,
   prettier,
   {
     ignores: [".expo/**", "dist/**", "node_modules/**"],
+  },
+  {
+    // Scope guardrails to UI source trees; keep tests, configs, and scripts out
+    // to avoid false positives on mock values and build config.
+    files: ["src/**/*.{ts,tsx}", "app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-syntax": ["error", ...designSystemRestrictedSyntax],
+    },
   },
 ];
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -3,6 +3,58 @@ import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import prettier from "eslint-config-prettier";
 
+// Design system guardrails — see docs/features/design-system.md and CLAUDE.md.
+// These rules block regressions of raw Tailwind greys, arbitrary color/shadow
+// values, and legacy palette utilities in JSX className strings. The intent is
+// to force new UI code to use the semantic/scale tokens defined in
+// apps/web/src/app/globals.css.
+//
+// To suppress for a legitimate exception (e.g. `bg-black/40` on a modal
+// backdrop), add a `// eslint-disable-next-line no-restricted-syntax` comment
+// on the line above with a short explanation.
+const designSystemRestrictedSyntax = [
+  {
+    // Raw Tailwind grey scales must be replaced with semantic tokens.
+    selector:
+      "JSXAttribute[name.name='className'] Literal[value=/\\b(?:bg|text|border|from|to|ring|divide|placeholder|caret|accent|decoration|outline|shadow)-(?:gray|slate|stone|zinc|neutral)-\\d+\\b/]",
+    message:
+      "Use semantic tokens (bg-bg, text-fg, text-fg-muted, border-border) or palette scale tokens (bg-neutral-600 from our theme is fine if that class lives in globals.css) instead of raw Tailwind greys (bg-gray-*, text-slate-*, bg-stone-*, bg-zinc-*, bg-neutral-*). See docs/features/design-system.md.",
+  },
+  {
+    // Same rule but for className expressions inside template literals / cn() calls.
+    selector:
+      "JSXAttribute[name.name='className'] TemplateElement[value.raw=/\\b(?:bg|text|border|from|to|ring|divide|placeholder|caret|accent|decoration|outline|shadow)-(?:gray|slate|stone|zinc|neutral)-\\d+\\b/]",
+    message:
+      "Use semantic tokens (bg-bg, text-fg, text-fg-muted, border-border) instead of raw Tailwind greys in className template literals. See docs/features/design-system.md.",
+  },
+  {
+    // Arbitrary Tailwind color values — disallow hex/rgb literals.
+    selector:
+      "JSXAttribute[name.name='className'] Literal[value=/\\b(?:bg|text|border|from|to|via|ring|shadow|outline|decoration|divide|placeholder|caret|accent|fill|stroke)-\\[(?:#[0-9a-fA-F]{3,8}|rgb|hsl)/]",
+    message:
+      "Use design system scale tokens (bg-primary-500, text-accent-400) instead of arbitrary color values (bg-[#4f46e5]). See docs/features/design-system.md.",
+  },
+  {
+    selector:
+      "JSXAttribute[name.name='className'] TemplateElement[value.raw=/\\b(?:bg|text|border|from|to|via|ring|shadow|outline|decoration|divide|placeholder|caret|accent|fill|stroke)-\\[(?:#[0-9a-fA-F]{3,8}|rgb|hsl)/]",
+    message:
+      "Use design system scale tokens (bg-primary-500, text-accent-400) instead of arbitrary color values. See docs/features/design-system.md.",
+  },
+  {
+    // Arbitrary shadow/rounded values — disallow pixel literals; allow CSS vars.
+    selector:
+      "JSXAttribute[name.name='className'] Literal[value=/\\b(?:shadow|rounded)-\\[(?!var\\()/]",
+    message:
+      "Use design system shadow/radius tokens (shadow-sm, shadow-md, rounded-md, rounded-lg) instead of arbitrary values. If you genuinely need a CSS-variable-driven value, use shadow-[var(--…)] or rounded-[var(--…)]. See docs/features/design-system.md.",
+  },
+  {
+    selector:
+      "JSXAttribute[name.name='className'] TemplateElement[value.raw=/\\b(?:shadow|rounded)-\\[(?!var\\()/]",
+    message:
+      "Use design system shadow/radius tokens (shadow-sm, shadow-md, rounded-md, rounded-lg) instead of arbitrary values. See docs/features/design-system.md.",
+  },
+];
+
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
@@ -20,6 +72,12 @@ const eslintConfig = defineConfig([
     // Claude worktrees:
     ".claude/**",
   ]),
+  {
+    files: ["src/**/*.{ts,tsx,js,jsx}"],
+    rules: {
+      "no-restricted-syntax": ["error", ...designSystemRestrictedSyntax],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/docs/features/design-system.md
+++ b/docs/features/design-system.md
@@ -49,6 +49,42 @@ Semantic surface tokens (`--bg`, `--fg`, …) react to the `.dark` class on web;
 - **Showcase-page rule:** when you add a new token to `globals.css` or a new primitive to `components/ui/`, you must add a corresponding example (all variants) to `apps/web/src/app/design-system/page.tsx`. This keeps the live reference in sync with the codebase.
 - **Cross-platform rule:** if you change a palette value or add a semantic token that mobile/desktop consume, update `apps/mobile/src/theme/tokens.ts` and `apps/desktop/src/theme/tokens.ts` in the same PR.
 
+## Lint guardrails (automated)
+
+The rules above are enforced by ESLint. Violations surface as `no-restricted-syntax` errors during `pnpm lint` and block PRs in CI.
+
+### Web (`apps/web/eslint.config.mjs`)
+
+Within `className` string and template literals, the web rule blocks:
+
+- **Raw Tailwind greys** — `bg-gray-*`, `text-slate-*`, `bg-stone-*`, `bg-zinc-*`, `bg-neutral-*` and their `border-/from-/to-/ring-/divide-/placeholder-/…` cousins. Use semantic tokens (`bg-bg`, `text-fg-muted`, `border-border`) or a palette scale class (`bg-primary-500`) that is defined in `globals.css`.
+- **Arbitrary color values** — `bg-[#...]`, `text-[#...]`, `border-[#...]`, `from-[#...]`, `to-[#...]`, `shadow-[rgb(...)]`, etc. Use a scale token. Arbitrary values that reference a CSS variable (`bg-[var(--surface-glass)]`) are still allowed.
+- **Arbitrary shadow/radius values** — `shadow-[0_0_10px_red]`, `rounded-[17px]`. Use the system shadows (`shadow-sm`, `shadow-md`) and radii (`rounded-md`, `rounded-lg`). CSS-variable-driven values (`shadow-[var(--shadow-glow)]`) remain allowed.
+
+### Mobile + desktop (`apps/mobile/eslint.config.mjs`, `apps/desktop/eslint.config.mjs`)
+
+Within `src/`, `app/`, and `components/` trees, the native rules block:
+
+- **Hardcoded `fontSize` numbers** — `fontSize: 14`, `fontSize: 20`. Use `fontSizes.sm` / `fontSizes.md` / … from `@/theme/tokens`.
+- **Hex color string literals assigned to color-bearing props** — `color: "#111"`, `backgroundColor: "#3525CD"`, `borderColor: "#fff"`, plus the `borderTopColor`/`borderBottomColor`/`borderLeftColor`/`borderRightColor`/`tintColor` variants. Use `semantic.fg` / `colors.primary[500]` / … from `@/theme/tokens`.
+- **Note:** `shadowColor` is intentionally **not** flagged. React Native's native shadow API expects a bare color (typically `"#000"`) and controls intensity via `shadowOpacity` + `shadowRadius`, so there is no semantic swap.
+
+Tests, jest setup, and build configs are deliberately out of scope — the rule only applies to UI source trees.
+
+### Suppressing for legitimate exceptions
+
+If you genuinely need a raw value (the canonical example is an emoji glyph sized as a visual, not typography), suppress with an explanatory comment:
+
+```tsx
+icon: {
+  // eslint-disable-next-line no-restricted-syntax -- emoji hero glyph, not typography
+  fontSize: 48,
+  marginBottom: spacing.lg,
+},
+```
+
+Always include a `-- <reason>` so reviewers can tell whether the exception still makes sense.
+
 ## Verify
 
 - Visit `/design-system` in the running web app and confirm every token swatch and primitive variant renders in both light and dark.


### PR DESCRIPTION
## Summary

Prior waves of the design-system remediation centralized tokens and fixed existing violations. This PR adds ESLint guardrails so those violations can't come back.

### Web (`apps/web/eslint.config.mjs`)

Blocks, inside JSX `className` strings / template literals / `cn()` args:

- **Raw Tailwind greys** — `bg-gray-*`, `text-slate-*`, `bg-stone-*`, `bg-zinc-*`, `bg-neutral-*` and the `border-/from-/to-/ring-/divide-/placeholder-/…` variants. Use semantic tokens (`bg-bg`, `text-fg-muted`, `border-border`) or palette scale classes defined in `globals.css`.
- **Arbitrary color values** — `bg-[#...]`, `text-[#...]`, `border-[#...]`, `from-[#...]`, `to-[#...]`, `shadow-[rgb(...)]`, etc. Use a scale token. Arbitrary values referencing a CSS variable (`bg-[var(--surface-glass)]`) remain allowed.
- **Arbitrary shadow/radius values** — `shadow-[0_0_10px_red]`, `rounded-[17px]`. Use the system shadows / radii (or a `[var(--…)]` wrapper for CSS-variable-driven values).

### Mobile + desktop (`apps/{mobile,desktop}/eslint.config.mjs`)

Scoped to `src/`, `app/`, `components/` only (not tests, jest setup, or build configs). Blocks:

- Numeric `fontSize` literals — `fontSize: 14` — must use `fontSizes.sm`/`fontSizes.md`/… from `@/theme/tokens`.
- Hex color string literals assigned to `color`, `backgroundColor`, `borderColor`, `borderTopColor`/`borderBottomColor`/`borderLeftColor`/`borderRightColor`, or `tintColor` — must use `semantic.*` or `colors.*[…]` from `@/theme/tokens`.

`shadowColor` is intentionally **not** flagged because React Native's native shadow API takes a bare color (typically `"#000"`) and controls intensity via `shadowOpacity` + `shadowRadius` — there's no semantic shadow-color token to swap in.

### Whitelisted exceptions (existing code)

Added `// eslint-disable-next-line no-restricted-syntax` with a `-- <reason>` note to the few legitimate hardcoded `fontSize: <number>` cases (emoji glyphs sized as visuals, not typography):

- `apps/mobile/app/(auth)/waiting-for-approval.tsx`
- `apps/desktop/src/screens/waiting-for-approval.tsx`
- `apps/desktop/src/components/editor/attachment-list.tsx` (×3)
- `apps/desktop/src/components/ui/empty-state.tsx`

## Approach

Used a single `no-restricted-syntax` rule with esquery selectors rather than adding a new plugin dependency. This avoids the `eslint-plugin-tailwindcss` Tailwind 4 compatibility gap and keeps the rule inline with the rest of the eslint config. Selectors match `JSXAttribute[name.name='className']` descendants (covers bare className strings, template literals, and `cn()` / `clsx()` call args) for the web rule and `Property[key.name=…] > Literal` for the native rules.

## Suppressing for legitimate exceptions

```tsx
icon: {
  // eslint-disable-next-line no-restricted-syntax -- emoji glyph, not typography
  fontSize: 48,
  marginBottom: spacing.lg,
},
```

Always include a `-- <reason>` so reviewers can assess whether the exception still makes sense.

## Documentation

- `CLAUDE.md` "Design System (Enforced)" section now lists the lint guardrails and how to suppress.
- `docs/features/design-system.md` adds a "Lint guardrails (automated)" section enumerating the full rule set.

## Test plan

- [x] `pnpm lint` — zero errors across all packages on the unmodified codebase.
- [x] `pnpm typecheck` — passes.
- [x] `cd apps/web && pnpm test` — 684/684 pass.
- [x] `cd apps/mobile && pnpm test` — 131/131 pass.
- [x] `cd apps/desktop && pnpm test` — 254/254 pass.
- [x] `cd packages/shared && pnpm test` — 202/202 pass.
- [x] Rule fires on intentional violation — verified by temporarily introducing `className="bg-gray-500 bg-[#4f46e5] shadow-[0_0_10px_red] rounded-[17px]"` on web and `{ fontSize: 99, color: "#abc123", backgroundColor: "#ff0", borderColor: "#112233" }` on both native configs; each selector fires with the expected message. Test files deleted afterward.