### PR TITLE
feat(db): add note_content_history table + WAL recovery script

### DIFF
--- a/docs/adr/0022-note-content-history.md
+++ b/docs/adr/0022-note-content-history.md
@@ -1,0 +1,72 @@
+# 0022 — Note Content History Table
+
+- **Status**: Accepted
+- **Date**: 2026-04-25
+- **Authors**: Jakub Anderwald
+
+## Context
+
+On 2026-04-24, a race-condition bug in a dev build (PR #323) running against production overwrote a single `notes.content` row with an empty BlockNote document. Recovery was only possible because a snapshot of the WatermelonDB WAL file existed locally on a developer's Mac, and a one-off Python script could extract pre-corruption page versions out of it.
+
+The production Supabase project is on the **Free** tier. Free tier provides:
+
+- **No** scheduled database backups.
+- **No** Point-in-Time Recovery (PITR).
+
+That makes the standard Postgres recovery story (PITR + side-restore for individual rows, as written for paid tiers in [`docs/operations/migrations.md`](../operations/migrations.md)) unavailable. Today the only first-party defense against an accidental `UPDATE`-style write is the soft delete on `notes` (which only covers row deletion, not content overwrites). For content overwrites we have nothing — we got lucky once.
+
+Two related choices were raised but not pursued in this ADR:
+
+- Upgrading to Supabase Pro to gain daily backups and PITR. Cost-driven decision; tracked separately. Even with PITR, the per-row recovery flow (restore into a side project, dump, re-insert) is heavier than checking a history table.
+- A "soft-delete-on-update" pattern using a parallel `notes_archive` table with full row snapshots and client attribution. Considered, then unified into the history table below to avoid two parallel mechanisms with the same payload.
+
+## Decision
+
+Add a `public.note_content_history` table that captures the prior `content` jsonb every time `notes.content` changes, retained for 30 days.
+
+Implementation (one migration, `supabase/migrations/20260425000001_note_content_history.sql`):
+
+1. **Table** — `note_content_history(id, note_id, user_id, content, content_updated_at, archived_at, archived_by)`. `note_id` cascades from `notes`. `archived_by` is a best-effort client tag from `current_setting('app.client', true)`; clients are not required to set it.
+2. **Trigger** — `BEFORE UPDATE ON public.notes` calls `archive_note_content()` (`SECURITY DEFINER`, `plpgsql`). Inserts a row only when `OLD.content IS DISTINCT FROM NEW.content`, so plain title or trash-flag updates don't write history.
+3. **RLS** — `SELECT` allowed only for the row's owner (mirrors the `notes` policy). No `INSERT`/`UPDATE`/`DELETE` policies; all writes go through the `SECURITY DEFINER` trigger and the cleanup function.
+4. **Retention** — `cleanup_note_content_history()` deletes rows where `archived_at < now() - interval '30 days'`. `pg_cron` runs it daily at 03:15 UTC, mirroring the existing `cleanup-trashed-notes` job at 03:00 UTC.
+
+Also commit `scripts/recover-from-wal.py` — a stdlib-only Python utility that reproduces the 2026-04-24 manual recovery: it parses the WatermelonDB WAL, walks every commit group, and prints each pre-corruption version of a target row. Used only when both server-side defenses fail.
+
+No client schema changes. The trigger fires on the existing `supabase.from('notes').update(...)` path; mobile, desktop, and web don't need to know history exists.
+
+## Consequences
+
+**Positive**
+
+- Single-row content overwrites are recoverable in a 30-day window with one SQL query, on the Free tier, without third-party support involvement.
+- The recovery path is the same regardless of whether the overwriter was a buggy client, a misfired migration, or a manual SQL editor mistake — every overwrite goes through the trigger.
+- Documenting the WAL script removes the "one developer with shell history" failure mode that would have lost the data on 2026-04-24 if the right Mac wasn't around.
+
+**Negative**
+
+- ~2× storage on the `notes` content footprint at steady state (every changed version retained for 30 days). Acceptable: notes are small (most are a few KB of BlockNote JSON), and storage on Supabase Free has plenty of headroom for a personal-scale app.
+- Every `notes.content` UPDATE writes an extra row in `note_content_history`. Editor autosaves are already debounced to ~500 ms; in practice this is one history insert per pause-in-typing, not per keystroke.
+- `archived_by` requires clients to opt in via `SET app.client = 'mobile-ios'` to be useful. Until the clients do this, the column is `NULL` for all rows and provides no attribution.
+
+**Neutral**
+
+- Adds a new public table that shows up in any schema-introspection (PostgREST, Supabase dashboard). Users with approved profiles can read their own history rows but not other users'.
+- The 30-day retention is asymmetric with PR #323's recovery window: PITR on Pro is 7 days. We're choosing 30 days because storage is cheap and longer windows make UI-driven self-recovery more useful if/when it's built.
+
+## Alternatives Considered
+
+- **Upgrade to Supabase Pro for daily backups + PITR.** A real option, but it changes the cost profile and still doesn't give per-row recovery without a side-restore. The history table is complementary regardless of plan tier; we can adopt it now and revisit Pro on its own merits.
+- **Separate `notes_archive` table for soft-delete-on-update with client attribution.** Same payload as the history table, doubled migration/maintenance overhead. Folded the client attribution into `note_content_history.archived_by` instead.
+- **Store history rows as a JSON array on `notes` itself.** Simpler to query but harder to retain with TTL semantics; also makes `notes` read paths bigger for no reason. Rejected.
+- **Client-side undo only.** Doesn't protect against server-side corruption (the actual 2026-04-24 failure mode was a client _writing_ corruption to the server). Rejected.
+- **Capture `archived_by` from `auth.uid()` only.** Already implicit via `user_id`; we want the _client_, not the user. Best-effort session variable is the right place for that.
+
+## Related
+
+- [ADR 0008 — Production Data Safety Guardrails](./0008-production-data-safety-guardrails.md)
+- [ADR 0010 — Offline Sync Strategy with WatermelonDB](./0010-offline-sync-strategy.md)
+- [`docs/operations/migrations.md`](../operations/migrations.md) — recovery runbook
+- [`supabase/migrations/20260425000001_note_content_history.sql`](../../supabase/migrations/20260425000001_note_content_history.sql)
+- [`scripts/recover-from-wal.py`](../../scripts/recover-from-wal.py)
+- GitHub issue #324, PR #323 (race-condition bug that triggered this work)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,3 +54,4 @@ Every ADR follows the template in [0000-adr-template.md](./0000-adr-template.md)
 | [0019](./0019-email-infrastructure-and-approval-flow.md) | Email Infrastructure and Account Approval Flow | Accepted           | 2026-04-20 |
 | [0020](./0020-email-design-tokens.md)                    | Email Design Tokens                            | Accepted           | 2026-04-21 |
 | [0021](./0021-shared-design-tokens.md)                   | Shared Design Tokens in `@drafto/shared`       | Accepted           | 2026-04-21 |
+| [0022](./0022-note-content-history.md)                   | Note Content History Table                     | Accepted           | 2026-04-25 |

--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -60,10 +60,14 @@ Never run any of the following against production:
 
 ## Backups and recovery
 
-- **Daily automatic backups**: provided by Supabase on all projects.
-- **Point-in-Time Recovery (PITR)**: enabled on the Pro plan (production), allowing granular restore to any moment in the retention window.
+Production is on the Supabase **Free** tier — there are **no daily automatic backups and no Point-in-Time Recovery**. The 2026-04-24 incident (PR #323) made the cost of relying on those backups concrete: a race-condition bug overwrote one note's content, and recovery only worked because a snapshot of the WatermelonDB WAL file was still on a developer's Mac. The defenses below are the ones we actually have.
+
+- **Per-note content history (`note_content_history`)**: a BEFORE-UPDATE trigger on `notes` archives the prior `content` jsonb on every change. Retained 30 days, then nightly `pg_cron` cleanup. See `supabase/migrations/20260425000001_note_content_history.sql` and ADR 0022. **First-line defense for content overwrites.**
 - **Soft delete for notes**: deletions set `is_trashed = true`; a `pg_cron` job purges rows trashed more than 30 days ago (`supabase/migrations/20260302000001_trash_auto_cleanup.sql`). Users can self-recover any accidentally deleted note within that window.
 - **Local replicas**: mobile and desktop clients keep a full WatermelonDB SQLite copy per device. These are not a formal backup, but in a worst-case server loss they are the last surviving copy of a user's notes.
+- **WAL recovery script**: `scripts/recover-from-wal.py` extracts pre-corruption row versions from a client-side WatermelonDB `.db-wal` file when no other copy survives. Last-resort tool — see section 5 below.
+
+If/when production is upgraded to the Supabase Pro tier, daily backups and PITR become available; the runbook below already references both. The defenses above remain useful regardless.
 
 ### Recovery runbook
 
@@ -92,7 +96,22 @@ Dev is meant to break — prefer the cheapest recovery:
 
 #### 4. You only need to recover specific rows (e.g. a bad `DELETE FROM notes WHERE …`)
 
-Full PITR is overkill here because it clobbers unrelated user activity. Preferred path:
+**For `notes.content` overwrites within the last 30 days, check the history table first** — it's almost always the right answer and doesn't disturb other user activity:
+
+```sql
+select content, content_updated_at, archived_at
+  from public.note_content_history
+ where note_id = '<id>'
+ order by archived_at desc;
+
+-- Restore the version you want:
+update public.notes
+   set content = (select content from public.note_content_history where id = '<history-id>'),
+       updated_at = now()
+ where id = '<note-id>';
+```
+
+If history isn't sufficient (older damage, deleted notes, or a different column), full PITR is overkill — it clobbers unrelated user activity. Preferred path on a paid plan:
 
 1. In the Supabase dashboard, restore PITR **into a new temporary project** (not over prod).
 2. `pg_dump` only the affected rows from the temp project.
@@ -101,11 +120,28 @@ Full PITR is overkill here because it clobbers unrelated user activity. Preferre
 
 If your plan tier does not expose "restore into a new project," contact Supabase support before touching prod — they can perform the side restore for you.
 
-#### 5. Damage is older than the PITR retention window
+#### 5. Damage is older than the PITR retention window (or there is no PITR)
 
-PITR cannot help. Remaining options, in order of viability:
+Production is on the Free tier today, so this is the _normal_ case for damage older than 30 days. Remaining options, in order of viability:
 
-- **Mobile/desktop users**: their WatermelonDB SQLite files (`apps/mobile/src/db/`, same schema on desktop) still hold their notes. There is no automated re-ingest — reconstruction is manual per user.
+- **`note_content_history`** (≤ 30 days, content overwrites only): see section 4 above.
+- **Mobile/desktop users**: their WatermelonDB SQLite files (`apps/mobile/src/db/`, same schema on desktop) still hold their notes. Two paths:
+  - **Live DB still readable**: open the `.db` file with `sqlite3` and `SELECT content FROM notes WHERE remote_id = '...'`.
+  - **Live DB already corrupted but `.db-wal` exists**: run `scripts/recover-from-wal.py` against the WAL file. It walks every commit group in the WAL and prints each pre-corruption version of the row. This is exactly how the 2026-04-24 incident was recovered.
+
+  Example (the actual 2026-04-24 incident invocation):
+
+  ```bash
+  python3 scripts/recover-from-wal.py \
+    --wal ~/Library/Containers/eu.drafto.mobile/Data/Documents/watermelon.db-wal \
+    --db  ~/Library/Containers/eu.drafto.mobile/Data/Documents/watermelon.db \
+    --note-id <supabase-uuid>
+  # ...inspect candidates, then emit SQL for the right one:
+  python3 scripts/recover-from-wal.py ... --emit-sql restore.sql --pick 1
+  ```
+
+  There is no automated re-ingest — reconstruction is manual per user.
+
 - **Web-only users**: effectively unrecoverable. Communicate honestly with affected users.
 
 ### Preventative guardrails to lean on

--- a/scripts/recover-from-wal.py
+++ b/scripts/recover-from-wal.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""Recover a single column value from a SQLite WAL snapshot.
+
+Last-resort tool for the case where production data has been overwritten and
+the only surviving copy is in a client-side WatermelonDB write-ahead log
+(typically `~/Library/Containers/eu.drafto.mobile/Data/Documents/watermelon.db-wal`
+on macOS). Walks every commit group in the WAL and, for each snapshot of the
+target row that the WAL still contains, prints one candidate version. Pick the
+right one and feed it back to Supabase as an `UPDATE` statement.
+
+Background: 2026-04-24 incident. A race-condition bug (PR #323) overwrote one
+`notes.content` row with an empty BlockNote document. Production was on the
+Supabase Free tier (no daily backups, no PITR). The only surviving pre-corruption
+copy was in a developer's local WatermelonDB WAL file. This script reproduces
+the manual extraction we did during the incident.
+
+See `docs/operations/migrations.md` (Recovery runbook) for the wider workflow,
+and ADR 0022 for context.
+
+Defaults target the WatermelonDB `notes` table:
+  search column: remote_id (the Supabase UUID)
+  output column: content (the BlockNote JSON)
+
+Usage:
+  python3 scripts/recover-from-wal.py \\
+      --wal ~/drafto-recovery/watermelon.db-wal.snapshot \\
+      --db  ~/drafto-recovery/read/watermelon.db \\
+      --note-id 4261ef83-3431-4a77-9adc-9251d8b0642c \\
+      --output-dir ~/drafto-recovery/
+
+Then, after picking the right candidate JSON, generate the restore SQL:
+  python3 scripts/recover-from-wal.py \\
+      --wal ... --db ... --note-id ... \\
+      --emit-sql ~/drafto-recovery/restore.sql \\
+      --pick latest
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import struct
+import sys
+from dataclasses import dataclass
+
+WAL_HEADER_SIZE = 32
+FRAME_HEADER_SIZE = 24
+WAL_MAGIC_LE = 0x377F0682
+WAL_MAGIC_BE = 0x377F0683
+TABLE_LEAF_PAGE_TYPE = 0x0D
+
+
+# -----------------------------------------------------------------------------
+# Varint + record format helpers
+# -----------------------------------------------------------------------------
+
+
+def read_varint(buf: bytes, offset: int) -> tuple[int, int]:
+    """Decode a SQLite varint starting at ``offset``. Returns (value, bytes_read)."""
+    value = 0
+    for i in range(8):
+        byte = buf[offset + i]
+        value = (value << 7) | (byte & 0x7F)
+        if not byte & 0x80:
+            return value, i + 1
+    # 9th byte uses all 8 bits.
+    value = (value << 8) | buf[offset + 8]
+    return value, 9
+
+
+def decode_serial(buf: bytes, offset: int, serial_type: int) -> tuple[object, int]:
+    """Decode one record-format value. Returns (value, bytes_consumed)."""
+    if serial_type == 0:
+        return None, 0
+    if serial_type == 1:
+        return int.from_bytes(buf[offset : offset + 1], "big", signed=True), 1
+    if serial_type == 2:
+        return int.from_bytes(buf[offset : offset + 2], "big", signed=True), 2
+    if serial_type == 3:
+        return int.from_bytes(buf[offset : offset + 3], "big", signed=True), 3
+    if serial_type == 4:
+        return int.from_bytes(buf[offset : offset + 4], "big", signed=True), 4
+    if serial_type == 5:
+        return int.from_bytes(buf[offset : offset + 6], "big", signed=True), 6
+    if serial_type == 6:
+        return int.from_bytes(buf[offset : offset + 8], "big", signed=True), 8
+    if serial_type == 7:
+        return struct.unpack(">d", buf[offset : offset + 8])[0], 8
+    if serial_type == 8:
+        return 0, 0
+    if serial_type == 9:
+        return 1, 0
+    if serial_type >= 12 and serial_type % 2 == 0:
+        n = (serial_type - 12) // 2
+        return buf[offset : offset + n], n
+    if serial_type >= 13 and serial_type % 2 == 1:
+        n = (serial_type - 13) // 2
+        return buf[offset : offset + n].decode("utf-8", errors="replace"), n
+    raise ValueError(f"unknown serial type {serial_type}")
+
+
+# -----------------------------------------------------------------------------
+# Local-payload size calculation
+# -----------------------------------------------------------------------------
+
+
+def local_payload_size(payload_size: int, page_size: int) -> int:
+    """Per https://www.sqlite.org/fileformat.html, table b-tree leaf cell.
+
+    Assumes reserved-space byte == 0 (Drafto/WatermelonDB doesn't customize this).
+    """
+    u = page_size
+    x = u - 35
+    if payload_size <= x:
+        return payload_size
+    m = ((u - 12) * 32 // 255) - 23
+    k = m + ((payload_size - m) % (u - 4))
+    return k if k <= x else m
+
+
+# -----------------------------------------------------------------------------
+# WAL parser
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class WalFrame:
+    index: int  # 0-based
+    page_number: int
+    db_size_after_commit: int  # 0 for non-commit frames
+    page_data: bytes
+
+
+def parse_wal(path: str) -> tuple[int, list[WalFrame]]:
+    with open(path, "rb") as f:
+        header = f.read(WAL_HEADER_SIZE)
+        if len(header) < WAL_HEADER_SIZE:
+            raise ValueError("WAL file truncated (no header)")
+        magic, _file_format, page_size, _ckpt_seq, _salt1, _salt2, _csum1, _csum2 = (
+            struct.unpack(">IIIIIIII", header)
+        )
+        if magic not in (WAL_MAGIC_LE, WAL_MAGIC_BE):
+            raise ValueError(f"bad WAL magic 0x{magic:08x}")
+
+        frames: list[WalFrame] = []
+        idx = 0
+        while True:
+            fh = f.read(FRAME_HEADER_SIZE)
+            if len(fh) < FRAME_HEADER_SIZE:
+                break
+            page_number, db_size_after_commit = struct.unpack(">II", fh[:8])
+            page_data = f.read(page_size)
+            if len(page_data) < page_size:
+                break
+            frames.append(
+                WalFrame(
+                    index=idx,
+                    page_number=page_number,
+                    db_size_after_commit=db_size_after_commit,
+                    page_data=page_data,
+                )
+            )
+            idx += 1
+    return page_size, frames
+
+
+def commit_group_snapshots(frames: list[WalFrame]) -> list[dict[int, bytes]]:
+    """Return one snapshot dict per commit group.
+
+    Each snapshot is the cumulative page-state visible *after* that commit.
+    Earlier commits in the WAL stay visible because checkpoint-style overwrites
+    only happen via newer frames within the same WAL file.
+    """
+    snapshots: list[dict[int, bytes]] = []
+    state: dict[int, bytes] = {}
+    has_uncommitted = False
+    for frame in frames:
+        state[frame.page_number] = frame.page_data
+        has_uncommitted = True
+        if frame.db_size_after_commit != 0:
+            snapshots.append(dict(state))
+            has_uncommitted = False
+    if has_uncommitted:
+        snapshots.append(dict(state))
+    return snapshots
+
+
+# -----------------------------------------------------------------------------
+# B-tree leaf cell parser
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class LeafCell:
+    payload_size: int
+    rowid: int
+    local_payload: bytes
+    overflow_page: int  # 0 if no overflow
+    columns: list[object]  # decoded record columns (may include partial overflow tail)
+
+
+def page_is_table_leaf(page: bytes, is_first_page: bool) -> bool:
+    # On page 1 (the file header page) the b-tree header sits 100 bytes in.
+    header_offset = 100 if is_first_page else 0
+    if len(page) < header_offset + 8:
+        return False
+    return page[header_offset] == TABLE_LEAF_PAGE_TYPE
+
+
+def parse_leaf_page(
+    page: bytes,
+    page_size: int,
+    is_first_page: bool,
+) -> list[LeafCell]:
+    header_offset = 100 if is_first_page else 0
+    page_type = page[header_offset]
+    if page_type != TABLE_LEAF_PAGE_TYPE:
+        return []
+    cell_count = int.from_bytes(page[header_offset + 3 : header_offset + 5], "big")
+    cells: list[LeafCell] = []
+    for i in range(cell_count):
+        ptr_offset = header_offset + 8 + 2 * i
+        if ptr_offset + 2 > len(page):
+            break
+        cell_offset = int.from_bytes(page[ptr_offset : ptr_offset + 2], "big")
+        if cell_offset == 0 or cell_offset >= len(page):
+            continue
+        try:
+            payload_size, n1 = read_varint(page, cell_offset)
+            rowid, n2 = read_varint(page, cell_offset + n1)
+            local_size = local_payload_size(payload_size, page_size)
+            payload_start = cell_offset + n1 + n2
+            local_payload = page[payload_start : payload_start + local_size]
+            overflow_page = 0
+            if payload_size > local_size:
+                overflow_page = int.from_bytes(
+                    page[payload_start + local_size : payload_start + local_size + 4],
+                    "big",
+                )
+            cells.append(
+                LeafCell(
+                    payload_size=payload_size,
+                    rowid=rowid,
+                    local_payload=local_payload,
+                    overflow_page=overflow_page,
+                    columns=[],
+                )
+            )
+        except (IndexError, ValueError):
+            continue
+    return cells
+
+
+def follow_overflow_chain(
+    first_page: int,
+    pages: dict[int, bytes],
+    page_size: int,
+    needed: int,
+) -> bytes:
+    """Read up to ``needed`` bytes from the overflow chain starting at first_page."""
+    out = bytearray()
+    page_num = first_page
+    while page_num and len(out) < needed:
+        page = pages.get(page_num)
+        if page is None:
+            break
+        next_page = int.from_bytes(page[:4], "big")
+        chunk = page[4 : 4 + min(page_size - 4, needed - len(out))]
+        out.extend(chunk)
+        page_num = next_page
+    return bytes(out)
+
+
+def decode_record(payload: bytes) -> list[object] | None:
+    """Decode SQLite record-format payload into column values."""
+    try:
+        header_len, n = read_varint(payload, 0)
+        if header_len > len(payload):
+            return None
+        serial_types: list[int] = []
+        offset = n
+        while offset < header_len:
+            st, m = read_varint(payload, offset)
+            serial_types.append(st)
+            offset += m
+        values: list[object] = []
+        data_offset = header_len
+        for st in serial_types:
+            value, consumed = decode_serial(payload, data_offset, st)
+            data_offset += consumed
+            values.append(value)
+        return values
+    except (IndexError, ValueError):
+        return None
+
+
+# -----------------------------------------------------------------------------
+# Schema introspection
+# -----------------------------------------------------------------------------
+
+
+def schema_columns(db_path: str, table: str) -> list[str]:
+    """Use sqlite3 (stdlib) to read the column order for ``table``."""
+    import sqlite3
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return [row[1] for row in rows]
+
+
+def db_pages(db_path: str, page_size: int) -> dict[int, bytes]:
+    """Return the main DB's pages as a fallback page source (for overflow chains
+    that begin in WAL pages but extend onto pages that were never re-written
+    in this WAL)."""
+    pages: dict[int, bytes] = {}
+    with open(db_path, "rb") as f:
+        page_num = 1
+        while True:
+            page = f.read(page_size)
+            if len(page) < page_size:
+                break
+            pages[page_num] = page
+            page_num += 1
+    return pages
+
+
+# -----------------------------------------------------------------------------
+# Main extraction flow
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class Candidate:
+    snapshot_index: int  # commit group index in the WAL (0-based)
+    rowid: int
+    columns: list[object]
+    content: str | None
+    content_updated_at: int | None  # raw int from updated_at column (epoch ms)
+    digest: str  # sha1 of content for dedup
+
+
+def extract_candidates(
+    wal_path: str,
+    db_path: str | None,
+    note_id: str,
+    table: str,
+    id_column: str,
+    content_column: str,
+    updated_at_column: str | None,
+) -> list[Candidate]:
+    page_size, frames = parse_wal(wal_path)
+
+    if db_path:
+        cols = schema_columns(db_path, table)
+    else:
+        # Fall back to the documented WatermelonDB notes layout.
+        cols = [
+            "id",
+            "_changed",
+            "_status",
+            "remote_id",
+            "notebook_id",
+            "user_id",
+            "title",
+            "content",
+            "is_trashed",
+            "trashed_at",
+            "created_at",
+            "updated_at",
+        ]
+
+    if id_column not in cols:
+        raise SystemExit(f"id-column {id_column!r} not found in schema {cols}")
+    if content_column not in cols:
+        raise SystemExit(f"content-column {content_column!r} not found in schema {cols}")
+
+    id_idx = cols.index(id_column)
+    content_idx = cols.index(content_column)
+    updated_idx = cols.index(updated_at_column) if updated_at_column in cols else None
+
+    # Use the live DB pages as a fallback source for overflow chains.
+    fallback_pages: dict[int, bytes] = db_pages(db_path, page_size) if db_path else {}
+
+    snapshots = commit_group_snapshots(frames)
+    print(
+        f"WAL {wal_path}: page_size={page_size}, frames={len(frames)}, "
+        f"commit_groups={len(snapshots)}",
+        file=sys.stderr,
+    )
+
+    target_bytes = note_id.encode()
+    seen: dict[str, Candidate] = {}
+
+    for snap_idx, snap in enumerate(snapshots):
+        # Cheap pre-filter: only consider pages whose bytes contain the note ID.
+        candidate_pages = [
+            (pn, page) for pn, page in snap.items() if target_bytes in page
+        ]
+        # Build a merged page map (snapshot WAL pages overlay the fallback DB pages).
+        merged_pages = dict(fallback_pages)
+        merged_pages.update(snap)
+
+        for page_num, page in candidate_pages:
+            is_first = page_num == 1
+            cells = parse_leaf_page(page, page_size, is_first)
+            for cell in cells:
+                full_payload = cell.local_payload
+                if cell.payload_size > len(full_payload) and cell.overflow_page:
+                    needed = cell.payload_size - len(full_payload)
+                    full_payload = full_payload + follow_overflow_chain(
+                        cell.overflow_page, merged_pages, page_size, needed
+                    )
+                if len(full_payload) < cell.payload_size:
+                    continue
+                full_payload = full_payload[: cell.payload_size]
+                values = decode_record(full_payload)
+                if values is None or len(values) <= max(id_idx, content_idx):
+                    continue
+                row_id_val = values[id_idx]
+                if row_id_val != note_id:
+                    continue
+                content_val = values[content_idx]
+                if isinstance(content_val, bytes):
+                    content_val = content_val.decode("utf-8", errors="replace")
+                if not isinstance(content_val, str):
+                    continue
+                updated_val = (
+                    values[updated_idx]
+                    if updated_idx is not None and updated_idx < len(values)
+                    else None
+                )
+                if not isinstance(updated_val, (int, float)):
+                    updated_val = None
+                digest = hashlib.sha1(content_val.encode()).hexdigest()
+                if digest in seen:
+                    continue
+                seen[digest] = Candidate(
+                    snapshot_index=snap_idx,
+                    rowid=cell.rowid,
+                    columns=values,
+                    content=content_val,
+                    content_updated_at=int(updated_val) if updated_val is not None else None,
+                    digest=digest,
+                )
+
+    candidates = list(seen.values())
+    candidates.sort(
+        key=lambda c: (c.content_updated_at or 0, c.snapshot_index),
+        reverse=True,
+    )
+    return candidates
+
+
+# -----------------------------------------------------------------------------
+# SQL output
+# -----------------------------------------------------------------------------
+
+
+def make_dollar_tag(content: str) -> str:
+    """Pick a dollar-quote tag that doesn't appear in ``content``."""
+    base = "drafto_restore"
+    candidate = base
+    counter = 0
+    while f"${candidate}$" in content:
+        counter += 1
+        candidate = f"{base}_{counter}"
+    return candidate
+
+
+def emit_sql(note_id: str, content: str, table_fqn: str = "public.notes") -> str:
+    tag = make_dollar_tag(content)
+    return (
+        f"-- Restore note {note_id} from WAL recovery (see ADR 0022).\n"
+        f"-- Generated by scripts/recover-from-wal.py.\n"
+        f"update {table_fqn}\n"
+        f"   set content = ${tag}${content}${tag}$::jsonb,\n"
+        f"       updated_at = now()\n"
+        f" where id = '{note_id}'\n"
+        f"returning id, length(content::text) as content_len, updated_at;\n"
+    )
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Recover a column value for a single row from a SQLite WAL.",
+    )
+    parser.add_argument("--wal", required=True, help="Path to the .db-wal snapshot.")
+    parser.add_argument(
+        "--db",
+        help=(
+            "Path to the companion .db snapshot (used for schema introspection "
+            "and overflow-page fallback). Recommended."
+        ),
+    )
+    parser.add_argument(
+        "--note-id", required=True, help="Value of --id-column to search for."
+    )
+    parser.add_argument("--table", default="notes", help="SQLite table name.")
+    parser.add_argument(
+        "--id-column",
+        default="remote_id",
+        help="Column whose value matches --note-id (WatermelonDB stores the "
+        "Supabase UUID in remote_id).",
+    )
+    parser.add_argument(
+        "--content-column",
+        default="content",
+        help="Column to extract.",
+    )
+    parser.add_argument(
+        "--updated-at-column",
+        default="updated_at",
+        help="Optional column used to sort candidates (latest first).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Write each candidate's content as a JSON file in this directory.",
+    )
+    parser.add_argument(
+        "--emit-sql",
+        help="Path to write the restore SQL to, using the candidate selected by --pick.",
+    )
+    parser.add_argument(
+        "--pick",
+        type=int,
+        help=(
+            "Index (from the candidate listing above) to use with --emit-sql. "
+            "REQUIRED when --emit-sql is set: the most-recent candidate is "
+            "often the corruption you're trying to undo, so the human picks."
+        ),
+    )
+    parser.add_argument(
+        "--table-fqn",
+        default="public.notes",
+        help="Fully qualified destination table name in the SQL output.",
+    )
+    args = parser.parse_args(argv)
+
+    candidates = extract_candidates(
+        wal_path=args.wal,
+        db_path=args.db,
+        note_id=args.note_id,
+        table=args.table,
+        id_column=args.id_column,
+        content_column=args.content_column,
+        updated_at_column=args.updated_at_column,
+    )
+
+    if not candidates:
+        print(f"No candidate versions of {args.note_id!r} found in WAL.", file=sys.stderr)
+        return 1
+
+    print(
+        f"Found {len(candidates)} unique pre-corruption versions of {args.note_id}",
+        file=sys.stderr,
+    )
+    for i, c in enumerate(candidates):
+        ts = c.content_updated_at
+        ts_human = ""
+        if ts:
+            from datetime import datetime, timezone
+
+            try:
+                ts_human = datetime.fromtimestamp(ts / 1000, tz=timezone.utc).isoformat()
+            except (OSError, OverflowError, ValueError):
+                ts_human = ""
+        content_len = len(c.content) if c.content else 0
+        print(
+            f"  [{i}] commit_group={c.snapshot_index} rowid={c.rowid} "
+            f"content_len={content_len} updated_at={ts} {ts_human}",
+            file=sys.stderr,
+        )
+
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+        for i, c in enumerate(candidates):
+            out_path = os.path.join(args.output_dir, f"candidate-{i:02d}.json")
+            with open(out_path, "w") as f:
+                f.write(c.content or "")
+            print(f"  wrote {out_path}", file=sys.stderr)
+
+    if args.emit_sql:
+        if args.pick is None:
+            print(
+                "--emit-sql requires --pick <index>. The most-recent candidate "
+                "is often the corruption itself; pick by index from the list above.",
+                file=sys.stderr,
+            )
+            return 2
+        if not 0 <= args.pick < len(candidates):
+            print(
+                f"--pick {args.pick} out of range (0..{len(candidates) - 1})",
+                file=sys.stderr,
+            )
+            return 2
+        chosen = candidates[args.pick]
+        sql = emit_sql(args.note_id, chosen.content or "", args.table_fqn)
+        with open(args.emit_sql, "w") as f:
+            f.write(sql)
+        print(
+            f"Wrote restore SQL to {args.emit_sql} "
+            f"(candidate [{args.pick}], content_len={len(chosen.content or '')})",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/recover-from-wal.py
+++ b/scripts/recover-from-wal.py
@@ -28,11 +28,13 @@ Usage:
       --note-id 4261ef83-3431-4a77-9adc-9251d8b0642c \\
       --output-dir ~/drafto-recovery/
 
-Then, after picking the right candidate JSON, generate the restore SQL:
+Then, after picking the right candidate JSON by index from the listing, generate
+the restore SQL (note: the most recent candidate is often the corruption itself,
+so always pick by explicit index rather than recency):
   python3 scripts/recover-from-wal.py \\
       --wal ... --db ... --note-id ... \\
       --emit-sql ~/drafto-recovery/restore.sql \\
-      --pick latest
+      --pick 1
 """
 
 from __future__ import annotations
@@ -41,9 +43,16 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import struct
 import sys
+from collections import ChainMap
+from collections.abc import Mapping
 from dataclasses import dataclass
+
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 WAL_HEADER_SIZE = 32
 FRAME_HEADER_SIZE = 24
@@ -255,7 +264,7 @@ def parse_leaf_page(
 
 def follow_overflow_chain(
     first_page: int,
-    pages: dict[int, bytes],
+    pages: Mapping[int, bytes],
     page_size: int,
     needed: int,
 ) -> bytes:
@@ -382,6 +391,9 @@ def extract_candidates(
 
     # Use the live DB pages as a fallback source for overflow chains.
     fallback_pages: dict[int, bytes] = db_pages(db_path, page_size) if db_path else {}
+    # Build the page-lookup map once. ChainMap consults the per-snapshot dict
+    # first and only falls back to the (potentially large) DB page map on miss
+    # — avoids reallocating the merged dict for every commit group.
 
     snapshots = commit_group_snapshots(frames)
     print(
@@ -398,9 +410,8 @@ def extract_candidates(
         candidate_pages = [
             (pn, page) for pn, page in snap.items() if target_bytes in page
         ]
-        # Build a merged page map (snapshot WAL pages overlay the fallback DB pages).
-        merged_pages = dict(fallback_pages)
-        merged_pages.update(snap)
+        # Snapshot WAL pages overlay the fallback DB pages without copying.
+        merged_pages = ChainMap(snap, fallback_pages)
 
         for page_num, page in candidate_pages:
             is_first = page_num == 1
@@ -433,7 +444,9 @@ def extract_candidates(
                 )
                 if not isinstance(updated_val, (int, float)):
                     updated_val = None
-                digest = hashlib.sha1(content_val.encode()).hexdigest()
+                digest = hashlib.sha1(
+                    content_val.encode(), usedforsecurity=False
+                ).hexdigest()
                 if digest in seen:
                     continue
                 seen[digest] = Candidate(
@@ -542,6 +555,13 @@ def main(argv: list[str] | None = None) -> int:
         help="Fully qualified destination table name in the SQL output.",
     )
     args = parser.parse_args(argv)
+
+    if args.emit_sql and not UUID_RE.match(args.note_id):
+        print(
+            f"--note-id {args.note_id!r} is not a UUID; refusing to emit SQL.",
+            file=sys.stderr,
+        )
+        return 2
 
     candidates = extract_candidates(
         wal_path=args.wal,

--- a/supabase/migrations/20260425000001_note_content_history.sql
+++ b/supabase/migrations/20260425000001_note_content_history.sql
@@ -1,0 +1,141 @@
+-- Per-note content history with 30-day retention.
+--
+-- Captures the prior `notes.content` jsonb on every UPDATE that actually
+-- changes content, via a BEFORE-UPDATE trigger. Lets us recover from
+-- accidental overwrites (incident 2026-04-24, PR #323) without depending
+-- on Supabase backups — production is on the Free tier, which provides
+-- neither daily backups nor PITR.
+--
+-- Retention is enforced by a nightly pg_cron job that deletes rows older
+-- than 30 days. Mirrors the existing trash cleanup pattern in
+-- 20260302000001_trash_auto_cleanup.sql.
+--
+-- See ADR 0022 (docs/adr/0022-note-content-history.md) for context.
+
+-- =============================================================================
+-- TABLE
+-- =============================================================================
+
+create table public.note_content_history (
+  id uuid primary key default gen_random_uuid(),
+  note_id uuid not null references public.notes(id) on delete cascade,
+  -- Copied from notes.user_id at archive time. No FK to auth.users — the
+  -- referencing notes row already has that constraint, and we want history
+  -- to survive briefly even if a user is deleted (cascade from notes.id
+  -- still cleans up).
+  user_id uuid not null,
+  -- The PRIOR content (what's about to be overwritten).
+  content jsonb,
+  -- OLD.updated_at at capture time, so we can tell when that version was
+  -- actually written by the client.
+  content_updated_at timestamptz not null,
+  archived_at timestamptz not null default now(),
+  -- Best-effort client tag from current_setting('app.client', true).
+  -- Clients aren't required to set it; null is acceptable.
+  archived_by text
+);
+
+create index idx_note_content_history_note_id
+  on public.note_content_history(note_id, archived_at desc);
+create index idx_note_content_history_user_id
+  on public.note_content_history(user_id);
+create index idx_note_content_history_archived_at
+  on public.note_content_history(archived_at);
+
+-- =============================================================================
+-- RLS
+-- =============================================================================
+
+alter table public.note_content_history enable row level security;
+
+create policy "Users can read own note content history"
+  on public.note_content_history for select
+  using (
+    auth.uid() = user_id
+    and exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid() and p.is_approved = true
+    )
+  );
+
+-- No insert/update/delete policies. Writes happen exclusively via the
+-- SECURITY DEFINER trigger below; cleanup happens via the SECURITY DEFINER
+-- pg_cron job. Both bypass RLS by design.
+
+-- =============================================================================
+-- TRIGGER: archive prior content on update
+-- =============================================================================
+
+create or replace function public.archive_note_content()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $$
+begin
+  if old.content is distinct from new.content then
+    insert into public.note_content_history
+      (note_id, user_id, content, content_updated_at, archived_by)
+    values
+      (
+        old.id,
+        old.user_id,
+        old.content,
+        old.updated_at,
+        nullif(current_setting('app.client', true), '')
+      );
+  end if;
+  return new;
+end;
+$$;
+
+create trigger on_notes_content_archive
+  before update on public.notes
+  for each row execute function public.archive_note_content();
+
+-- =============================================================================
+-- CLEANUP FUNCTION (30-day retention)
+-- =============================================================================
+
+create or replace function public.cleanup_note_content_history()
+returns integer
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $$
+declare
+  deleted_count integer;
+begin
+  delete from public.note_content_history
+  where archived_at < now() - interval '30 days';
+
+  get diagnostics deleted_count = row_count;
+  return deleted_count;
+end;
+$$;
+
+-- =============================================================================
+-- SCHEDULE DAILY CRON JOB
+-- =============================================================================
+
+-- pg_cron is already enabled by 20260302000001_trash_auto_cleanup.sql, but
+-- include the create-extension here so this migration is self-contained if
+-- ever applied to a fresh project.
+create extension if not exists pg_cron with schema pg_catalog;
+
+-- Idempotent re-apply: drop the job if it already exists.
+do $$
+begin
+  perform cron.unschedule('cleanup-note-content-history');
+exception when others then
+  null;
+end;
+$$;
+
+-- Run daily at 03:15 UTC (15 min after the trash cleanup so they don't
+-- start in the same instant).
+select cron.schedule(
+  'cleanup-note-content-history',
+  '15 3 * * *',
+  $$select public.cleanup_note_content_history()$$
+);

--- a/supabase/migrations/20260425000001_note_content_history.sql
+++ b/supabase/migrations/20260425000001_note_content_history.sql
@@ -73,25 +73,27 @@ security definer
 set search_path = public, pg_catalog
 as $$
 begin
-  if old.content is distinct from new.content then
-    insert into public.note_content_history
-      (note_id, user_id, content, content_updated_at, archived_by)
-    values
-      (
-        old.id,
-        old.user_id,
-        old.content,
-        old.updated_at,
-        nullif(current_setting('app.client', true), '')
-      );
-  end if;
+  insert into public.note_content_history
+    (note_id, user_id, content, content_updated_at, archived_by)
+  values
+    (
+      old.id,
+      old.user_id,
+      old.content,
+      old.updated_at,
+      nullif(current_setting('app.client', true), '')
+    );
   return new;
 end;
 $$;
 
+-- The IS DISTINCT FROM guard lives on the trigger so plain title /
+-- is_trashed / notebook_id updates skip the SECURITY DEFINER call entirely.
 create trigger on_notes_content_archive
   before update on public.notes
-  for each row execute function public.archive_note_content();
+  for each row
+  when (old.content is distinct from new.content)
+  execute function public.archive_note_content();
 
 -- =============================================================================
 -- CLEANUP FUNCTION (30-day retention)


### PR DESCRIPTION
## Summary

Closes #324. Three deliverables that, together, harden Drafto against the next incident shaped like 2026-04-24's race-condition overwrite (PR #323).

- **`supabase/migrations/20260425000001_note_content_history.sql`** — new `public.note_content_history` table, BEFORE-UPDATE trigger on `notes` that archives the prior `content` jsonb whenever it changes, and a nightly `pg_cron` cleanup at 03:15 UTC retaining 30 days. RLS lets owners read their own history; writes happen exclusively via the SECURITY DEFINER trigger.
- **`scripts/recover-from-wal.py`** — stdlib-only Python tool that reproduces the manual WAL extraction we did during the 2026-04-24 incident. Parses SQLite WAL frames + B-tree leaf cells + overflow chains, prints every pre-corruption candidate of a target row, and emits a dollar-quoted `UPDATE` statement once the human picks one. Validated against the snapshots in `~/drafto-recovery/` — reproduces `note-2026-04-21-{latest,earliest}-full.json` byte-for-byte.
- **Docs** — fixes `docs/operations/migrations.md`'s misleading "daily backups available" claim (production is on the Free tier with neither PITR nor daily backups), routes the recovery runbook through the new history table first, and documents the WAL fallback. New ADR 0022 captures the rationale, scope, and rejected alternatives.

No client-side changes — the trigger fires on the existing `supabase.from('notes').update(...)` write path. The "nice-to-have" `notes_archive` from the issue is unified into `note_content_history` (same payload, single mechanism).

## Test plan

- [x] `pnpm migration:check` — passes (0 errors).
- [x] `pnpm format:check` — clean.
- [x] WAL script smoke test — `--help` works; round-trip against `~/drafto-recovery/watermelon.db-wal.snapshot` reproduces the incident JSON exactly.
- [ ] Apply to dev: `pnpm supabase:link:dev && pnpm supabase:push` (deferred; needs `supabase login` first).
- [ ] Trigger smoke on dev:
  ```sql
  update public.notes set content = '{"v":1}'::jsonb where id = '<test-note>';
  update public.notes set content = '{"v":2}'::jsonb where id = '<test-note>';
  select content, content_updated_at, archived_at
    from public.note_content_history
   where note_id = '<test-note>'
   order by archived_at desc;
  ```
- [ ] No-op test on dev: title-only update doesn't insert a history row.
- [ ] Cleanup test on dev: synthetic row with `archived_at = now() - interval '31 days'` is purged by `select public.cleanup_note_content_history()`.
- [ ] RLS check on dev: a different authenticated user cannot read another user's history rows.
- [ ] Apply to prod: `pnpm supabase:link:prod && pnpm supabase:push` (only after explicit user "yes" stating ref `tbmjbxxseonkciqovnpl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added note content history system that automatically retains prior versions of note content for 30 days.
  * Added recovery script for last-resort content restoration from database WAL files.

* **Documentation**
  * Documented note content history architecture decision.
  * Updated recovery runbook with new content recovery options leveraging the 30-day retention window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->