### PR TITLE
fix(desktop): deliver macOS OAuth callback to JS and exchange PKCE code

### DIFF
--- a/apps/desktop/__tests__/lib/oauth.test.ts
+++ b/apps/desktop/__tests__/lib/oauth.test.ts
@@ -1,0 +1,48 @@
+const mockExchangeCodeForSession = jest.fn();
+const mockSetSession = jest.fn();
+
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      exchangeCodeForSession: (...args: unknown[]) => mockExchangeCodeForSession(...args),
+      setSession: (...args: unknown[]) => mockSetSession(...args),
+    },
+  },
+}));
+
+import { handleOAuthCallback } from "../../src/lib/oauth";
+
+describe("handleOAuthCallback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExchangeCodeForSession.mockResolvedValue({ data: {}, error: null });
+    mockSetSession.mockResolvedValue({ data: {}, error: null });
+  });
+
+  it("ignores URLs that are not the desktop callback scheme", () => {
+    handleOAuthCallback("https://drafto.eu/auth/callback?code=abc");
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+    expect(mockSetSession).not.toHaveBeenCalled();
+  });
+
+  it("exchanges the PKCE code when present in the query string", () => {
+    handleOAuthCallback("eu.drafto.desktop://auth/callback?code=pkce-code-123");
+    expect(mockExchangeCodeForSession).toHaveBeenCalledWith("pkce-code-123");
+    expect(mockSetSession).not.toHaveBeenCalled();
+  });
+
+  it("sets the session when implicit-flow tokens arrive in the hash fragment", () => {
+    handleOAuthCallback("eu.drafto.desktop://auth/callback#access_token=AAA&refresh_token=RRR");
+    expect(mockSetSession).toHaveBeenCalledWith({
+      access_token: "AAA",
+      refresh_token: "RRR",
+    });
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no recognized auth params are present", () => {
+    handleOAuthCallback("eu.drafto.desktop://auth/callback");
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+    expect(mockSetSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/macos/Drafto-macOS/AppDelegate.mm
+++ b/apps/desktop/macos/Drafto-macOS/AppDelegate.mm
@@ -2,6 +2,7 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTDevLoadingViewSetEnabled.h>
+#import <React/RCTLinkingManager.h>
 #import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
 
 @implementation AppDelegate
@@ -16,6 +17,15 @@
   self.dependencyProvider = [RCTAppDependencyProvider new];
   
   [super applicationDidFinishLaunching:notification];
+
+  // React Native macOS delivers custom-scheme URL callbacks via the classic
+  // 'GURL' Apple Event. Route them into RCTLinkingManager so JS
+  // Linking.addEventListener("url", ...) fires for eu.drafto.desktop://auth/callback.
+  [[NSAppleEventManager sharedAppleEventManager]
+      setEventHandler:[RCTLinkingManager class]
+          andSelector:@selector(getUrlEventHandler:withReplyEvent:)
+        forEventClass:kInternetEventClass
+           andEventID:kAEGetURL];
 
   // Window frame persistence + minimum size
   NSWindow *window = NSApp.windows.firstObject;

--- a/apps/desktop/macos/Drafto-macOS/AppDelegate.mm
+++ b/apps/desktop/macos/Drafto-macOS/AppDelegate.mm
@@ -7,6 +7,18 @@
 
 @implementation AppDelegate
 
+- (void)applicationWillFinishLaunching:(NSNotification *)notification
+{
+  // Register the 'GURL' Apple Event handler before DidFinishLaunching so
+  // cold-launch URLs (app opened by clicking eu.drafto.desktop://...) reach
+  // RCTLinkingManager in time for JS Linking.getInitialURL() to see them.
+  [[NSAppleEventManager sharedAppleEventManager]
+      setEventHandler:[RCTLinkingManager class]
+          andSelector:@selector(getUrlEventHandler:withReplyEvent:)
+        forEventClass:kInternetEventClass
+           andEventID:kAEGetURL];
+}
+
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
   RCTDevLoadingViewSetEnabled(NO);
@@ -15,17 +27,8 @@
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
   self.dependencyProvider = [RCTAppDependencyProvider new];
-  
-  [super applicationDidFinishLaunching:notification];
 
-  // React Native macOS delivers custom-scheme URL callbacks via the classic
-  // 'GURL' Apple Event. Route them into RCTLinkingManager so JS
-  // Linking.addEventListener("url", ...) fires for eu.drafto.desktop://auth/callback.
-  [[NSAppleEventManager sharedAppleEventManager]
-      setEventHandler:[RCTLinkingManager class]
-          andSelector:@selector(getUrlEventHandler:withReplyEvent:)
-        forEventClass:kInternetEventClass
-           andEventID:kAEGetURL];
+  [super applicationDidFinishLaunching:notification];
 
   // Window frame persistence + minimum size
   NSWindow *window = NSApp.windows.firstObject;

--- a/apps/desktop/macos/Drafto-macOS/Info.plist
+++ b/apps/desktop/macos/Drafto-macOS/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>21</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/apps/desktop/macos/Drafto.xcodeproj/project.pbxproj
+++ b/apps/desktop/macos/Drafto.xcodeproj/project.pbxproj
@@ -362,7 +362,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 21;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "Drafto-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -384,7 +384,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = "Drafto-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -408,7 +408,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Drafto-macOS/Drafto.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = 4J2USPSG2U;
 				"EXCLUDED_ARCHS[sdk=macosx*]" = x86_64;
@@ -439,7 +439,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Drafto-macOS/Drafto.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 4J2USPSG2U;
 				"EXCLUDED_ARCHS[sdk=macosx*]" = x86_64;
 				INFOPLIST_FILE = "Drafto-macOS/Info.plist";

--- a/apps/desktop/src/lib/oauth.ts
+++ b/apps/desktop/src/lib/oauth.ts
@@ -31,16 +31,24 @@ export async function signInWithOAuthBrowser(
 
 export function handleOAuthCallback(url: string): void {
   try {
-    const parsed = new URL(url);
-
-    if (!parsed.pathname.includes("auth/callback")) {
+    if (!url.startsWith("eu.drafto.desktop:")) {
       return;
     }
 
-    // Handle fragment-based tokens (implicit flow) or code-based (PKCE)
-    const params = new URLSearchParams(parsed.hash ? parsed.hash.substring(1) : parsed.search);
+    console.info("[oauth] handling callback", url);
 
-    const code = params.get("code");
+    const parsed = new URL(url);
+
+    // Callbacks can arrive with params in the query string (PKCE) or the
+    // hash fragment (implicit). WHATWG URL parses `auth` as the host for
+    // non-special schemes, so do not gate on pathname — gate on scheme
+    // above and on the presence of known auth params below.
+    const searchParams = new URLSearchParams(parsed.search);
+    const hashParams = new URLSearchParams(
+      parsed.hash.startsWith("#") ? parsed.hash.slice(1) : parsed.hash,
+    );
+
+    const code = searchParams.get("code") ?? hashParams.get("code");
     if (code) {
       supabase.auth.exchangeCodeForSession(code).catch((err) => {
         console.error("[oauth] Failed to exchange code for session:", err);
@@ -48,8 +56,8 @@ export function handleOAuthCallback(url: string): void {
       return;
     }
 
-    const accessToken = params.get("access_token");
-    const refreshToken = params.get("refresh_token");
+    const accessToken = searchParams.get("access_token") ?? hashParams.get("access_token");
+    const refreshToken = searchParams.get("refresh_token") ?? hashParams.get("refresh_token");
     if (accessToken && refreshToken) {
       supabase.auth
         .setSession({ access_token: accessToken, refresh_token: refreshToken })

--- a/apps/desktop/src/lib/oauth.ts
+++ b/apps/desktop/src/lib/oauth.ts
@@ -31,11 +31,10 @@ export async function signInWithOAuthBrowser(
 
 export function handleOAuthCallback(url: string): void {
   try {
-    if (!url.startsWith("eu.drafto.desktop:")) {
+    // URL schemes are case-insensitive per RFC 3986 — normalize before match.
+    if (!url.toLowerCase().startsWith("eu.drafto.desktop:")) {
       return;
     }
-
-    console.info("[oauth] handling callback", url);
 
     const parsed = new URL(url);
 
@@ -47,6 +46,13 @@ export function handleOAuthCallback(url: string): void {
     const hashParams = new URLSearchParams(
       parsed.hash.startsWith("#") ? parsed.hash.slice(1) : parsed.hash,
     );
+
+    // Log only non-sensitive metadata — never the raw URL, which carries
+    // the OAuth code or access/refresh tokens.
+    console.info("[oauth] handling callback", {
+      hasQuery: !!parsed.search,
+      hasHash: !!parsed.hash,
+    });
 
     const code = searchParams.get("code") ?? hashParams.get("code");
     if (code) {

--- a/apps/desktop/src/lib/supabase.ts
+++ b/apps/desktop/src/lib/supabase.ts
@@ -20,5 +20,6 @@ export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: false,
+    flowType: "pkce",
   },
 });


### PR DESCRIPTION
## Summary

After #310 restored the `eu.drafto.desktop` URL scheme in `Info.plist`, Google sign-in on the macOS app still left the user on the login screen. Three downstream bugs were each independently sufficient to break the flow:

1. **AppDelegate never received the URL.** react-native-macos delivers custom-scheme URLs via the classic `'GURL'` Apple Event, but the app didn't register `[RCTLinkingManager class]` with `NSAppleEventManager`, so `Linking.addEventListener("url", …)` in `app-navigator.tsx` never fired. Added the registration in `applicationDidFinishLaunching:`.
2. **`handleOAuthCallback` rejected valid URLs.** It guarded on `parsed.pathname.includes("auth/callback")`, but for `eu.drafto.desktop://auth/callback?code=…` the WHATWG URL parser puts `auth` in the host — pathname is just `/callback`. Replaced with a scheme check plus a param-presence check; also read params from both `search` and `hash` so implicit-flow callbacks work.
3. **Supabase client flowType was implicit.** `oauth.ts` assumes PKCE (`exchangeCodeForSession`), but the client defaulted to `implicit`. Set `flowType: "pkce"` explicitly.

Also bumps `CFBundleVersion` / `CURRENT_PROJECT_VERSION` to **21** for the next TestFlight build, and adds unit tests covering the callback branches (wrong scheme, PKCE code, implicit hash tokens, no-op when unrecognized).

No changes on mobile or web — mobile Google uses `signInWithIdToken` and Apple uses native auth, both already working.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` in `apps/desktop` — 258/258 pass (4 new oauth tests)
- [x] `xcodebuild -workspace Drafto.xcworkspace -scheme Drafto-macOS -configuration Debug CODE_SIGNING_ALLOWED=NO` — BUILD SUCCEEDED; AppDelegate.mm compiles cleanly against `RCTLinkingManager.h`
- [ ] TestFlight beta build cut via `fastlane mac beta` after merge
- [ ] Install TestFlight build on a tester Mac, sign in with Google → confirm the app transitions past the login screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OAuth callback handling with enhanced parameter extraction from authorization URLs
  * Integrated macOS native URL event handling for desktop app linking

* **Bug Fixes**
  * Fixed OAuth callback validation to properly recognize authorization schemes

* **Tests**
  * Added comprehensive test coverage for OAuth callback handling scenarios

* **Chores**
  * Updated application build version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->