### PR TITLE
fix(attachments): strip non-ASCII from filenames before using as storage key

### DIFF
--- a/apps/desktop/__tests__/lib/attachment-utils.test.ts
+++ b/apps/desktop/__tests__/lib/attachment-utils.test.ts
@@ -33,4 +33,27 @@ describe("sanitizeFileName", () => {
   it("handles empty string", () => {
     expect(sanitizeFileName("")).toBe("");
   });
+
+  it("strips NFD-decomposed combining marks (macOS filesystem encoding)", () => {
+    // macOS returns filenames in NFD — "ö" is stored as "o" + U+0308 (combining diaeresis).
+    // Without this, the filename lands in Supabase Storage where its key regex rejects non-ASCII.
+    const nfd = "partikelverb Aöb(1).pdf";
+    expect(sanitizeFileName(nfd)).toBe("partikelverb Aob(1).pdf");
+  });
+
+  it("strips NFC precomposed accented characters via NFD normalisation", () => {
+    const nfc = "partikelverb Aöb(1).pdf";
+    expect(sanitizeFileName(nfc)).toBe("partikelverb Aob(1).pdf");
+  });
+
+  it("replaces non-Latin characters (CJK, emoji) with underscores", () => {
+    expect(sanitizeFileName("hello 🎉.txt")).toMatch(/^hello _+\.txt$/);
+    expect(sanitizeFileName("文件.txt")).toBe("__.txt");
+  });
+
+  it("produces ASCII-only output for Supabase Storage keys", () => {
+    const result = sanitizeFileName("café résumé naïve.pdf");
+    expect(result).toBe("cafe resume naive.pdf");
+    expect(result).toMatch(/^[\x20-\x7e]*$/);
+  });
 });

--- a/apps/desktop/src/lib/data/attachment-utils.ts
+++ b/apps/desktop/src/lib/data/attachment-utils.ts
@@ -1,7 +1,17 @@
 export function sanitizeFileName(name: string): string {
-  return name
-    .replace(/[/\\]/g, "_")
-    .replace(/\.\./g, "_")
-    .replace(/[<>:"|?*\x00-\x1f]/g, "_")
-    .slice(0, 255);
+  return (
+    name
+      // Decompose combining marks so accented chars become base + mark (e.g. "ö" → "o" + U+0308),
+      // then strip the marks. Supabase Storage rejects non-ASCII keys; this lossy normalisation
+      // preserves the readable base letter instead of falling back to an underscore.
+      .normalize("NFD")
+      .replace(/[̀-ͯ]/g, "")
+      // Any remaining non-printable-ASCII (emoji, CJK, control chars) becomes "_"
+      .replace(/[^\x20-\x7e]/g, "_")
+      // Filesystem-unsafe ASCII chars
+      .replace(/[/\\<>:"|?*]/g, "_")
+      // Path traversal
+      .replace(/\.\./g, "_")
+      .slice(0, 255)
+  );
 }

--- a/apps/mobile/src/lib/data/attachment-queue.ts
+++ b/apps/mobile/src/lib/data/attachment-queue.ts
@@ -17,11 +17,21 @@ interface PickedFile {
 const ATTACHMENTS_DIR_NAME = "attachments";
 
 function sanitizeFileName(name: string): string {
-  return name
-    .replace(/[/\\]/g, "_")
-    .replace(/\.\./g, "_")
-    .replace(/[<>:"|?*\x00-\x1f]/g, "_")
-    .slice(0, 255);
+  return (
+    name
+      // Decompose combining marks so accented chars become base + mark (e.g. "ö" → "o" + U+0308),
+      // then strip the marks. Supabase Storage rejects non-ASCII keys; this lossy normalisation
+      // preserves the readable base letter instead of falling back to an underscore.
+      .normalize("NFD")
+      .replace(/[̀-ͯ]/g, "")
+      // Any remaining non-printable-ASCII (emoji, CJK, control chars) becomes "_"
+      .replace(/[^\x20-\x7e]/g, "_")
+      // Filesystem-unsafe ASCII chars
+      .replace(/[/\\<>:"|?*]/g, "_")
+      // Path traversal
+      .replace(/\.\./g, "_")
+      .slice(0, 255)
+  );
 }
 
 function getAttachmentsDir(): Directory {


### PR DESCRIPTION
## Summary

Follow-up to #315. The previous fix got the PDF past the filesystem step (no more "no such file" dialog), which surfaced the next layer: Supabase Storage rejected the object key with `Invalid key: …/partikelverb Aöb(1).pdf`. Supabase's storage-api key regex does not permit non-ASCII characters.

`sanitizeFileName` stripped path separators, path-traversal, and some unsafe ASCII chars, but let Unicode through. Fix: normalize NFD and strip combining marks first (macOS stores "ö" as `o` + U+0308), then replace any remaining non-printable-ASCII with `_`.

Example: `partikelverb Aöb(1).pdf` → `partikelverb Aob(1).pdf`.

Applied in both `apps/desktop/src/lib/data/attachment-utils.ts` and `apps/mobile/src/lib/data/attachment-queue.ts` (they carry identical copies of the function today).

## Test plan

- [x] New unit cases: NFD input, NFC input, emoji/CJK fallback, ASCII-only invariant
- [x] Existing 8 `sanitizeFileName` tests still pass
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] Desktop tests: 267/267 passing
- [x] Mobile tests: 131/131 passing
- [ ] Manual macOS: re-pick `~/Downloads/partikelverb Aöb(1).pdf`, confirm upload succeeds (delete the currently-failed attachment first — its stale `file_path` still has the bad key)

## Note

The failed attachment currently shown in the app has the bad key baked into `file_path`. This PR only fixes the sanitiser for *new* uploads — to clear the existing failed one, delete it via the trash icon and re-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)