### PR TITLE
docs(migrations): add developer recovery runbook for DB mistakes

### DIFF
--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -50,7 +50,7 @@ Never run any of the following against production:
 - `DELETE FROM ...` without a `WHERE` clause
 - `supabase db reset` (drops and recreates the entire database)
 
-`pnpm migration:check` scans staged migrations for these patterns and blocks the push when it finds them. Run it before every migration push.
+`pnpm migration:check` scans all `supabase/migrations/*.sql` files (or explicitly passed paths) for these patterns and blocks the push when it finds them. Run it before every migration push.
 
 ## Production operation confirmation rules
 
@@ -79,7 +79,7 @@ Dev is meant to break — prefer the cheapest recovery:
 
 - Fix the migration file and re-run `pnpm supabase:link:dev && pnpm supabase:push`, **or**
 - Restore via the Supabase dashboard → dev project → Database → Backups, **or**
-- If dev is throwaway, `pnpm supabase:link:dev` then `supabase db reset` to wipe and re-apply all migrations. **Never run `supabase db reset` against prod.**
+- If dev is throwaway, `pnpm supabase:link:dev` then `supabase db reset --linked` to wipe and re-apply all migrations on the linked dev project. **Never run `supabase db reset --linked` against prod.**
 
 #### 3. Bad migration or query hit **prod** (`tbmjbxxseonkciqovnpl`)
 
@@ -110,7 +110,7 @@ PITR cannot help. Remaining options, in order of viability:
 
 ### Preventative guardrails to lean on
 
-- `pnpm migration:check` — blocks `DROP TABLE`, `TRUNCATE`, and bare `DELETE` in staged migrations.
+- `pnpm migration:check` — inspects all `supabase/migrations/*.sql` files (or explicitly passed paths) and blocks `DROP TABLE`, `TRUNCATE`, and bare `DELETE`.
 - `supabase projects list` before every prod push — confirms which ref is currently linked. Easy to forget when switching between dev and prod.
 - Require explicit user "yes" before any prod database operation; state the project ref, operation, and affected data first.
 - Apply every migration to dev first and verify before touching prod.

--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -62,8 +62,58 @@ Never run any of the following against production:
 
 - **Daily automatic backups**: provided by Supabase on all projects.
 - **Point-in-Time Recovery (PITR)**: enabled on the Pro plan (production), allowing granular restore to any moment in the retention window.
+- **Soft delete for notes**: deletions set `is_trashed = true`; a `pg_cron` job purges rows trashed more than 30 days ago (`supabase/migrations/20260302000001_trash_auto_cleanup.sql`). Users can self-recover any accidentally deleted note within that window.
+- **Local replicas**: mobile and desktop clients keep a full WatermelonDB SQLite copy per device. These are not a formal backup, but in a worst-case server loss they are the last surviving copy of a user's notes.
 
-If a destructive change lands in prod, use PITR via the Supabase dashboard to restore before proceeding with further changes.
+### Recovery runbook
+
+Pick the section that matches the blast radius. **Stop writing to the affected database before restoring** — PITR restores the whole DB to a point in time, so every write between the mistake and the restore is also lost.
+
+#### 1. Mistake is local only (not pushed)
+
+Edit or delete the offending migration file under `supabase/migrations/` and start over. No restore needed.
+
+#### 2. Bad migration or query hit **dev** (`huhzactreblzcogqkbsd`)
+
+Dev is meant to break — prefer the cheapest recovery:
+
+- Fix the migration file and re-run `pnpm supabase:link:dev && pnpm supabase:push`, **or**
+- Restore via the Supabase dashboard → dev project → Database → Backups, **or**
+- If dev is throwaway, `pnpm supabase:link:dev` then `supabase db reset` to wipe and re-apply all migrations. **Never run `supabase db reset` against prod.**
+
+#### 3. Bad migration or query hit **prod** (`tbmjbxxseonkciqovnpl`)
+
+1. **Stop the bleeding.** Do not run further migrations, queries, or deploys. Consider putting the app in read-only / maintenance mode if the bug is still actively corrupting data.
+2. **Find the exact timestamp just before the mistake.** Check `git log` on the offending migration, CI run time, or Supabase logs (Dashboard → Logs).
+3. **Open** Supabase dashboard → `drafto.eu` project (`tbmjbxxseonkciqovnpl`) → Database → Backups → **Point in Time Recovery**.
+4. **Pick the timestamp** and trigger the restore. This restores the entire database — every write between the chosen timestamp and now is lost, including legitimate user activity. Accept this trade-off only if the damage is worse than the lost writes.
+5. **Fix the root cause in git** — revert/repair the migration file so the next `supabase db push` does not reapply the same bad SQL.
+6. **Post-mortem**: add a regression case to `pnpm migration:check` if the pattern wasn't caught, and record the incident in an ADR if the fix changes a process or convention.
+
+#### 4. You only need to recover specific rows (e.g. a bad `DELETE FROM notes WHERE …`)
+
+Full PITR is overkill here because it clobbers unrelated user activity. Preferred path:
+
+1. In the Supabase dashboard, restore PITR **into a new temporary project** (not over prod).
+2. `pg_dump` only the affected rows from the temp project.
+3. `INSERT` them back into prod under transaction, with constraints disabled only if necessary and re-enabled after.
+4. Delete the temporary project once verified.
+
+If your plan tier does not expose "restore into a new project," contact Supabase support before touching prod — they can perform the side restore for you.
+
+#### 5. Damage is older than the PITR retention window
+
+PITR cannot help. Remaining options, in order of viability:
+
+- **Mobile/desktop users**: their WatermelonDB SQLite files (`apps/mobile/src/db/`, same schema on desktop) still hold their notes. There is no automated re-ingest — reconstruction is manual per user.
+- **Web-only users**: effectively unrecoverable. Communicate honestly with affected users.
+
+### Preventative guardrails to lean on
+
+- `pnpm migration:check` — blocks `DROP TABLE`, `TRUNCATE`, and bare `DELETE` in staged migrations.
+- `supabase projects list` before every prod push — confirms which ref is currently linked. Easy to forget when switching between dev and prod.
+- Require explicit user "yes" before any prod database operation; state the project ref, operation, and affected data first.
+- Apply every migration to dev first and verify before touching prod.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Expands the Backups and recovery section of `docs/operations/migrations.md` with a triage-by-blast-radius runbook
- Covers five scenarios: local-only mistakes, dev-only, prod via PITR, targeted row recovery into a temp project, and past-retention damage
- Also documents the soft-delete safety net and local WatermelonDB replicas as complementary backup layers

## Test plan
- [x] `pnpm format:check` passes on the edited file
- [x] Links resolve (ADRs, migration file reference)
- [ ] Reviewer sanity-checks the runbook steps against actual Supabase dashboard UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded recovery and backup documentation with comprehensive step-by-step procedures for various failure scenarios.
  * Added preventative guardrails subsection with concrete tooling checks and process recommendations.
  * Enhanced operational guidance for handling migration issues at different deployment stages across local, dev, and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->