### PR TITLE
fix(releases): use top-level builds endpoint for TestFlight notes

### DIFF
--- a/apps/desktop/scripts/post-release-notes.mjs
+++ b/apps/desktop/scripts/post-release-notes.mjs
@@ -87,9 +87,11 @@ async function postTestFlightNotes(releaseNotes) {
     "Content-Type": "application/json",
   };
 
-  // 1. Find the latest macOS build (filter by platform-identifying fields for multi-platform app)
+  // 1. Find the latest macOS build (filter by platform-identifying fields for multi-platform app).
+  // Uses the top-level /v1/builds endpoint because the relationship endpoint /v1/apps/{id}/builds
+  // no longer accepts the `sort` query parameter.
   const buildsRes = await fetch(
-    `${baseUrl}/apps/${appId}/builds?sort=-uploadedDate&limit=10&fields[builds]=version,processingState,computedMinMacOsVersion,lsMinimumSystemVersion`,
+    `${baseUrl}/builds?filter[app]=${appId}&sort=-uploadedDate&limit=10&fields[builds]=version,processingState,computedMinMacOsVersion,lsMinimumSystemVersion`,
     { headers },
   );
   if (!buildsRes.ok) {

--- a/apps/mobile/scripts/post-release-notes.mjs
+++ b/apps/mobile/scripts/post-release-notes.mjs
@@ -203,9 +203,11 @@ async function postTestFlightNotes(releaseNotes) {
     "Content-Type": "application/json",
   };
 
-  // 1. Find the latest build (most recent preReleaseVersion)
+  // 1. Find the latest build (most recent preReleaseVersion).
+  // Uses the top-level /v1/builds endpoint because the relationship endpoint /v1/apps/{id}/builds
+  // no longer accepts the `sort` query parameter.
   const buildsRes = await fetch(
-    `${baseUrl}/apps/${appId}/builds?sort=-uploadedDate&limit=1&fields[builds]=version,processingState`,
+    `${baseUrl}/builds?filter[app]=${appId}&sort=-uploadedDate&limit=1&fields[builds]=version,processingState`,
     { headers },
   );
   if (!buildsRes.ok) {


### PR DESCRIPTION
## Summary

- Both `apps/desktop/scripts/post-release-notes.mjs` and `apps/mobile/scripts/post-release-notes.mjs` were hitting the relationship endpoint `GET /v1/apps/{id}/builds?sort=-uploadedDate&...`. Apple's App Store Connect API no longer accepts `sort` on that endpoint and returns `400 PARAMETER_ERROR.ILLEGAL "The parameter 'sort' can not be used with this request"`.
- Switched both scripts to the top-level `GET /v1/builds?filter[app]={id}&sort=-uploadedDate&...`, which is documented to accept `filter[app]` together with `sort`. Same semantics, same fields, one-line change each.
- Fastlane treated the previous failure as non-fatal (the TestFlight upload itself succeeded), but the "What to Test" string was never posted, so testers saw empty release notes on every build.

## Why not just drop `sort`?

The mobile script uses `limit=1` and relies on the first result being the newest upload. Removing `sort` without bumping the limit + sorting client-side would pick an arbitrary build. Switching endpoints preserves the existing limit/semantics.

## Test plan

- [ ] `node --check apps/desktop/scripts/post-release-notes.mjs` — parses
- [ ] `node --check apps/mobile/scripts/post-release-notes.mjs` — parses
- [ ] `prettier --check` passes on both files
- [ ] End-to-end verification on next release: run `fastlane mac beta` and `fastlane ios beta`; confirm the scripts print `TestFlight: "What to Test" updated for ... build <version>` instead of `400 PARAMETER_ERROR.ILLEGAL`, and that TestFlight shows the release notes for the new build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build query methods in post-release automation scripts for desktop and mobile applications
  * Modified API endpoint usage to improve compatibility while preserving existing sorting, pagination, and build data retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->