### PR TITLE
feat(supabase): add Drafto-branded auth email templates

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -232,6 +232,23 @@ otp_expiry = 3600
 # subject = "You have been invited"
 # content_path = "./supabase/templates/invite.html"
 
+# Drafto-branded auth email templates (palette mirrors apps/web/src/lib/email/templates.ts EMAIL_COLORS).
+[auth.email.template.confirmation]
+subject = "Confirm your Drafto account"
+content_path = "./supabase/templates/confirmation.html"
+
+[auth.email.template.recovery]
+subject = "Reset your Drafto password"
+content_path = "./supabase/templates/recovery.html"
+
+[auth.email.template.magic_link]
+subject = "Your Drafto sign-in link"
+content_path = "./supabase/templates/magic-link.html"
+
+[auth.email.template.reauthentication]
+subject = "Confirm your Drafto identity"
+content_path = "./supabase/templates/reauthentication.html"
+
 # Uncomment to customize notification email template
 # [auth.email.notification.password_changed]
 # enabled = true

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,32 +1,50 @@
 <!doctype html>
 <html>
-  <body style="margin:0;padding:0;background:#fff8f5;">
+  <body style="margin: 0; padding: 0; background: #fff8f5">
     <div
-      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+      style="
+        font-family:
+          -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial,
+          sans-serif;
+        color: #1f1b17;
+        line-height: 1.5;
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 32px 24px;
+      "
     >
-      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+      <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 700; color: #1f1b17">
         Confirm your Drafto account
       </h1>
-      <p style="margin:0 0 16px;">
+      <p style="margin: 0 0 16px">
         Tap the button below to confirm your email address and finish setting up your Drafto
         account.
       </p>
-      <p style="margin:24px 0;">
+      <p style="margin: 24px 0">
         <a
           href="{{ .ConfirmationURL }}"
-          style="display:inline-block;background:#3525cd;color:#ffffff !important;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:16px;"
+          style="
+            display: inline-block;
+            background: #3525cd;
+            color: #ffffff !important;
+            text-decoration: none;
+            padding: 12px 24px;
+            border-radius: 8px;
+            font-weight: 600;
+            font-size: 16px;
+          "
           >Confirm email</a
         >
       </p>
-      <p style="margin:0 0 8px;color:#6b6360;font-size:14px;">
+      <p style="margin: 0 0 8px; color: #6b6360; font-size: 14px">
         Or copy this link into your browser:
       </p>
-      <p style="margin:0 0 16px;word-break:break-all;color:#3525cd;font-size:14px;">
+      <p style="margin: 0 0 16px; word-break: break-all; color: #3525cd; font-size: 14px">
         {{ .ConfirmationURL }}
       </p>
-      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
-      <p style="margin:0;font-size:12px;color:#9c9590;">
-        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      <hr style="margin: 32px 0 16px; border: 0; border-top: 1px solid #eae1da" />
+      <p style="margin: 0; font-size: 12px; color: #9c9590">
+        Drafto · <a href="https://drafto.eu" style="color: #6b6360">drafto.eu</a>
       </p>
     </div>
   </body>

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#fff8f5;">
+    <div
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+    >
+      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+        Confirm your Drafto account
+      </h1>
+      <p style="margin:0 0 16px;">
+        Tap the button below to confirm your email address and finish setting up your Drafto
+        account.
+      </p>
+      <p style="margin:24px 0;">
+        <a
+          href="{{ .ConfirmationURL }}"
+          style="display:inline-block;background:#3525cd;color:#ffffff !important;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:16px;"
+          >Confirm email</a
+        >
+      </p>
+      <p style="margin:0 0 8px;color:#6b6360;font-size:14px;">
+        Or copy this link into your browser:
+      </p>
+      <p style="margin:0 0 16px;word-break:break-all;color:#3525cd;font-size:14px;">
+        {{ .ConfirmationURL }}
+      </p>
+      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
+      <p style="margin:0;font-size:12px;color:#9c9590;">
+        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      </p>
+    </div>
+  </body>
+</html>

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <body style="margin: 0; padding: 0; background: #fff8f5">
     <div
       style="
@@ -41,6 +41,10 @@
       </p>
       <p style="margin: 0 0 16px; word-break: break-all; color: #3525cd; font-size: 14px">
         {{ .ConfirmationURL }}
+      </p>
+      <p style="margin: 16px 0 0; color: #6b6360; font-size: 14px">
+        If you didn't sign up for Drafto, you can safely ignore this email — no account will be
+        created.
       </p>
       <hr style="margin: 32px 0 16px; border: 0; border-top: 1px solid #eae1da" />
       <p style="margin: 0; font-size: 12px; color: #9c9590">

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <body style="margin: 0; padding: 0; background: #fff8f5">
     <div
       style="
@@ -37,6 +37,9 @@
       </p>
       <p style="margin: 0 0 8px; color: #6b6360; font-size: 14px">
         Or enter this code: <strong style="color: #1f1b17">{{ .Token }}</strong>
+      </p>
+      <p style="margin: 16px 0 0; color: #6b6360; font-size: 14px">
+        If you didn't ask to sign in, you can safely ignore this email — no action is needed.
       </p>
       <hr style="margin: 32px 0 16px; border: 0; border-top: 1px solid #eae1da" />
       <p style="margin: 0; font-size: 12px; color: #9c9590">

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -1,28 +1,46 @@
 <!doctype html>
 <html>
-  <body style="margin:0;padding:0;background:#fff8f5;">
+  <body style="margin: 0; padding: 0; background: #fff8f5">
     <div
-      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+      style="
+        font-family:
+          -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial,
+          sans-serif;
+        color: #1f1b17;
+        line-height: 1.5;
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 32px 24px;
+      "
     >
-      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+      <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 700; color: #1f1b17">
         Sign in to Drafto
       </h1>
-      <p style="margin:0 0 16px;">
+      <p style="margin: 0 0 16px">
         Use the button below to sign in to Drafto. This link is single-use and expires shortly.
       </p>
-      <p style="margin:24px 0;">
+      <p style="margin: 24px 0">
         <a
           href="{{ .ConfirmationURL }}"
-          style="display:inline-block;background:#3525cd;color:#ffffff !important;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:16px;"
+          style="
+            display: inline-block;
+            background: #3525cd;
+            color: #ffffff !important;
+            text-decoration: none;
+            padding: 12px 24px;
+            border-radius: 8px;
+            font-weight: 600;
+            font-size: 16px;
+          "
           >Sign in</a
         >
       </p>
-      <p style="margin:0 0 8px;color:#6b6360;font-size:14px;">
-        Or enter this code: <strong style="color:#1f1b17;">{{ .Token }}</strong>
+      <p style="margin: 0 0 8px; color: #6b6360; font-size: 14px">
+        Or enter this code: <strong style="color: #1f1b17">{{ .Token }}</strong>
       </p>
-      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
-      <p style="margin:0;font-size:12px;color:#9c9590;">
-        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      <hr style="margin: 32px 0 16px; border: 0; border-top: 1px solid #eae1da" />
+      <p style="margin: 0; font-size: 12px; color: #9c9590">
+        Drafto · <a href="https://drafto.eu" style="color: #6b6360">drafto.eu</a>
       </p>
     </div>
   </body>

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#fff8f5;">
+    <div
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+    >
+      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+        Sign in to Drafto
+      </h1>
+      <p style="margin:0 0 16px;">
+        Use the button below to sign in to Drafto. This link is single-use and expires shortly.
+      </p>
+      <p style="margin:24px 0;">
+        <a
+          href="{{ .ConfirmationURL }}"
+          style="display:inline-block;background:#3525cd;color:#ffffff !important;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:16px;"
+          >Sign in</a
+        >
+      </p>
+      <p style="margin:0 0 8px;color:#6b6360;font-size:14px;">
+        Or enter this code: <strong style="color:#1f1b17;">{{ .Token }}</strong>
+      </p>
+      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
+      <p style="margin:0;font-size:12px;color:#9c9590;">
+        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      </p>
+    </div>
+  </body>
+</html>

--- a/supabase/templates/reauthentication.html
+++ b/supabase/templates/reauthentication.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <body style="margin: 0; padding: 0; background: #fff8f5">
     <div
       style="

--- a/supabase/templates/reauthentication.html
+++ b/supabase/templates/reauthentication.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#fff8f5;">
+    <div
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+    >
+      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+        Confirm your identity
+      </h1>
+      <p style="margin:0 0 16px;">
+        For a sensitive change on your Drafto account we need to reconfirm it's you. Enter this code
+        in the browser window that prompted you:
+      </p>
+      <p
+        style="margin:24px 0;font-size:24px;font-weight:700;letter-spacing:2px;color:#1f1b17;background:#fcf2eb;border:1px solid #eae1da;border-radius:8px;padding:16px 20px;display:inline-block;"
+      >
+        {{ .Token }}
+      </p>
+      <p style="margin:16px 0 0;color:#6b6360;font-size:14px;">
+        If you did not request this, you can safely ignore the email and no change will be made.
+      </p>
+      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
+      <p style="margin:0;font-size:12px;color:#9c9590;">
+        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      </p>
+    </div>
+  </body>
+</html>

--- a/supabase/templates/reauthentication.html
+++ b/supabase/templates/reauthentication.html
@@ -1,27 +1,47 @@
 <!doctype html>
 <html>
-  <body style="margin:0;padding:0;background:#fff8f5;">
+  <body style="margin: 0; padding: 0; background: #fff8f5">
     <div
-      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+      style="
+        font-family:
+          -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial,
+          sans-serif;
+        color: #1f1b17;
+        line-height: 1.5;
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 32px 24px;
+      "
     >
-      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+      <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 700; color: #1f1b17">
         Confirm your identity
       </h1>
-      <p style="margin:0 0 16px;">
+      <p style="margin: 0 0 16px">
         For a sensitive change on your Drafto account we need to reconfirm it's you. Enter this code
         in the browser window that prompted you:
       </p>
       <p
-        style="margin:24px 0;font-size:24px;font-weight:700;letter-spacing:2px;color:#1f1b17;background:#fcf2eb;border:1px solid #eae1da;border-radius:8px;padding:16px 20px;display:inline-block;"
+        style="
+          margin: 24px 0;
+          font-size: 24px;
+          font-weight: 700;
+          letter-spacing: 2px;
+          color: #1f1b17;
+          background: #fcf2eb;
+          border: 1px solid #eae1da;
+          border-radius: 8px;
+          padding: 16px 20px;
+          display: inline-block;
+        "
       >
         {{ .Token }}
       </p>
-      <p style="margin:16px 0 0;color:#6b6360;font-size:14px;">
+      <p style="margin: 16px 0 0; color: #6b6360; font-size: 14px">
         If you did not request this, you can safely ignore the email and no change will be made.
       </p>
-      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
-      <p style="margin:0;font-size:12px;color:#9c9590;">
-        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      <hr style="margin: 32px 0 16px; border: 0; border-top: 1px solid #eae1da" />
+      <p style="margin: 0; font-size: 12px; color: #9c9590">
+        Drafto · <a href="https://drafto.eu" style="color: #6b6360">drafto.eu</a>
       </p>
     </div>
   </body>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <body style="margin: 0; padding: 0; background: #fff8f5">
     <div
       style="

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#fff8f5;">
+    <div
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+    >
+      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+        Reset your Drafto password
+      </h1>
+      <p style="margin:0 0 16px;">
+        We received a request to reset the password for your Drafto account. If this was you, tap
+        the button below to choose a new one.
+      </p>
+      <p style="margin:24px 0;">
+        <a
+          href="{{ .ConfirmationURL }}"
+          style="display:inline-block;background:#3525cd;color:#ffffff !important;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:16px;"
+          >Reset password</a
+        >
+      </p>
+      <p style="margin:0 0 8px;color:#6b6360;font-size:14px;">
+        If you didn't request a reset, you can safely ignore this email — your password will not
+        change.
+      </p>
+      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
+      <p style="margin:0;font-size:12px;color:#9c9590;">
+        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      </p>
+    </div>
+  </body>
+</html>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,30 +1,48 @@
 <!doctype html>
 <html>
-  <body style="margin:0;padding:0;background:#fff8f5;">
+  <body style="margin: 0; padding: 0; background: #fff8f5">
     <div
-      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f1b17;line-height:1.5;max-width:560px;margin:0 auto;padding:32px 24px;"
+      style="
+        font-family:
+          -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial,
+          sans-serif;
+        color: #1f1b17;
+        line-height: 1.5;
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 32px 24px;
+      "
     >
-      <h1 style="margin:0 0 16px;font-size:20px;font-weight:700;color:#1f1b17;">
+      <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 700; color: #1f1b17">
         Reset your Drafto password
       </h1>
-      <p style="margin:0 0 16px;">
+      <p style="margin: 0 0 16px">
         We received a request to reset the password for your Drafto account. If this was you, tap
         the button below to choose a new one.
       </p>
-      <p style="margin:24px 0;">
+      <p style="margin: 24px 0">
         <a
           href="{{ .ConfirmationURL }}"
-          style="display:inline-block;background:#3525cd;color:#ffffff !important;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:16px;"
+          style="
+            display: inline-block;
+            background: #3525cd;
+            color: #ffffff !important;
+            text-decoration: none;
+            padding: 12px 24px;
+            border-radius: 8px;
+            font-weight: 600;
+            font-size: 16px;
+          "
           >Reset password</a
         >
       </p>
-      <p style="margin:0 0 8px;color:#6b6360;font-size:14px;">
+      <p style="margin: 0 0 8px; color: #6b6360; font-size: 14px">
         If you didn't request a reset, you can safely ignore this email — your password will not
         change.
       </p>
-      <hr style="margin:32px 0 16px;border:0;border-top:1px solid #eae1da;" />
-      <p style="margin:0;font-size:12px;color:#9c9590;">
-        Drafto · <a href="https://drafto.eu" style="color:#6b6360;">drafto.eu</a>
+      <hr style="margin: 32px 0 16px; border: 0; border-top: 1px solid #eae1da" />
+      <p style="margin: 0; font-size: 12px; color: #9c9590">
+        Drafto · <a href="https://drafto.eu" style="color: #6b6360">drafto.eu</a>
       </p>
     </div>
   </body>


### PR DESCRIPTION
## Summary

Adds HTML templates for the four Supabase Auth transactional emails under `supabase/templates/` and wires them into `supabase/config.toml` via `[auth.email.template.*]` blocks.

- **Confirmation** — signup confirmation link
- **Recovery** — password reset link
- **Magic link** — passwordless sign-in (link + code)
- **Reauthentication** — 6-digit identity confirmation code

Palette inlined to match `EMAIL_COLORS` in `apps/web/src/lib/email/templates.ts` (Drafto indigo on warm neutrals).

## Applying to remote projects

This PR commits the local artifacts. Push them to hosted projects via:

\`\`\`bash
pnpm supabase:link:dev
# Set OAuth env vars to match remote so push only touches email templates
supabase config push --yes
pnpm supabase:link:prod
supabase config push --yes
\`\`\`

Note: local config has \`skip_nonce_check = true\` on external OAuth while remote has \`false\`. Align before pushing, or push will modify OAuth config alongside email templates.

## Test plan

- [ ] Push config to dev, trigger signup/reset/magic-link, verify Drafto palette
- [ ] Push to prod after dev verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom authentication email templates implemented for account confirmation, password recovery, magic link sign-in, and identity reauthentication.
  * Branded email communications now feature consistent professional styling, clear call-to-action buttons, and improved instructions across all key authentication touchpoints.
  * Enhanced user experience during critical security workflows with recognizable branding and straightforward messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->