### PR TITLE
fix(releases): cd to repo root in release-notes generator

### DIFF
--- a/apps/desktop/scripts/generate-release-notes.sh
+++ b/apps/desktop/scripts/generate-release-notes.sh
@@ -21,6 +21,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Run from repo root so `git log -- apps/desktop/ packages/shared/` pathspecs
+# resolve correctly regardless of where fastlane invoked us (it calls this
+# script from `apps/desktop/`, which would make the pathspec look for
+# `apps/desktop/apps/desktop/` and silently match nothing).
+cd "$(git rev-parse --show-toplevel)"
+
 # Find the latest desktop release tag.
 # If the latest tag points to HEAD (just created by the tag job), use the
 # previous tag so the range covers the actual changes in this release.

--- a/apps/mobile/scripts/generate-release-notes.sh
+++ b/apps/mobile/scripts/generate-release-notes.sh
@@ -15,6 +15,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Run from repo root so `git log -- apps/mobile/ packages/shared/` pathspecs
+# resolve correctly regardless of where fastlane invoked us (it calls this
+# script from `apps/mobile/`, which would make the pathspec look for
+# `apps/mobile/apps/mobile/` and silently match nothing).
+cd "$(git rev-parse --show-toplevel)"
+
 # Find the latest mobile release tag.
 # If the latest tag points to HEAD (just created by the tag job), use the
 # previous tag so the range covers the actual changes in this release.


### PR DESCRIPTION
## Summary

TestFlight build 0.3.1/23 shipped with `"Maintenance update."` as the "What to Test" note instead of the real changelog. Root cause: `apps/desktop/scripts/generate-release-notes.sh` filters commits with `git log -- apps/desktop/ packages/shared/`. Fastlane runs the script from `apps/desktop/` (via `Dir.chdir(PROJECT_ROOT)` in `Fastfile`), and git pathspecs are cwd-relative — so the filter silently matched nothing (`apps/desktop/apps/desktop/*` doesn't exist), `FEATURES`/`FIXES` came out empty, and the script fell through to its last-resort literal.

Mobile's `apps/mobile/scripts/generate-release-notes.sh` has the identical bug — Android and iOS releases would hit the same fallback.

## Fix

One-line `cd "$(git rev-parse --show-toplevel)"` near the top of each script (after arg parsing). Makes all subsequent `git log` invocations resolve pathspecs against the repo root regardless of where fastlane invoked the script.

## Verification

Ran each script from its fastlane-invocation cwd (the previously bug-triggering one):

**Desktop (`cd apps/desktop && bash scripts/generate-release-notes.sh --max-chars 4000`):**
```
What's new:
- add Button, Input, Card, Badge primitives (#301)
- add Google and Apple OAuth login (#275)
…
Bug fixes:
- use top-level builds endpoint for TestFlight notes (#318)
- strip non-ASCII from filenames before using as storage key (#319)
- decode picker path on macOS and surface upload failures (#315)
…
```

**Mobile (`cd apps/mobile && bash scripts/generate-release-notes.sh --max-chars 500`):**
Same behaviour — full list, no more fallback. Note: mobile's sed pipeline for stripping conv-commit prefixes has a pre-existing cosmetic bug (e.g. `fix(releases): x` → `releases): x`, missing opening paren). **Not in scope for this PR** — separate follow-up if the notes still look ugly in production.

Also verified from repo root on both platforms — output is identical, confirming the fix is cwd-independent.

## Test plan

- [x] Desktop script run from `apps/desktop/` — produces real changelog, not fallback
- [x] Desktop script run from repo root — same output (regression check)
- [x] Mobile script run from `apps/mobile/` — produces real changelog, not fallback
- [x] Mobile script run from repo root — same output
- [x] `pnpm format:check` — clean
- [ ] Next `fastlane mac beta` / `fastlane ios beta` release shows a proper changelog in the "What to Test" field (proves itself on next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)