### PR TITLE
fix(attachments): decode picker path on macOS and surface upload failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,19 @@ echo "sdk.dir=/Users/jakub/Library/Android/sdk" > apps/mobile/android/local.prop
 - **Cannot merge PRs with `--delete-branch`**: `gh pr merge --delete-branch` fails because it tries to switch to `main` locally. Instead use the GitHub API: `gh api repos/{owner}/{repo}/pulls/{number}/merge -f merge_method=squash`
 - **Fastlane in worktrees**: Worktrees do not share Ruby gems. Run `bundle install` in the worktree's `apps/mobile/` (or `apps/desktop/`) directory before using Fastlane commands. Also copy `google-play-service-account.json` if needed for store submissions.
 
+## Parallel Tool Execution
+
+When planning, fan out independent actions into a single batched message — don't serialise across turns. Only stay sequential when a tool genuinely needs a prior tool's output (e.g., commit after edits, push after commit).
+
+**High-yield cases in this repo:**
+
+- **Cross-platform mirror edits**: `apps/mobile/src/db/` and `apps/desktop/src/db/` must stay in sync (schema, migrations, models). Batch all 6 file edits in one message — never edit one platform, then the other.
+- **Cross-platform UI**: files like `attachment-list.tsx` on desktop and mobile are different files with no dependency — batch, don't serialise.
+- **Verification sweep**: `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, per-app `pnpm --filter … test`, and `pnpm --filter=@drafto/shared test` are independent — fan out in one message.
+- **Exploration**: Launch multiple `Explore` subagents in one message when scoping work across separate areas.
+
+**Worktree gotcha**: `Edit`/`Write` require a prior `Read` of the _exact_ path. Reading `/Users/…/drafto/foo.ts` does NOT satisfy an edit against `/Users/…/drafto-worktree/foo.ts`. Pattern when starting work in a worktree: one batched `Read` for every worktree file you'll touch, then one batched `Edit`/`Write` for all the changes.
+
 ## SOLID Principles (Enforced)
 
 Every module must follow SOLID:

--- a/apps/desktop/__tests__/db/migrations.test.ts
+++ b/apps/desktop/__tests__/db/migrations.test.ts
@@ -30,8 +30,26 @@ describe("WatermelonDB Migrations", () => {
     expect(columnNames).toContain("upload_status");
   });
 
+  it("has migration to version 3", () => {
+    const v3 = migrations.sortedMigrations.find((m) => m.toVersion === 3);
+    expect(v3).toBeDefined();
+    expect(v3!.steps).toBeInstanceOf(Array);
+    expect(v3!.steps.length).toBeGreaterThan(0);
+  });
+
+  it("version 3 adds upload_error column to attachments", () => {
+    const v3 = migrations.sortedMigrations.find((m) => m.toVersion === 3);
+    expect(v3).toBeDefined();
+    const step = v3!.steps[0] as { type: string; table: string; columns: { name: string }[] };
+    expect(step.type).toBe("add_columns");
+    expect(step.table).toBe("attachments");
+
+    const columnNames = step.columns.map((c) => c.name);
+    expect(columnNames).toContain("upload_error");
+  });
+
   it("has correct version range", () => {
     expect(migrations.minVersion).toBe(1);
-    expect(migrations.maxVersion).toBe(2);
+    expect(migrations.maxVersion).toBe(3);
   });
 });

--- a/apps/desktop/__tests__/db/schema.test.ts
+++ b/apps/desktop/__tests__/db/schema.test.ts
@@ -1,8 +1,8 @@
 import { schema, notebooksTable, notesTable, attachmentsTable } from "@/db/schema";
 
 describe("WatermelonDB Schema", () => {
-  it("has schema version 2", () => {
-    expect(schema.version).toBe(2);
+  it("has schema version 3", () => {
+    expect(schema.version).toBe(3);
   });
 
   it("defines 3 tables", () => {
@@ -78,6 +78,7 @@ describe("WatermelonDB Schema", () => {
       expect(columnNames).toContain("mime_type");
       expect(columnNames).toContain("local_uri");
       expect(columnNames).toContain("upload_status");
+      expect(columnNames).toContain("upload_error");
       expect(columnNames).toContain("created_at");
     });
 
@@ -89,6 +90,11 @@ describe("WatermelonDB Schema", () => {
     it("has local_uri as optional", () => {
       const localUriCol = attachmentsTable.columnArray.find((c) => c.name === "local_uri");
       expect(localUriCol?.isOptional).toBe(true);
+    });
+
+    it("has upload_error as optional", () => {
+      const uploadErrorCol = attachmentsTable.columnArray.find((c) => c.name === "upload_error");
+      expect(uploadErrorCol?.isOptional).toBe(true);
     });
   });
 });

--- a/apps/desktop/__tests__/lib/attachment-queue.test.ts
+++ b/apps/desktop/__tests__/lib/attachment-queue.test.ts
@@ -1,15 +1,16 @@
 const mockUpload = jest.fn();
 const mockUpsert = jest.fn();
 const mockQuery = jest.fn();
-const mockFetch = jest.fn();
 const mockDatabaseWrite = jest.fn((fn: () => Promise<unknown>) => fn());
 const mockDatabaseGet = jest.fn();
+const mockCreate = jest.fn();
 
 jest.mock("react-native-fs", () => ({
   DocumentDirectoryPath: "/mock/documents",
   exists: jest.fn().mockResolvedValue(true),
   mkdir: jest.fn().mockResolvedValue(undefined),
   copyFile: jest.fn().mockResolvedValue(undefined),
+  readFile: jest.fn().mockResolvedValue(""),
   unlink: jest.fn().mockResolvedValue(undefined),
   readDir: jest.fn().mockResolvedValue([]),
 }));
@@ -24,7 +25,12 @@ jest.mock("@/db", () => ({
     write: (fn: () => Promise<unknown>) => mockDatabaseWrite(fn),
     get: (_table: string) =>
       mockDatabaseGet(_table) ?? {
-        create: jest.fn().mockResolvedValue({ id: "att-1" }),
+        create: (builder: (rec: Record<string, unknown>) => void) => {
+          const rec: Record<string, unknown> = { _raw: {} };
+          builder(rec);
+          mockCreate(rec);
+          return { id: rec.remoteId ?? "att-1" };
+        },
         query: (...qArgs: unknown[]) => mockQuery(...qArgs),
       },
   },
@@ -44,24 +50,114 @@ jest.mock("@/lib/generate-id", () => ({
   generateId: () => "mock-id-123",
 }));
 
-// Mock global fetch
-const originalFetch = global.fetch;
-beforeAll(() => {
-  global.fetch = mockFetch as unknown as typeof fetch;
-});
-afterAll(() => {
-  global.fetch = originalFetch;
-});
+// atob is used by attachment-queue to decode base64 from RNFS.readFile.
+// In Node test env, provide a global shim if not already present.
+if (typeof globalThis.atob !== "function") {
+  globalThis.atob = (b64: string) => Buffer.from(b64, "base64").toString("binary");
+}
 
-import { processPendingUploads, cleanupOrphanedFiles } from "@/lib/data/attachment-queue";
+import {
+  queueAttachment,
+  processPendingUploads,
+  cleanupOrphanedFiles,
+} from "@/lib/data/attachment-queue";
 import RNFS from "react-native-fs";
 
 beforeEach(() => {
   jest.clearAllMocks();
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+  (RNFS.exists as jest.Mock).mockResolvedValue(true);
+  mockDatabaseWrite.mockImplementation((fn: () => Promise<unknown>) => fn());
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("queueAttachment (saveFileLocally path handling)", () => {
+  it("passes the decoded filesystem path to RNFS.copyFile (not the percent-encoded URI)", async () => {
+    // Simulates react-native-document-picker-macos output for a file whose name
+    // contains a space and an NFD-decomposed umlaut: percent-encoded URI +
+    // decoded path. Using the URI string with RNFS.copyFile surfaces the
+    // "no such file" error reported on macOS.
+    const file = {
+      uri: "file:///Users/j/Downloads/partikelverb%20Ao%CC%88b(1).pdf",
+      path: "/Users/j/Downloads/partikelverb Aöb(1).pdf",
+      fileName: "partikelverb Aöb(1).pdf",
+      mimeType: "application/pdf",
+      fileSize: 2048,
+    };
+
+    await queueAttachment("user-1", "note-1", file);
+
+    expect(RNFS.copyFile).toHaveBeenCalledWith(
+      "/Users/j/Downloads/partikelverb Aöb(1).pdf",
+      expect.stringContaining("/mock/documents/attachments/"),
+    );
+    expect(RNFS.copyFile).not.toHaveBeenCalledWith(
+      expect.stringContaining("%20"),
+      expect.anything(),
+    );
+  });
+
+  it("throws when file exceeds MAX_FILE_SIZE", async () => {
+    const bigFile = {
+      uri: "file:///big.bin",
+      path: "/big.bin",
+      fileName: "big.bin",
+      mimeType: "application/octet-stream",
+      fileSize: 26 * 1024 * 1024,
+    };
+
+    await expect(queueAttachment("user-1", "note-1", bigFile)).rejects.toThrow(
+      "File size exceeds 25MB limit",
+    );
+    expect(RNFS.copyFile).not.toHaveBeenCalled();
+  });
+
+  it("initialises record with pending status and null uploadError", async () => {
+    const file = {
+      uri: "file:///doc.pdf",
+      path: "/doc.pdf",
+      fileName: "doc.pdf",
+      mimeType: "application/pdf",
+      fileSize: 1024,
+    };
+
+    await queueAttachment("user-1", "note-1", file);
+
+    expect(mockCreate).toHaveBeenCalled();
+    const record = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(record.uploadStatus).toBe("pending");
+    expect(record.uploadError).toBeNull();
+  });
 });
 
 describe("processPendingUploads", () => {
-  it("returns 0 when no pending attachments", async () => {
+  function makeAttachment(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      id: "att-1",
+      remoteId: "remote-1",
+      noteId: "note-1",
+      userId: "user-1",
+      fileName: "photo.jpg",
+      filePath: "user-1/note-1/photo.jpg",
+      fileSize: 1024,
+      mimeType: "image/jpeg",
+      localUri: "file:///local/photo.jpg",
+      uploadStatus: "pending",
+      uploadError: null,
+      update: jest.fn((builder: (rec: Record<string, unknown>) => void) => {
+        const rec: Record<string, unknown> = {};
+        builder(rec);
+        Object.assign(overrides, rec);
+        return Promise.resolve();
+      }),
+      ...overrides,
+    };
+  }
+
+  it("returns 0 when queue is empty", async () => {
     mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([]) });
     mockDatabaseGet.mockReturnValue({
       query: (...args: unknown[]) => mockQuery(...args),
@@ -71,117 +167,121 @@ describe("processPendingUploads", () => {
     expect(uploaded).toBe(0);
   });
 
-  it("skips upload when local file does not exist", async () => {
-    const mockAttachment = {
-      id: "att-1",
-      remoteId: "remote-1",
-      noteId: "note-1",
-      userId: "user-1",
-      fileName: "photo.jpg",
-      filePath: "user-1/note-1/photo.jpg",
-      fileSize: 1024,
-      mimeType: "image/jpeg",
-      localUri: "file:///local/photo.jpg",
-      uploadStatus: "pending",
-      update: jest.fn(),
-    };
+  it("uploads via Uint8Array derived from RNFS.readFile(base64), not fetch+blob", async () => {
+    const attachment = makeAttachment();
+    mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([attachment]) });
+    mockDatabaseGet.mockReturnValue({
+      query: (...args: unknown[]) => mockQuery(...args),
+    });
 
-    mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([mockAttachment]) });
+    // "hello" in base64
+    (RNFS.readFile as jest.Mock).mockResolvedValue("aGVsbG8=");
+    mockUpload.mockResolvedValue({ error: null });
+    mockUpsert.mockResolvedValue({ error: null });
+
+    const uploaded = await processPendingUploads();
+
+    expect(uploaded).toBe(1);
+    expect(RNFS.readFile).toHaveBeenCalledWith("/local/photo.jpg", "base64");
+    const [, body, opts] = mockUpload.mock.calls[0];
+    expect(body).toBeInstanceOf(Uint8Array);
+    expect((body as Uint8Array).length).toBe(5);
+    expect(opts).toEqual({ contentType: "image/jpeg", upsert: false });
+  });
+
+  it("persists error message and transitions status to 'failed' when upload throws", async () => {
+    const attachment = makeAttachment();
+    mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([attachment]) });
+    mockDatabaseGet.mockReturnValue({
+      query: (...args: unknown[]) => mockQuery(...args),
+    });
+
+    (RNFS.readFile as jest.Mock).mockResolvedValue("aGVsbG8=");
+    mockUpload.mockResolvedValue({ error: { message: "Upload timeout" } });
+
+    await processPendingUploads();
+
+    // Last update call should set status=failed and uploadError=message
+    expect(attachment.update).toHaveBeenCalled();
+    const calls = attachment.update.mock.calls;
+    const lastBuilder = calls[calls.length - 1][0] as (rec: Record<string, unknown>) => void;
+    const rec: Record<string, unknown> = {};
+    lastBuilder(rec);
+    expect(rec.uploadStatus).toBe("failed");
+    expect(rec.uploadError).toContain("Upload timeout");
+  });
+
+  it("persists 'Local file not found' as error when file is missing", async () => {
+    const attachment = makeAttachment();
+    mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([attachment]) });
     mockDatabaseGet.mockReturnValue({
       query: (...args: unknown[]) => mockQuery(...args),
     });
 
     (RNFS.exists as jest.Mock).mockResolvedValue(false);
 
-    const uploaded = await processPendingUploads();
-    expect(uploaded).toBe(0);
-    expect(mockUpload).not.toHaveBeenCalled();
+    await processPendingUploads();
+
+    const calls = attachment.update.mock.calls;
+    const lastBuilder = calls[calls.length - 1][0] as (rec: Record<string, unknown>) => void;
+    const rec: Record<string, unknown> = {};
+    lastBuilder(rec);
+    expect(rec.uploadStatus).toBe("failed");
+    expect(rec.uploadError).toBe("Local file not found");
   });
 
-  it("uploads attachment and marks as uploaded on success", async () => {
-    const mockUpdate = jest.fn();
-    const mockAttachment = {
-      id: "att-1",
-      remoteId: "remote-1",
-      noteId: "note-1",
-      userId: "user-1",
-      fileName: "photo.jpg",
-      filePath: "user-1/note-1/photo.jpg",
-      fileSize: 1024,
-      mimeType: "image/jpeg",
-      localUri: "file:///local/photo.jpg",
-      uploadStatus: "pending",
-      update: mockUpdate,
-    };
-
-    mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([mockAttachment]) });
+  it("resets a previously-failed attachment to 'pending' before retrying", async () => {
+    const attachment = makeAttachment({ uploadStatus: "failed", uploadError: "prior failure" });
+    mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([attachment]) });
     mockDatabaseGet.mockReturnValue({
       query: (...args: unknown[]) => mockQuery(...args),
     });
 
-    (RNFS.exists as jest.Mock).mockResolvedValue(true);
-
-    const mockBlob = { size: 1024 };
-    mockFetch.mockResolvedValue({
-      blob: jest.fn().mockResolvedValue(mockBlob),
-    });
+    (RNFS.readFile as jest.Mock).mockResolvedValue("aGVsbG8=");
     mockUpload.mockResolvedValue({ error: null });
     mockUpsert.mockResolvedValue({ error: null });
-    mockDatabaseWrite.mockImplementation((fn: () => Promise<unknown>) => fn());
 
-    const uploaded = await processPendingUploads();
+    await processPendingUploads();
 
-    expect(uploaded).toBe(1);
-    expect(mockUpload).toHaveBeenCalledWith("user-1/note-1/photo.jpg", mockBlob, {
-      contentType: "image/jpeg",
-      upsert: false,
-    });
+    // First update call (before the upload attempt) should flip to pending + null error
+    const firstBuilder = attachment.update.mock.calls[0][0] as (
+      rec: Record<string, unknown>,
+    ) => void;
+    const rec: Record<string, unknown> = {};
+    firstBuilder(rec);
+    expect(rec.uploadStatus).toBe("pending");
+    expect(rec.uploadError).toBeNull();
   });
 
-  it("continues with next attachment on individual failure", async () => {
-    const att1 = {
-      id: "att-1",
-      remoteId: "remote-1",
-      noteId: "note-1",
-      userId: "user-1",
-      fileName: "fail.jpg",
-      filePath: "user-1/note-1/fail.jpg",
-      fileSize: 1024,
-      mimeType: "image/jpeg",
-      localUri: "file:///local/fail.jpg",
-      uploadStatus: "pending",
-      update: jest.fn(),
-    };
-
-    const att2 = {
-      id: "att-2",
-      remoteId: "remote-2",
-      noteId: "note-1",
-      userId: "user-1",
-      fileName: "ok.jpg",
-      filePath: "user-1/note-1/ok.jpg",
-      fileSize: 2048,
-      mimeType: "image/jpeg",
-      localUri: "file:///local/ok.jpg",
-      uploadStatus: "pending",
-      update: jest.fn(),
-    };
-
-    mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([att1, att2]) });
+  it("queries for both 'pending' and 'failed' upload_status values", async () => {
+    mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([]) });
     mockDatabaseGet.mockReturnValue({
       query: (...args: unknown[]) => mockQuery(...args),
     });
 
-    (RNFS.exists as jest.Mock).mockResolvedValue(true);
+    await processPendingUploads();
 
-    // First attachment fails at fetch, second succeeds
-    mockFetch.mockRejectedValueOnce(new Error("File read error")).mockResolvedValueOnce({
-      blob: jest.fn().mockResolvedValue({ size: 2048 }),
+    // First arg to Q.where is the column; second should be a Q.oneOf(["pending", "failed"])
+    expect(mockQuery).toHaveBeenCalled();
+    const queryArg = mockQuery.mock.calls[0][0];
+    // Q.where("upload_status", Q.oneOf(["pending", "failed"])) — just verify
+    // the query was called with something involving upload_status; the exact
+    // shape depends on WatermelonDB internals.
+    expect(JSON.stringify(queryArg)).toContain("upload_status");
+  });
+
+  it("treats 'already exists' storage error as success (idempotent retry)", async () => {
+    const attachment = makeAttachment();
+    mockQuery.mockReturnValue({ fetch: jest.fn().mockResolvedValue([attachment]) });
+    mockDatabaseGet.mockReturnValue({
+      query: (...args: unknown[]) => mockQuery(...args),
     });
 
-    mockUpload.mockResolvedValue({ error: null });
+    (RNFS.readFile as jest.Mock).mockResolvedValue("aGVsbG8=");
+    mockUpload.mockResolvedValue({
+      error: { message: "The resource already exists", statusCode: "409" },
+    });
     mockUpsert.mockResolvedValue({ error: null });
-    mockDatabaseWrite.mockImplementation((fn: () => Promise<unknown>) => fn());
 
     const uploaded = await processPendingUploads();
     expect(uploaded).toBe(1);

--- a/apps/desktop/__tests__/lib/data/attachments.test.ts
+++ b/apps/desktop/__tests__/lib/data/attachments.test.ts
@@ -13,33 +13,19 @@ jest.mock("@drafto/shared", () => ({
   SIGNED_URL_EXPIRY_SECONDS: 604800,
 }));
 
-jest.mock("@/lib/data/attachment-utils", () => ({
-  sanitizeFileName: (name: string) => name.replace(/[^a-zA-Z0-9._-]/g, "_"),
-}));
-
 import { NativeModules } from "react-native";
 import { supabase } from "@/lib/supabase";
-import type { PickedFile } from "@/lib/data/attachments";
 
 // Configure the native module mock that the source file destructures at load time.
 // The react-native preset provides NativeModules as a plain object;
 // we must set RNDocumentPicker on it *before* the source module is first required.
-// Because jest.mock calls above are hoisted and run before imports, and the
-// attachments module import below triggers the first require, we need to ensure
-// NativeModules.RNDocumentPicker is set before that. We use a jest.mock for
-// the source module itself, deferring to requireActual after setting up NativeModules.
 const mockPick = jest.fn();
 
-// Install the mock on NativeModules. This runs at module scope, after jest.mock
-// calls are processed but before the dynamic imports below.
 NativeModules.RNDocumentPicker = { pick: mockPick };
 
-// Now import the module under test. By this point NativeModules.RNDocumentPicker
-// is set, so the destructuring in the source file captures our mock.
-// NOTE: We use require() to guarantee ordering (imports would be hoisted).
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- require needed for load ordering
 const attachments = require("@/lib/data/attachments") as typeof import("@/lib/data/attachments");
-const { pickImage, pickDocument, uploadAttachment, getSignedUrl, deleteAttachment } = attachments;
+const { pickImage, pickDocument, getSignedUrl, deleteAttachment } = attachments;
 
 function createChainableMock(resolvedValue: { data?: unknown; error?: unknown }) {
   const chain: Record<string, jest.Mock> = {};
@@ -61,9 +47,7 @@ const mockStorageFrom = supabase.storage.from as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // Re-install the mock since clearAllMocks resets mockPick
   NativeModules.RNDocumentPicker = { pick: mockPick };
-  (global.fetch as jest.Mock) = jest.fn();
   jest.spyOn(console, "warn").mockImplementation(() => {});
 });
 
@@ -74,9 +58,15 @@ afterEach(() => {
 // ---------- pickImage ----------
 
 describe("pickImage", () => {
-  it("returns a PickedFile when user selects an image", async () => {
+  it("returns a PickedFile with both uri and decoded path", async () => {
     mockPick.mockResolvedValue([
-      { uri: "file:///img.png", name: "img.png", mimeType: "image/png", size: 1024 },
+      {
+        uri: "file:///img.png",
+        path: "/img.png",
+        name: "img.png",
+        mimeType: "image/png",
+        size: 1024,
+      },
     ]);
 
     const result = await pickImage();
@@ -86,10 +76,31 @@ describe("pickImage", () => {
     );
     expect(result).toEqual({
       uri: "file:///img.png",
+      path: "/img.png",
       fileName: "img.png",
       mimeType: "image/png",
       fileSize: 1024,
     });
+  });
+
+  it("preserves decoded path when the URI contains percent-encoded characters", async () => {
+    // macOS returns NFD-decomposed ö as two code points (o + U+0308), URL-encoded as %CC%88
+    mockPick.mockResolvedValue([
+      {
+        uri: "file:///Users/j/Downloads/partikelverb%20Ao%CC%88b(1).pdf",
+        path: "/Users/j/Downloads/partikelverb Aöb(1).pdf",
+        name: "partikelverb Aöb(1).pdf",
+        mimeType: "application/pdf",
+        size: 2048,
+      },
+    ]);
+
+    const result = await pickDocument();
+
+    // path must be the decoded filesystem path — otherwise RNFS.copyFile fails
+    // with "no such file" and surfaces the percent-encoded name in the error.
+    expect(result?.path).toBe("/Users/j/Downloads/partikelverb Aöb(1).pdf");
+    expect(result?.uri).toContain("%20");
   });
 
   it("returns null when picker returns empty results", async () => {
@@ -122,13 +133,16 @@ describe("pickImage", () => {
   });
 
   it("uses fallback values when name/mimeType/size are null", async () => {
-    mockPick.mockResolvedValue([{ uri: "file:///x", name: null, mimeType: null, size: null }]);
+    mockPick.mockResolvedValue([
+      { uri: "file:///x", path: "/x", name: null, mimeType: null, size: null },
+    ]);
 
     const result = await pickImage();
 
     expect(result).toEqual(
       expect.objectContaining({
         uri: "file:///x",
+        path: "/x",
         mimeType: "application/octet-stream",
         fileSize: 0,
       }),
@@ -142,7 +156,13 @@ describe("pickImage", () => {
 describe("pickDocument", () => {
   it("returns a PickedFile when user selects a document", async () => {
     mockPick.mockResolvedValue([
-      { uri: "file:///doc.pdf", name: "doc.pdf", mimeType: "application/pdf", size: 2048 },
+      {
+        uri: "file:///doc.pdf",
+        path: "/doc.pdf",
+        name: "doc.pdf",
+        mimeType: "application/pdf",
+        size: 2048,
+      },
     ]);
 
     const result = await pickDocument();
@@ -153,6 +173,7 @@ describe("pickDocument", () => {
     );
     expect(result).toEqual({
       uri: "file:///doc.pdf",
+      path: "/doc.pdf",
       fileName: "doc.pdf",
       mimeType: "application/pdf",
       fileSize: 2048,
@@ -169,118 +190,15 @@ describe("pickDocument", () => {
   });
 
   it("uses fallback values when name/mimeType/size are null", async () => {
-    mockPick.mockResolvedValue([{ uri: "file:///y", name: null, mimeType: null, size: null }]);
+    mockPick.mockResolvedValue([
+      { uri: "file:///y", path: "/y", name: null, mimeType: null, size: null },
+    ]);
 
     const result = await pickDocument();
 
     expect(result!.fileName).toMatch(/^file_\d+$/);
     expect(result!.mimeType).toBe("application/octet-stream");
     expect(result!.fileSize).toBe(0);
-  });
-});
-
-// ---------- uploadAttachment ----------
-
-describe("uploadAttachment", () => {
-  const file: PickedFile = {
-    uri: "file:///photo.jpg",
-    fileName: "photo.jpg",
-    mimeType: "image/jpeg",
-    fileSize: 5000,
-  };
-
-  const fakeBlob = new Blob(["data"]);
-
-  function setupUploadMocks(opts?: {
-    uploadError?: { message: string };
-    dbData?: Record<string, unknown> | null;
-    dbError?: { message: string } | null;
-  }) {
-    (global.fetch as jest.Mock).mockResolvedValue({ blob: () => Promise.resolve(fakeBlob) });
-
-    const uploadMock = jest.fn().mockResolvedValue({ error: opts?.uploadError ?? null });
-    const removeMock = jest.fn().mockResolvedValue({ error: null });
-    mockStorageFrom.mockReturnValue({ upload: uploadMock, remove: removeMock });
-
-    const dbRecord = opts?.dbData ?? {
-      id: "att-1",
-      note_id: "note-1",
-      file_name: "photo.jpg",
-      file_path: "user-1/note-1/photo.jpg",
-      file_size: 5000,
-      mime_type: "image/jpeg",
-    };
-    const chain = createChainableMock({
-      data: opts?.dbData === null ? null : dbRecord,
-      error: opts?.dbError ?? null,
-    });
-    // Override single to return { data: attachment, error }
-    chain.single = jest.fn(() =>
-      Promise.resolve({
-        data: opts?.dbError || opts?.dbData === null ? null : dbRecord,
-        error: opts?.dbError ?? null,
-      }),
-    );
-    mockFrom.mockReturnValue(chain);
-
-    return { uploadMock, removeMock, chain };
-  }
-
-  it("throws when file exceeds MAX_FILE_SIZE", async () => {
-    const bigFile: PickedFile = { ...file, fileSize: 26 * 1024 * 1024 };
-
-    await expect(uploadAttachment("user-1", "note-1", bigFile)).rejects.toThrow(
-      "File size exceeds 25MB limit",
-    );
-  });
-
-  it("uploads file to storage and creates DB record", async () => {
-    const { uploadMock } = setupUploadMocks();
-
-    const result = await uploadAttachment("user-1", "note-1", file);
-
-    expect(global.fetch).toHaveBeenCalledWith("file:///photo.jpg");
-    expect(mockStorageFrom).toHaveBeenCalledWith("attachments");
-    expect(uploadMock).toHaveBeenCalledWith(
-      expect.stringContaining("user-1/note-1/"),
-      fakeBlob,
-      expect.objectContaining({ contentType: "image/jpeg", upsert: false }),
-    );
-    expect(result).toEqual(
-      expect.objectContaining({
-        id: "att-1",
-        noteId: "note-1",
-        fileName: "photo.jpg",
-        fileSize: 5000,
-        mimeType: "image/jpeg",
-      }),
-    );
-  });
-
-  it("throws on storage upload error", async () => {
-    setupUploadMocks({ uploadError: { message: "Storage full" } });
-
-    await expect(uploadAttachment("user-1", "note-1", file)).rejects.toThrow(
-      "Upload failed: Storage full",
-    );
-  });
-
-  it("cleans up storage on DB insert failure", async () => {
-    const { removeMock } = setupUploadMocks({ dbError: { message: "DB constraint" } });
-
-    await expect(uploadAttachment("user-1", "note-1", file)).rejects.toThrow(
-      "Failed to save attachment record: DB constraint",
-    );
-    expect(removeMock).toHaveBeenCalledWith([expect.stringContaining("user-1/note-1/")]);
-  });
-
-  it("cleans up storage when DB returns null data", async () => {
-    const { removeMock } = setupUploadMocks({ dbData: null });
-
-    await expect(uploadAttachment("user-1", "note-1", file)).rejects.toThrow(
-      "Failed to save attachment record",
-    );
-    expect(removeMock).toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/components/editor/attachment-list.tsx
+++ b/apps/desktop/src/components/editor/attachment-list.tsx
@@ -13,6 +13,7 @@ import {
 import { getSignedUrl, deleteAttachment as deleteAttachmentApi, openAttachment } from "@/lib/data";
 import { useDatabase } from "@/providers/database-provider";
 import { useTheme } from "@/providers/theme-provider";
+import { Badge } from "@/components/ui/badge";
 import { colors, fontSizes, radii, spacing } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
 import type { Attachment } from "@/db";
@@ -34,21 +35,24 @@ function formatFileSize(bytes: number): string {
 interface AttachmentItemProps {
   attachment: Attachment;
   onDelete: (attachment: Attachment) => void;
+  onRetry: () => void;
   styles: ReturnType<typeof createStyles>;
 }
 
-function AttachmentItem({ attachment, onDelete, styles }: AttachmentItemProps) {
+function AttachmentItem({ attachment, onDelete, onRetry, styles }: AttachmentItemProps) {
   const [signedUrl, setSignedUrl] = useState<string | null>(null);
   const [loadingUrl, setLoadingUrl] = useState(false);
   const [urlError, setUrlError] = useState(false);
   const [imageError, setImageError] = useState(false);
   const isImage = isImageMimeType(attachment.mimeType);
   const isPending = attachment.isPendingUpload;
+  const hasFailed = attachment.hasFailed;
+  const isLocal = isPending || hasFailed;
 
-  const displayUri = isPending ? attachment.localUri : signedUrl;
+  const displayUri = isLocal ? attachment.localUri : signedUrl;
 
   useEffect(() => {
-    if (isPending) return;
+    if (isLocal) return;
 
     let cancelled = false;
 
@@ -69,9 +73,14 @@ function AttachmentItem({ attachment, onDelete, styles }: AttachmentItemProps) {
     return () => {
       cancelled = true;
     };
-  }, [attachment.filePath, isPending]);
+  }, [attachment.filePath, isLocal]);
 
   const handlePress = useCallback(async () => {
+    if (hasFailed) {
+      onRetry();
+      return;
+    }
+
     if (!isPending && urlError) {
       setLoadingUrl(true);
       setUrlError(false);
@@ -92,7 +101,15 @@ function AttachmentItem({ attachment, onDelete, styles }: AttachmentItemProps) {
       localUri: attachment.localUri,
       isPending,
     });
-  }, [signedUrl, isPending, attachment.localUri, attachment.filePath, urlError]);
+  }, [
+    signedUrl,
+    isPending,
+    hasFailed,
+    attachment.localUri,
+    attachment.filePath,
+    urlError,
+    onRetry,
+  ]);
 
   const handleDelete = useCallback(() => {
     onDelete(attachment);
@@ -101,7 +118,7 @@ function AttachmentItem({ attachment, onDelete, styles }: AttachmentItemProps) {
   if (isImage) {
     return (
       <View style={styles.imageItem}>
-        {!isPending && loadingUrl ? (
+        {!isLocal && loadingUrl ? (
           <View style={styles.imagePlaceholder}>
             <ActivityIndicator size="small" color={colors.primary[600]} />
           </View>
@@ -115,7 +132,7 @@ function AttachmentItem({ attachment, onDelete, styles }: AttachmentItemProps) {
               accessibilityLabel={attachment.fileName}
             />
           </Pressable>
-        ) : urlError ? (
+        ) : urlError || hasFailed ? (
           <Pressable onPress={handlePress} style={styles.imagePlaceholder}>
             <Text style={styles.retryIcon}>↻</Text>
             <Text style={styles.retryHint}>Click to retry</Text>
@@ -133,6 +150,7 @@ function AttachmentItem({ attachment, onDelete, styles }: AttachmentItemProps) {
         <View style={styles.imageFooter}>
           <View style={styles.fileNameRow}>
             {isPending && <PendingBadge />}
+            {hasFailed && <FailedBadge />}
             <Text style={styles.imageFileName} numberOfLines={1}>
               {attachment.fileName}
             </Text>
@@ -146,28 +164,42 @@ function AttachmentItem({ attachment, onDelete, styles }: AttachmentItemProps) {
             <Text style={styles.deleteIcon}>🗑</Text>
           </Pressable>
         </View>
+        {hasFailed && attachment.uploadError && (
+          <Text style={styles.errorText} numberOfLines={2}>
+            {attachment.uploadError}
+          </Text>
+        )}
       </View>
     );
   }
+
+  const fileMeta = hasFailed
+    ? (attachment.uploadError ?? "Upload failed — click to retry")
+    : urlError
+      ? "Click to retry"
+      : formatFileSize(attachment.fileSize);
 
   return (
     <Pressable
       style={styles.fileItem}
       onPress={handlePress}
-      disabled={!isPending && !signedUrl && !urlError && loadingUrl}
-      accessibilityLabel={`Open ${attachment.fileName}`}
-      accessibilityRole="link"
+      disabled={!isLocal && !signedUrl && !urlError && loadingUrl}
+      accessibilityLabel={
+        hasFailed ? `Retry upload of ${attachment.fileName}` : `Open ${attachment.fileName}`
+      }
+      accessibilityRole={hasFailed ? "button" : "link"}
     >
-      <Text style={styles.fileIcon}>{urlError ? "↻" : "📄"}</Text>
+      <Text style={styles.fileIcon}>{hasFailed || urlError ? "↻" : "📄"}</Text>
       <View style={styles.fileInfo}>
         <View style={styles.fileNameRow}>
           {isPending && <PendingBadge />}
+          {hasFailed && <FailedBadge />}
           <Text style={styles.fileFileName} numberOfLines={1}>
             {attachment.fileName}
           </Text>
         </View>
-        <Text style={styles.fileMeta}>
-          {urlError ? "Click to retry" : formatFileSize(attachment.fileSize)}
+        <Text style={hasFailed ? styles.errorText : styles.fileMeta} numberOfLines={2}>
+          {fileMeta}
         </Text>
       </View>
       <Pressable
@@ -191,10 +223,20 @@ function PendingBadge() {
   );
 }
 
+function FailedBadge() {
+  return <Badge label="Failed" variant="error" />;
+}
+
 export function AttachmentList({ attachments }: AttachmentListProps) {
   const { database, sync } = useDatabase();
   const { semantic } = useTheme();
   const styles = useMemo(() => createStyles(semantic), [semantic]);
+
+  const handleRetry = useCallback(() => {
+    sync().catch((err) => {
+      console.warn("[AttachmentList] Retry sync failed:", err);
+    });
+  }, [sync]);
 
   const handleDelete = useCallback(
     (attachment: Attachment) => {
@@ -206,7 +248,7 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
           onPress: async () => {
             try {
               // Only delete from Supabase if already uploaded
-              if (!attachment.isPendingUpload) {
+              if (attachment.uploadStatus === "uploaded") {
                 await deleteAttachmentApi(attachment.remoteId, attachment.filePath);
               }
               await database.write(async () => {
@@ -237,7 +279,12 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
         horizontal={false}
         scrollEnabled={false}
         renderItem={({ item }) => (
-          <AttachmentItem attachment={item} onDelete={handleDelete} styles={styles} />
+          <AttachmentItem
+            attachment={item}
+            onDelete={handleDelete}
+            onRetry={handleRetry}
+            styles={styles}
+          />
         )}
       />
     </View>
@@ -358,6 +405,12 @@ const createStyles = (semantic: SemanticColors) =>
       fontSize: fontSizes.sm,
       color: semantic.fgSubtle,
       marginTop: spacing["2xs"],
+    },
+    errorText: {
+      fontSize: fontSizes.sm,
+      color: semantic.errorText,
+      marginTop: spacing["2xs"],
+      paddingHorizontal: spacing.sm,
     },
     fileNameRow: {
       flexDirection: "row",

--- a/apps/desktop/src/db/migrations.ts
+++ b/apps/desktop/src/db/migrations.ts
@@ -3,6 +3,15 @@ import { schemaMigrations, addColumns } from "@nozbe/watermelondb/Schema/migrati
 export const migrations = schemaMigrations({
   migrations: [
     {
+      toVersion: 3,
+      steps: [
+        addColumns({
+          table: "attachments",
+          columns: [{ name: "upload_error", type: "string", isOptional: true }],
+        }),
+      ],
+    },
+    {
       toVersion: 2,
       steps: [
         addColumns({

--- a/apps/desktop/src/db/models/attachment.ts
+++ b/apps/desktop/src/db/models/attachment.ts
@@ -3,7 +3,7 @@ import { field, date, readonly, relation } from "@nozbe/watermelondb/decorators"
 
 import type { Note } from "./note";
 
-export type UploadStatus = "pending" | "uploaded";
+export type UploadStatus = "pending" | "uploaded" | "failed";
 
 export class Attachment extends Model {
   static table = "attachments";
@@ -22,10 +22,15 @@ export class Attachment extends Model {
   @readonly @date("created_at") createdAt!: Date;
   @field("local_uri") localUri!: string | null;
   @field("upload_status") uploadStatus!: UploadStatus;
+  @field("upload_error") uploadError!: string | null;
 
   @relation("notes", "note_id") note!: Relation<Note>;
 
   get isPendingUpload(): boolean {
     return this.uploadStatus === "pending";
+  }
+
+  get hasFailed(): boolean {
+    return this.uploadStatus === "failed";
   }
 }

--- a/apps/desktop/src/db/schema.ts
+++ b/apps/desktop/src/db/schema.ts
@@ -39,10 +39,11 @@ export const attachmentsTable = tableSchema({
     { name: "created_at", type: "number" },
     { name: "local_uri", type: "string", isOptional: true },
     { name: "upload_status", type: "string" },
+    { name: "upload_error", type: "string", isOptional: true },
   ],
 });
 
 export const schema = appSchema({
-  version: 2,
+  version: 3,
   tables: [notebooksTable, notesTable, attachmentsTable],
 });

--- a/apps/desktop/src/lib/data/attachment-queue.ts
+++ b/apps/desktop/src/lib/data/attachment-queue.ts
@@ -25,9 +25,10 @@ async function saveFileLocally(file: PickedFile): Promise<string> {
   const localFileName = `${generateId()}_${sanitizeFileName(file.fileName)}`;
   const destination = `${dir}/${localFileName}`;
 
-  // react-native-document-picker-macos provides file:// URIs on macOS
-  const sourcePath = file.uri.startsWith("file://") ? file.uri.slice(7) : file.uri;
-  await RNFS.copyFile(sourcePath, destination);
+  // Use the decoded POSIX path from the native picker — `file.uri` is a
+  // percent-encoded file:// URL (e.g. macOS NFD-decomposed ö becomes %CC%88),
+  // which RNFS.copyFile cannot resolve as a filesystem path.
+  await RNFS.copyFile(file.path, destination);
 
   return `file://${destination}`;
 }
@@ -58,10 +59,20 @@ export async function queueAttachment(
       record.mimeType = file.mimeType;
       record.localUri = localUri;
       record.uploadStatus = "pending";
+      record.uploadError = null;
     });
   });
 
   return attachment;
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = globalThis.atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
 }
 
 async function uploadSingleAttachment(attachment: Attachment): Promise<void> {
@@ -76,14 +87,20 @@ async function uploadSingleAttachment(attachment: Attachment): Promise<void> {
     throw new Error("Local file not found");
   }
 
-  // Read file as a Blob via fetch
-  const fetchResponse = await fetch(localUri);
-  const blob = await fetchResponse.blob();
+  // Read file bytes natively via RNFS — React Native's fetch() with file://
+  // URIs can produce empty or truncated blobs for larger files on macOS.
+  const base64 = await RNFS.readFile(localPath, "base64");
+  const bytes = base64ToBytes(base64);
 
-  // Upload to Supabase Storage
+  if (bytes.length === 0) {
+    throw new Error("Local file is empty — skipping upload");
+  }
+
+  // Pass Uint8Array directly — Blob does not work reliably in React Native
+  // (documented supabase-js limitation).
   const { error: uploadError } = await supabase.storage
     .from(BUCKET_NAME)
-    .upload(attachment.filePath, blob, {
+    .upload(attachment.filePath, bytes, {
       contentType: attachment.mimeType,
       upsert: false,
     });
@@ -119,6 +136,7 @@ async function uploadSingleAttachment(attachment: Attachment): Promise<void> {
   await database.write(async () => {
     await attachment.update((record) => {
       record.uploadStatus = "uploaded";
+      record.uploadError = null;
       record.localUri = null;
     });
   });
@@ -140,22 +158,41 @@ export async function processPendingUploads(): Promise<number> {
   isProcessing = true;
 
   try {
-    const pending = await database
+    // Retry both pending and previously failed uploads so a transient error
+    // doesn't strand an attachment forever.
+    const queued = await database
       .get<Attachment>("attachments")
-      .query(Q.where("upload_status", "pending"))
+      .query(Q.where("upload_status", Q.oneOf(["pending", "failed"])))
       .fetch();
 
-    if (pending.length === 0) return 0;
+    if (queued.length === 0) return 0;
 
     let uploaded = 0;
 
-    for (const attachment of pending) {
+    for (const attachment of queued) {
+      // Flip back to "pending" (and clear any prior error) so the UI reads
+      // "Pending" during the retry attempt rather than "Failed".
+      if (attachment.uploadStatus === "failed") {
+        await database.write(async () => {
+          await attachment.update((record) => {
+            record.uploadStatus = "pending";
+            record.uploadError = null;
+          });
+        });
+      }
+
       try {
         await uploadSingleAttachment(attachment);
         uploaded += 1;
       } catch (err) {
-        // Log and continue with next attachment — will retry on next sync
+        const message = err instanceof Error ? err.message : String(err);
         console.warn(`Failed to upload attachment ${attachment.fileName}:`, err);
+        await database.write(async () => {
+          await attachment.update((record) => {
+            record.uploadStatus = "failed";
+            record.uploadError = message;
+          });
+        });
       }
     }
 

--- a/apps/desktop/src/lib/data/attachments.ts
+++ b/apps/desktop/src/lib/data/attachments.ts
@@ -1,26 +1,17 @@
 import { NativeModules } from "react-native";
 
-import { MAX_FILE_SIZE, BUCKET_NAME, SIGNED_URL_EXPIRY_SECONDS } from "@drafto/shared";
+import { BUCKET_NAME, SIGNED_URL_EXPIRY_SECONDS } from "@drafto/shared";
 
 import { supabase } from "@/lib/supabase";
-import { sanitizeFileName } from "./attachment-utils";
 
 const { RNDocumentPicker } = NativeModules;
 
 export interface PickedFile {
   uri: string;
+  path: string;
   fileName: string;
   mimeType: string;
   fileSize: number;
-}
-
-interface UploadResult {
-  id: string;
-  noteId: string;
-  fileName: string;
-  filePath: string;
-  fileSize: number;
-  mimeType: string;
 }
 
 interface MacOSPickerResult {
@@ -51,6 +42,7 @@ export async function pickImage(): Promise<PickedFile | null> {
     const result = results[0];
     return {
       uri: result.uri,
+      path: result.path,
       fileName: result.name ?? `image_${Date.now()}`,
       mimeType: result.mimeType ?? "application/octet-stream",
       fileSize: result.size ?? 0,
@@ -69,6 +61,7 @@ export async function pickDocument(): Promise<PickedFile | null> {
     const result = results[0];
     return {
       uri: result.uri,
+      path: result.path,
       fileName: result.name ?? `file_${Date.now()}`,
       mimeType: result.mimeType ?? "application/octet-stream",
       fileSize: result.size ?? 0,
@@ -84,62 +77,6 @@ function isPickerCancelled(err: unknown): boolean {
   // react-native-document-picker-macos rejects with code "USER_CANCELLED"
   const errorWithCode = err as Error & { code?: string };
   return errorWithCode.code === "USER_CANCELLED" || err.message.includes("cancel");
-}
-
-export async function uploadAttachment(
-  userId: string,
-  noteId: string,
-  file: PickedFile,
-): Promise<UploadResult> {
-  if (file.fileSize > MAX_FILE_SIZE) {
-    throw new Error("File size exceeds 25MB limit");
-  }
-
-  const fileName = sanitizeFileName(file.fileName);
-  const filePath = `${userId}/${noteId}/${fileName}`;
-
-  // Read file as blob for upload
-  const response = await fetch(file.uri);
-  const blob = await response.blob();
-
-  // Upload to Supabase Storage
-  const { error: uploadError } = await supabase.storage.from(BUCKET_NAME).upload(filePath, blob, {
-    contentType: file.mimeType,
-    upsert: false,
-  });
-
-  if (uploadError) {
-    throw new Error(`Upload failed: ${uploadError.message}`);
-  }
-
-  // Create attachment record in database
-  const { data: attachment, error: dbError } = await supabase
-    .from("attachments")
-    .insert({
-      note_id: noteId,
-      user_id: userId,
-      file_name: fileName,
-      file_path: filePath,
-      file_size: file.fileSize,
-      mime_type: file.mimeType,
-    })
-    .select("id, note_id, file_name, file_path, file_size, mime_type")
-    .single();
-
-  if (dbError || !attachment) {
-    // Clean up uploaded file if DB insert fails
-    await supabase.storage.from(BUCKET_NAME).remove([filePath]);
-    throw new Error(`Failed to save attachment record: ${dbError?.message ?? "Unknown error"}`);
-  }
-
-  return {
-    id: attachment.id,
-    noteId: attachment.note_id,
-    fileName: attachment.file_name,
-    filePath: attachment.file_path,
-    fileSize: attachment.file_size,
-    mimeType: attachment.mime_type,
-  };
 }
 
 export async function getSignedUrl(filePath: string): Promise<string> {

--- a/apps/desktop/src/lib/data/index.ts
+++ b/apps/desktop/src/lib/data/index.ts
@@ -11,13 +11,7 @@ export {
   deleteNotePermanent,
 } from "./notes";
 
-export {
-  pickImage,
-  pickDocument,
-  uploadAttachment,
-  deleteAttachment,
-  getSignedUrl,
-} from "./attachments";
+export { pickImage, pickDocument, deleteAttachment, getSignedUrl } from "./attachments";
 export type { PickedFile } from "./attachments";
 
 export { queueAttachment, processPendingUploads, cleanupOrphanedFiles } from "./attachment-queue";

--- a/apps/mobile/__tests__/performance/startup-perf.test.ts
+++ b/apps/mobile/__tests__/performance/startup-perf.test.ts
@@ -94,7 +94,7 @@ describe("Startup Performance", () => {
     const duration = Date.now() - start;
 
     expect(schema).toBeDefined();
-    expect(schema.version).toBe(2);
+    expect(schema.version).toBe(3);
     expect(Object.keys(schema.tables)).toHaveLength(3);
     // 500ms allows headroom for slower CI runners
     expect(duration).toBeLessThan(500);

--- a/apps/mobile/src/components/editor/attachment-list.tsx
+++ b/apps/mobile/src/components/editor/attachment-list.tsx
@@ -45,11 +45,12 @@ type ShowToast = (message: string, type: "success" | "warning") => void;
 interface AttachmentItemProps {
   attachment: Attachment;
   onDelete: (attachment: Attachment) => void;
+  onRetry: () => void;
   showToast: ShowToast;
   styles: ReturnType<typeof createStyles>;
 }
 
-function AttachmentItem({ attachment, onDelete, showToast, styles }: AttachmentItemProps) {
+function AttachmentItem({ attachment, onDelete, onRetry, showToast, styles }: AttachmentItemProps) {
   // Initialise from cache so images that were already resolved render instantly
   const [signedUrl, setSignedUrl] = useState<string | null>(() =>
     getCachedSignedUrlSync(attachment.filePath),
@@ -59,6 +60,7 @@ function AttachmentItem({ attachment, onDelete, showToast, styles }: AttachmentI
   const [imageError, setImageError] = useState(false);
   const isImage = isImageMimeType(attachment.mimeType);
   const isPending = attachment.isPendingUpload;
+  const hasFailed = attachment.hasFailed;
 
   // Preserve the last successfully displayed URI so the image stays visible
   // while transitioning from pending (localUri) to uploaded (signedUrl).
@@ -132,6 +134,12 @@ function AttachmentItem({ attachment, onDelete, showToast, styles }: AttachmentI
   }, [attachment.filePath, isPending, signedUrl]);
 
   const handlePress = useCallback(async () => {
+    if (hasFailed) {
+      onRetry();
+      showToast("Retrying upload…", "success");
+      return;
+    }
+
     // If URL failed to load, retry fetching it (bypass cache)
     if (!isPending && urlError) {
       setLoadingUrl(true);
@@ -166,7 +174,16 @@ function AttachmentItem({ attachment, onDelete, showToast, styles }: AttachmentI
     if (result.status === "unavailable") {
       showToast(result.reason, "warning");
     }
-  }, [signedUrl, isPending, attachment.localUri, attachment.filePath, urlError, showToast]);
+  }, [
+    signedUrl,
+    isPending,
+    hasFailed,
+    attachment.localUri,
+    attachment.filePath,
+    urlError,
+    showToast,
+    onRetry,
+  ]);
 
   const handleDelete = useCallback(() => {
     onDelete(attachment);
@@ -207,6 +224,7 @@ function AttachmentItem({ attachment, onDelete, showToast, styles }: AttachmentI
         <View style={styles.imageFooter}>
           <View style={styles.fileNameRow}>
             {isPending && <PendingBadge />}
+            {hasFailed && <FailedBadge />}
             <Text style={styles.imageFileName} numberOfLines={1}>
               {attachment.fileName}
             </Text>
@@ -244,8 +262,12 @@ function AttachmentItem({ attachment, onDelete, showToast, styles }: AttachmentI
             {attachment.fileName}
           </Text>
         </View>
-        <Text style={styles.fileMeta}>
-          {urlError ? "Tap to retry" : formatFileSize(attachment.fileSize)}
+        <Text style={hasFailed ? styles.errorText : styles.fileMeta} numberOfLines={2}>
+          {hasFailed
+            ? (attachment.uploadError ?? "Upload failed — tap to retry")
+            : urlError
+              ? "Tap to retry"
+              : formatFileSize(attachment.fileSize)}
         </Text>
       </View>
       <Pressable
@@ -264,11 +286,21 @@ function PendingBadge() {
   return <Badge label="Pending" variant="warning" size="sm" />;
 }
 
+function FailedBadge() {
+  return <Badge label="Failed" variant="error" size="sm" />;
+}
+
 export function AttachmentList({ attachments }: AttachmentListProps) {
   const { database, sync } = useDatabase();
   const { showToast } = useToast();
   const { semantic } = useTheme();
   const styles = useMemo(() => createStyles(semantic), [semantic]);
+
+  const handleRetry = useCallback(() => {
+    sync().catch((err) => {
+      console.warn("[AttachmentList] Retry sync failed:", err);
+    });
+  }, [sync]);
 
   const handleDelete = useCallback(
     (attachment: Attachment) => {
@@ -315,6 +347,7 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
           <AttachmentItem
             attachment={item}
             onDelete={handleDelete}
+            onRetry={handleRetry}
             showToast={showToast}
             styles={styles}
           />
@@ -400,6 +433,11 @@ const createStyles = (semantic: SemanticColors) =>
     fileMeta: {
       fontSize: fontSizes.sm,
       color: semantic.fgSubtle,
+      marginTop: 2,
+    },
+    errorText: {
+      fontSize: fontSizes.sm,
+      color: semantic.errorText,
       marginTop: 2,
     },
     fileNameRow: {

--- a/apps/mobile/src/db/migrations.ts
+++ b/apps/mobile/src/db/migrations.ts
@@ -3,6 +3,15 @@ import { schemaMigrations, addColumns } from "@nozbe/watermelondb/Schema/migrati
 export const migrations = schemaMigrations({
   migrations: [
     {
+      toVersion: 3,
+      steps: [
+        addColumns({
+          table: "attachments",
+          columns: [{ name: "upload_error", type: "string", isOptional: true }],
+        }),
+      ],
+    },
+    {
       toVersion: 2,
       steps: [
         addColumns({

--- a/apps/mobile/src/db/models/attachment.ts
+++ b/apps/mobile/src/db/models/attachment.ts
@@ -3,7 +3,7 @@ import { field, date, readonly, relation } from "@nozbe/watermelondb/decorators"
 
 import type { Note } from "./note";
 
-export type UploadStatus = "pending" | "uploaded";
+export type UploadStatus = "pending" | "uploaded" | "failed";
 
 export class Attachment extends Model {
   static table = "attachments";
@@ -22,10 +22,15 @@ export class Attachment extends Model {
   @readonly @date("created_at") createdAt!: Date;
   @field("local_uri") localUri!: string | null;
   @field("upload_status") uploadStatus!: UploadStatus;
+  @field("upload_error") uploadError!: string | null;
 
   @relation("notes", "note_id") note!: Relation<Note>;
 
   get isPendingUpload(): boolean {
     return this.uploadStatus === "pending";
+  }
+
+  get hasFailed(): boolean {
+    return this.uploadStatus === "failed";
   }
 }

--- a/apps/mobile/src/db/schema.ts
+++ b/apps/mobile/src/db/schema.ts
@@ -39,10 +39,11 @@ export const attachmentsTable = tableSchema({
     { name: "created_at", type: "number" },
     { name: "local_uri", type: "string", isOptional: true },
     { name: "upload_status", type: "string" },
+    { name: "upload_error", type: "string", isOptional: true },
   ],
 });
 
 export const schema = appSchema({
-  version: 2,
+  version: 3,
   tables: [notebooksTable, notesTable, attachmentsTable],
 });

--- a/apps/mobile/src/lib/data/attachment-queue.ts
+++ b/apps/mobile/src/lib/data/attachment-queue.ts
@@ -71,6 +71,7 @@ export async function queueAttachment(
       record.mimeType = file.mimeType;
       record.localUri = localUri;
       record.uploadStatus = "pending";
+      record.uploadError = null;
     });
   });
 
@@ -131,6 +132,7 @@ async function uploadSingleAttachment(attachment: Attachment): Promise<void> {
   await database.write(async () => {
     await attachment.update((record) => {
       record.uploadStatus = "uploaded";
+      record.uploadError = null;
       record.localUri = null;
     });
   });
@@ -149,24 +151,43 @@ export interface UploadResult {
 }
 
 export async function processPendingUploads(): Promise<UploadResult> {
-  const pending = await database
+  // Retry both pending and previously failed uploads so a transient error
+  // doesn't strand an attachment forever.
+  const queued = await database
     .get<Attachment>("attachments")
-    .query(Q.where("upload_status", "pending"))
+    .query(Q.where("upload_status", Q.oneOf(["pending", "failed"])))
     .fetch();
 
-  if (pending.length === 0) return { uploaded: 0, failed: 0 };
+  if (queued.length === 0) return { uploaded: 0, failed: 0 };
 
   let uploaded = 0;
   let failed = 0;
 
-  for (const attachment of pending) {
+  for (const attachment of queued) {
+    // Flip back to "pending" (and clear any prior error) so the UI reads
+    // "Pending" during the retry attempt rather than "Failed".
+    if (attachment.uploadStatus === "failed") {
+      await database.write(async () => {
+        await attachment.update((record) => {
+          record.uploadStatus = "pending";
+          record.uploadError = null;
+        });
+      });
+    }
+
     try {
       await uploadSingleAttachment(attachment);
       uploaded += 1;
     } catch (err) {
       failed += 1;
-      // Log and continue with next attachment — will retry on next sync
+      const message = err instanceof Error ? err.message : String(err);
       console.warn(`Failed to upload attachment ${attachment.fileName}:`, err);
+      await database.write(async () => {
+        await attachment.update((record) => {
+          record.uploadStatus = "failed";
+          record.uploadError = message;
+        });
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes two macOS attachment-upload bugs reported while picking files from `~/Downloads/`:

- **Bug A — "no such file" error for non-ASCII filenames.** Picking `partikelverb Aöb(1).pdf` showed `The file "partikelverb%20Ao%CC%88b(1).pdf" couldn't be opened because there is no such file.` `react-native-document-picker-macos` returns both a percent-encoded `uri` and a decoded `path`; the JS wrapper discarded `path` and handed the percent-encoded URI (minus `file://`) to `RNFS.copyFile`. Use the decoded `path` instead.
- **Bug B — 21.8 MB MP3 stuck in "Pending".** Uploads that failed were caught with `console.warn` and never updated status; the enum had no `failed` state. Users saw no error and no way to retry. Add `failed` status + `upload_error` column (WatermelonDB schema v3), persist errors, and make failed items tappable to retry via `sync()`.

Root cause for the MP3 specifically: desktop's upload used `fetch(localUri)` + `.blob()`, which produces empty/truncated blobs on RN macOS for larger files. Switch to `RNFS.readFile(base64)` → `Uint8Array`, mirroring the pattern mobile already uses on Android for the same reason.

Also: deleted the unused `uploadAttachment()` — the real flow is `queueAttachment` → `processPendingUploads`.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `apps/desktop` unit tests — 263 passing (includes new attachment-queue regression tests)
- [x] `apps/mobile` unit tests — 131 passing
- [x] `packages/shared` tests — 202 passing
- [ ] Manual macOS: pick `~/Downloads/partikelverb Aöb(1).pdf` → no error dialog, uploads
- [ ] Manual macOS: pick `~/Downloads/p3_serie_del_3_av_6_djupet_20220617_1134356110.mp3` → uploads; if it still fails, "Failed" badge shows the real error message
- [ ] Tap failed item → triggers retry; status transitions through pending again
- [ ] Verify WatermelonDB v2→v3 migration runs cleanly with existing attachments (no data loss)

## Schema migration

WatermelonDB bumps from v2 to v3, adding `upload_error TEXT` (nullable) to `attachments`. Migration is additive-only; no existing rows touched. Kept in sync across desktop + mobile per CLAUDE.md cross-platform rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)