### PR TITLE
fix(mobile): patch @expo/dom-webview to import React for iOS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     },
     "patchedDependencies": {
       "@nozbe/watermelondb@0.28.0": "patches/@nozbe__watermelondb@0.28.0.patch",
-      "@nozbe/simdjson@3.9.4": "patches/@nozbe__simdjson@3.9.4.patch"
+      "@nozbe/simdjson@3.9.4": "patches/@nozbe__simdjson@3.9.4.patch",
+      "@expo/dom-webview@55.0.3": "patches/@expo__dom-webview@55.0.3.patch"
     }
   },
   "devDependencies": {

--- a/patches/@expo__dom-webview@55.0.3.patch
+++ b/patches/@expo__dom-webview@55.0.3.patch
@@ -1,0 +1,11 @@
+diff --git a/ios/DomWebView.swift b/ios/DomWebView.swift
+index 7a38d9f98bf8c37853b777dbf945a13d46560e30..7da5303dd353e5bf05a824d75876984c9cb42c69 100644
+--- a/ios/DomWebView.swift
++++ b/ios/DomWebView.swift
+@@ -1,5 +1,6 @@
+ // Copyright 2015-present 650 Industries. All rights reserved.
+ 
++import React
+ import ExpoModulesCore
+ import WebKit
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ overrides:
   '@asamuzakjp/dom-selector>lru-cache': 11.2.7
 
 patchedDependencies:
+  '@expo/dom-webview@55.0.3':
+    hash: 72dd4b01f85c1400466542bde65521ac52413bb593d942da3c01dfb8cec737cc
+    path: patches/@expo__dom-webview@55.0.3.patch
   '@nozbe/simdjson@3.9.4':
     hash: 25390e3a53217ef60abf6a29045d514dc4a786fcae08709866bdd53bb13ca44a
     path: patches/@nozbe__simdjson@3.9.4.patch
@@ -157,7 +160,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.12.2)
+        version: 29.7.0(@types/node@25.5.2)
       react-native-dotenv:
         specifier: ^3.4.11
         version: 3.4.11(@babel/runtime@7.29.2)
@@ -226,7 +229,7 @@ importers:
         version: 55.0.11(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       expo-router:
         specifier: ~55.0.10
-        version: 55.0.10(dee2d36fa3bbf3c60bc0d92a202d711e)
+        version: 55.0.10(6ac8ee578381f927ae46ba9dcb480947)
       expo-secure-store:
         specifier: ^55.0.11
         version: 55.0.11(expo@55.0.11)
@@ -263,7 +266,7 @@ importers:
         version: 5.4.3(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
       '@testing-library/react-native':
         specifier: ^13.3.3
-        version: 13.3.3(jest@29.7.0(@types/node@25.5.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 13.3.3(jest@29.7.0(@types/node@24.12.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -287,10 +290,10 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.5.2)
+        version: 29.7.0(@types/node@24.12.2)
       jest-expo:
         specifier: ^55.0.13
-        version: 55.0.13(@babel/core@7.29.0)(expo@55.0.11)(jest@29.7.0(@types/node@25.5.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+        version: 55.0.13(@babel/core@7.29.0)(expo@55.0.11)(jest@29.7.0(@types/node@24.12.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react-test-renderer:
         specifier: 19.1.4
         version: 19.1.4(react@19.1.4)
@@ -10407,7 +10410,7 @@ snapshots:
       ws: 8.20.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.10(dee2d36fa3bbf3c60bc0d92a202d711e)
+      expo-router: 55.0.10(6ac8ee578381f927ae46ba9dcb480947)
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -10477,7 +10480,7 @@ snapshots:
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
 
-  '@expo/dom-webview@55.0.3(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
+  '@expo/dom-webview@55.0.3(patch_hash=72dd4b01f85c1400466542bde65521ac52413bb593d942da3c01dfb8cec737cc)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
       expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react: 19.1.4
@@ -10532,7 +10535,7 @@ snapshots:
 
   '@expo/log-box@55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@expo/dom-webview': 55.0.3(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/dom-webview': 55.0.3(patch_hash=72dd4b01f85c1400466542bde65521ac52413bb593d942da3c01dfb8cec737cc)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       anser: 1.4.10
       expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react: 19.1.4
@@ -10541,7 +10544,7 @@ snapshots:
 
   '@expo/log-box@55.0.7(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@expo/dom-webview': 55.0.3(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/dom-webview': 55.0.3(patch_hash=72dd4b01f85c1400466542bde65521ac52413bb593d942da3c01dfb8cec737cc)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       anser: 1.4.10
       expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.10)(react-dom@19.2.4(react@19.1.4))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       react: 19.1.4
@@ -10669,7 +10672,7 @@ snapshots:
       react: 19.1.4
     optionalDependencies:
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
-      expo-router: 55.0.10(dee2d36fa3bbf3c60bc0d92a202d711e)
+      expo-router: 55.0.10(6ac8ee578381f927ae46ba9dcb480947)
       react-dom: 19.2.4(react@19.1.4)
     transitivePeerDependencies:
       - supports-color
@@ -12350,9 +12353,7 @@ snapshots:
       metro-runtime: 0.83.5
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/metro-config@0.84.1(@babel/core@7.29.0)':
     dependencies:
@@ -13046,7 +13047,7 @@ snapshots:
       react-test-renderer: 19.1.4(react@19.1.4)
       redent: 3.0.0
 
-  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@24.12.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       jest-matcher-utils: 30.2.0
       picocolors: 1.1.1
@@ -13056,7 +13057,7 @@ snapshots:
       react-test-renderer: 19.1.4(react@19.1.4)
       redent: 3.0.0
     optionalDependencies:
-      jest: 29.7.0(@types/node@25.5.2)
+      jest: 29.7.0(@types/node@24.12.2)
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
@@ -15561,7 +15562,7 @@ snapshots:
       react: 19.1.4
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
 
-  expo-router@55.0.10(dee2d36fa3bbf3c60bc0d92a202d711e):
+  expo-router@55.0.10(6ac8ee578381f927ae46ba9dcb480947):
     dependencies:
       '@expo/log-box': 55.0.10(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
@@ -15598,7 +15599,7 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.1.4)
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.1.4))(react@19.1.4)
     optionalDependencies:
-      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.5.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@24.12.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
       react-dom: 19.2.4(react@19.1.4)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -15661,7 +15662,7 @@ snapshots:
       react-refresh: 0.14.2
       whatwg-url-minimum: 0.1.1
     optionalDependencies:
-      '@expo/dom-webview': 55.0.3(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
+      '@expo/dom-webview': 55.0.3(patch_hash=72dd4b01f85c1400466542bde65521ac52413bb593d942da3c01dfb8cec737cc)(expo@55.0.11)(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.11)(react-dom@19.2.4(react@19.1.4))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
       react-native-webview: 13.16.1(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)
     transitivePeerDependencies:
@@ -16694,7 +16695,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@55.0.13(@babel/core@7.29.0)(expo@55.0.11)(jest@29.7.0(@types/node@25.5.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3):
+  jest-expo@55.0.13(@babel/core@7.29.0)(expo@55.0.11)(jest@29.7.0(@types/node@24.12.2))(react-native@0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4))(react@19.1.4)(typescript@5.9.3):
     dependencies:
       '@expo/config': 55.0.12(typescript@5.9.3)
       '@expo/json-file': 10.0.13
@@ -16705,7 +16706,7 @@ snapshots:
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@25.5.2))
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@24.12.2))
       json5: 2.2.3
       lodash: 4.18.1
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native-community/cli@18.0.0(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.1.4)
@@ -16904,11 +16905,11 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@25.5.2)):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@24.12.2)):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 29.7.0(@types/node@25.5.2)
+      jest: 29.7.0(@types/node@24.12.2)
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0


### PR DESCRIPTION
## Summary

- `@expo/dom-webview@55.0.3` calls `RCTConvert.nsurlRequest()` in `ios/DomWebView.swift` but never imports React, causing the iOS archive to fail with `cannot find 'RCTConvert' in scope` — blocking TestFlight uploads via `pnpm release:beta:ios`.
- Upstream already shipped the identical fix in `55.0.5` (`internal import React`). We apply the equivalent via `pnpm patch` rather than bumping the override — the repo already uses `patchedDependencies` and this keeps the lockfile churn at 43 lines instead of ~4700 from a full re-resolve.
- Zero app-code changes; the patched package isn't imported anywhere in `apps/mobile/`.

## Test plan

- [x] `pnpm install` applies the patch (`head -5 node_modules/@expo/dom-webview/ios/DomWebView.swift` shows `import React`)
- [x] `pnpm release:beta:ios` completes `build_app` + `upload_to_testflight` successfully (verified locally — build uploaded to TestFlight)
- [ ] CI green (lint, typecheck, tests on web / mobile / desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)