### PR TITLE
fix(desktop): render Google/Apple OAuth icons on macOS

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drafto/desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/apps/desktop/src/components/auth/oauth-buttons.tsx
+++ b/apps/desktop/src/components/auth/oauth-buttons.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { View, Text, Pressable, StyleSheet, ActivityIndicator } from "react-native";
+import { View, Text, Pressable, StyleSheet, ActivityIndicator, Platform } from "react-native";
 import Svg, { Path } from "react-native-svg";
 
 import { useTheme } from "@/providers/theme-provider";
@@ -9,7 +9,18 @@ import { signInWithOAuthBrowser } from "@/lib/oauth";
 
 type OAuthProvider = "google" | "apple";
 
+// react-native-svg renders as 0x0 on react-native-macos, so we fall back to
+// text-based icons there. Other platforms keep the branded SVG.
+const IS_MACOS = Platform.OS === "macos";
+
 function GoogleIcon() {
+  if (IS_MACOS) {
+    return (
+      <View style={googleFallback.wrap}>
+        <Text style={googleFallback.letter}>G</Text>
+      </View>
+    );
+  }
   return (
     <Svg width={20} height={20} viewBox="0 0 24 24">
       <Path
@@ -33,12 +44,47 @@ function GoogleIcon() {
 }
 
 function AppleIcon({ color }: { color: string }) {
+  if (IS_MACOS) {
+    // U+F8FF is the Apple logo glyph in Apple system fonts — renders natively on macOS.
+    return <Text style={[appleFallback.glyph, { color }]}>{""}</Text>;
+  }
   return (
     <Svg width={20} height={20} viewBox="0 0 24 24" fill={color}>
       <Path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
     </Svg>
   );
 }
+
+const googleFallback = StyleSheet.create({
+  wrap: {
+    width: 20,
+    height: 20,
+    borderRadius: radii.sm,
+    // eslint-disable-next-line no-restricted-syntax -- Google brand white
+    backgroundColor: "#ffffff",
+    borderWidth: 1,
+    // eslint-disable-next-line no-restricted-syntax -- Google brand outline
+    borderColor: "#DADCE0",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  letter: {
+    fontSize: fontSizes.md,
+    fontWeight: "700",
+    // eslint-disable-next-line no-restricted-syntax -- Google brand blue
+    color: "#4285F4",
+    lineHeight: 16,
+  },
+});
+
+const appleFallback = StyleSheet.create({
+  glyph: {
+    fontSize: fontSizes["2xl"],
+    lineHeight: 20,
+    width: 20,
+    textAlign: "center",
+  },
+});
 
 interface OAuthButtonsProps {
   onError?: (error: string) => void;


### PR DESCRIPTION
## Summary

The desktop login screen was showing OAuth buttons with just the text "Google" and "Apple" — no icons visible. Root cause: \`react-native-svg\` 15.15.4 technically supports macOS (\`:osx => "10.14"\` in the podspec) but renders as 0x0 on react-native-macos, so the \`<Svg>\` element exists but is invisible.

Fix: add a \`Platform.OS === "macos"\` fallback in \`apps/desktop/src/components/auth/oauth-buttons.tsx\`:

- **Google**: a bordered white chip with a bold Google-blue (\`#4285F4\`) "G"
- **Apple**: the \`U+F8FF\` Apple-logo glyph (rendered natively by macOS system fonts) in \`semantic.fg\`

Other platforms (iOS, Android) keep the original branded SVGs.

Bumps desktop to \`0.3.1\` — user-visible patch.

## Test plan

- [x] \`pnpm lint && pnpm typecheck\` pass
- [x] \`cd apps/desktop && pnpm test\` → 254 pass
- [ ] Visual verification on macOS: log in screen shows the blue G and Apple glyph

🤖 Generated with [Claude Code](https://claude.com/claude-code)