### PR TITLE
feat(support-agent): phase C live label-only + zoho endpoint fixes

### DIFF
--- a/scripts/__tests__/zoho-cli.test.mjs
+++ b/scripts/__tests__/zoho-cli.test.mjs
@@ -391,13 +391,77 @@ describe("OAuth disk cache", () => {
 });
 
 describe("listPending filters terminal labels", () => {
-  it("excludes Agent-Replied/Spam/Linked-Issue threads but keeps Needs-Human", async () => {
+  it("excludes Agent-Replied/Spam/Linked-Issue threads but keeps Needs-Human (real labelId[] shape)", async () => {
+    // Real Zoho /messages/view surface: each message carries `labelId: [<id>]`,
+    // not full label objects. The lib resolves IDs against /labels.
     cli._setFetchForTests(
       makeFetch([
         tokenHandler,
         {
           match: (url, init) => url.endsWith("/folders") && (init.method ?? "GET") === "GET",
           response: jsonResponse(200, { data: [{ folderName: "Inbox", folderId: "INBOX-1" }] }),
+        },
+        {
+          match: (url, init) => url.endsWith("/labels") && (init.method ?? "GET") === "GET",
+          response: jsonResponse(200, {
+            data: [
+              { labelId: "L-AR", displayName: "Drafto/Support/Agent-Replied" },
+              { labelId: "L-NH", displayName: "Drafto/Support/Needs-Human" },
+              { labelId: "L-LI42", displayName: "Drafto/Support/Linked-Issue/42" },
+              { labelId: "L-SP", displayName: "Drafto/Support/Spam" },
+            ],
+          }),
+        },
+        {
+          match: (url) => url.includes("/messages/view"),
+          response: jsonResponse(200, {
+            data: [
+              { threadId: "A", messageId: "MA", subject: "no labels" },
+              {
+                threadId: "B",
+                messageId: "MB",
+                subject: "agent replied",
+                labelId: ["L-AR"],
+              },
+              {
+                threadId: "C",
+                messageId: "MC",
+                subject: "needs human",
+                labelId: ["L-NH"],
+              },
+              {
+                threadId: "D",
+                messageId: "MD",
+                subject: "linked issue",
+                labelId: ["L-LI42"],
+              },
+              {
+                threadId: "E",
+                messageId: "ME",
+                subject: "spam",
+                labelId: ["L-SP"],
+              },
+            ],
+          }),
+        },
+      ]),
+    );
+    const out = await cli.listPending();
+    const ids = out.map((m) => m.threadId).sort();
+    assert.deepEqual(ids, ["A", "C"]);
+  });
+
+  it("also accepts inline `labels: [{displayName}]` objects (legacy shape)", async () => {
+    cli._setFetchForTests(
+      makeFetch([
+        tokenHandler,
+        {
+          match: (url, init) => url.endsWith("/folders") && (init.method ?? "GET") === "GET",
+          response: jsonResponse(200, { data: [{ folderName: "Inbox", folderId: "INBOX-1" }] }),
+        },
+        {
+          match: (url, init) => url.endsWith("/labels") && (init.method ?? "GET") === "GET",
+          response: jsonResponse(200, { data: [] }),
         },
         {
           match: (url) => url.includes("/messages/view"),
@@ -408,25 +472,7 @@ describe("listPending filters terminal labels", () => {
                 threadId: "B",
                 messageId: "MB",
                 subject: "agent replied",
-                labels: [{ labelName: "Drafto/Support/Agent-Replied" }],
-              },
-              {
-                threadId: "C",
-                messageId: "MC",
-                subject: "needs human",
-                labels: [{ labelName: "Drafto/Support/Needs-Human" }],
-              },
-              {
-                threadId: "D",
-                messageId: "MD",
-                subject: "linked issue",
-                labels: [{ labelName: "Drafto/Support/Linked-Issue/42" }],
-              },
-              {
-                threadId: "E",
-                messageId: "ME",
-                subject: "spam",
-                labels: [{ labelName: "Drafto/Support/Spam" }],
+                labels: [{ displayName: "Drafto/Support/Agent-Replied" }],
               },
             ],
           }),
@@ -434,8 +480,10 @@ describe("listPending filters terminal labels", () => {
       ]),
     );
     const out = await cli.listPending();
-    const ids = out.map((m) => m.threadId).sort();
-    assert.deepEqual(ids, ["A", "C"]);
+    assert.deepEqual(
+      out.map((m) => m.threadId),
+      ["A"],
+    );
   });
 
   // Inbox listing returns one entry per message — two messages in the same
@@ -449,6 +497,10 @@ describe("listPending filters terminal labels", () => {
         {
           match: (url, init) => url.endsWith("/folders") && (init.method ?? "GET") === "GET",
           response: jsonResponse(200, { data: [{ folderName: "Inbox", folderId: "INBOX-1" }] }),
+        },
+        {
+          match: (url, init) => url.endsWith("/labels") && (init.method ?? "GET") === "GET",
+          response: jsonResponse(200, { data: [] }),
         },
         {
           match: (url) => url.includes("/messages/view"),

--- a/scripts/__tests__/zoho-cli.test.mjs
+++ b/scripts/__tests__/zoho-cli.test.mjs
@@ -116,6 +116,44 @@ describe("add-label", () => {
   });
 });
 
+describe("add-message-label", () => {
+  it("refuses any label outside Drafto/Support/", async () => {
+    cli._setFetchForTests(makeFetch([]));
+    await assert.rejects(() => cli.addMessageLabel("M1", "Foo/Bar"), /Drafto\/Support\//);
+    assert.equal(calls.length, 0);
+  });
+
+  it("creates the label lazily, then PUTs /updatemessage with messageId", async () => {
+    cli._setFetchForTests(
+      makeFetch([
+        tokenHandler,
+        {
+          match: (url, init) => url.endsWith("/labels") && (init.method ?? "GET") === "GET",
+          response: jsonResponse(200, { data: [] }),
+        },
+        {
+          match: (url, init) => url.endsWith("/labels") && init.method === "POST",
+          response: jsonResponse(200, {
+            data: { labelName: "Drafto/Support/Seen", labelId: "L42" },
+          }),
+        },
+        {
+          match: (url, init) => url.endsWith("/updatemessage") && init.method === "PUT",
+          response: jsonResponse(200, { data: { ok: true } }),
+        },
+      ]),
+    );
+    const out = await cli.addMessageLabel("MSG-X", "Drafto/Support/Seen");
+    assert.equal(out.ok, true);
+    const applyCall = calls.find((c) => c.url.endsWith("/updatemessage"));
+    assert.ok(applyCall);
+    const applyBody = JSON.parse(applyCall.init.body);
+    assert.equal(applyBody.mode, "applyLabel");
+    assert.deepEqual(applyBody.messageId, ["MSG-X"]);
+    assert.deepEqual(applyBody.labelId, ["L42"]);
+  });
+});
+
 describe("move-to-folder", () => {
   it("refuses any folder outside Drafto/Support/", async () => {
     cli._setFetchForTests(makeFetch([]));
@@ -263,6 +301,95 @@ describe("OAuth refresh on 401", () => {
   });
 });
 
+// support-agent.sh fires several short-lived `node scripts/lib/zoho-cli.mjs`
+// processes per launchd interval. Without an on-disk cache, each one would
+// refresh the OAuth token and we'd hit Zoho's "too many requests" cap.
+describe("OAuth disk cache", () => {
+  // Per-test cache file inside TMP_DIR — overrides the default
+  // <oauth-dir>/zoho-token-cache.json so tests can isolate their state.
+  const TOKEN_CACHE_FILE = path.join(TMP_DIR, `token-cache-${Date.now()}.json`);
+
+  beforeEach(() => {
+    process.env.ZOHO_TOKEN_CACHE_PATH = TOKEN_CACHE_FILE;
+  });
+
+  after(() => {
+    delete process.env.ZOHO_TOKEN_CACHE_PATH;
+  });
+
+  it("hydrates the second process from disk and skips the refresh", async () => {
+    let tokenCalls = 0;
+    const fetchA = makeFetch([
+      {
+        match: (url) => url.startsWith("https://accounts.zoho.eu/oauth/v2/token"),
+        response: () => {
+          tokenCalls += 1;
+          return jsonResponse(200, { access_token: "DISK-TOKEN", expires_in: 3600 });
+        },
+      },
+      {
+        match: (url, init) => url.endsWith("/labels") && (init.method ?? "GET") === "GET",
+        response: jsonResponse(200, {
+          data: [{ labelName: "Drafto/Support/Seen", labelId: "L1" }],
+        }),
+      },
+      {
+        match: (url, init) => url.endsWith("/updatethread") && init.method === "PUT",
+        response: jsonResponse(200, { data: { ok: true } }),
+      },
+    ]);
+    cli._setFetchForTests(fetchA);
+    await cli.addLabel("T1", "Drafto/Support/Seen");
+    assert.equal(tokenCalls, 1, "first process refreshes once");
+    const onDisk = JSON.parse(await fs.readFile(TOKEN_CACHE_FILE, "utf8"));
+    assert.equal(onDisk.value, "DISK-TOKEN");
+    const stat = await fs.stat(TOKEN_CACHE_FILE);
+    assert.equal(stat.mode & 0o777, 0o600, "token cache file is mode 0600");
+
+    // Simulate a second Node process by re-importing zoho-cli.mjs (cache-bust)
+    // — that gives us a fresh in-memory cache, so getAccessToken must consult
+    // the disk to find DISK-TOKEN.
+    const cli2 = await import(`../lib/zoho-cli.mjs?t=${Date.now()}-disk-cache`);
+    const fetchB = makeFetch([
+      {
+        match: (url) => url.startsWith("https://accounts.zoho.eu/oauth/v2/token"),
+        response: () => {
+          tokenCalls += 1;
+          return jsonResponse(200, { access_token: "WOULD-NOT-USE", expires_in: 3600 });
+        },
+      },
+      {
+        match: (url, init) => url.endsWith("/labels") && (init.method ?? "GET") === "GET",
+        response: jsonResponse(200, {
+          data: [{ labelName: "Drafto/Support/Seen", labelId: "L1" }],
+        }),
+      },
+      {
+        match: (url, init) => url.endsWith("/updatethread") && init.method === "PUT",
+        response: jsonResponse(200, { data: { ok: true } }),
+      },
+    ]);
+    cli2._setFetchForTests(fetchB);
+    // _setFetchForTests calls _resetForTests which (now) clears the disk cache
+    // — undo that for this test, since we want to assert the disk path.
+    await fs.writeFile(TOKEN_CACHE_FILE, JSON.stringify(onDisk), { mode: 0o600 });
+    await fs.chmod(TOKEN_CACHE_FILE, 0o600);
+
+    await cli2.addLabel("T2", "Drafto/Support/Seen");
+    assert.equal(tokenCalls, 1, "second process reused disk token instead of refreshing");
+    const labelGet = calls.find(
+      (c) => c.url.endsWith("/labels") && (c.init.method ?? "GET") === "GET" && c.init.headers,
+    );
+    assert.ok(labelGet);
+    // The disk-hydrated token must be the one in use.
+    const labelCalls = calls.filter((c) => c.url.endsWith("/labels"));
+    assert.equal(
+      labelCalls[labelCalls.length - 1].init.headers.Authorization,
+      "Zoho-oauthtoken DISK-TOKEN",
+    );
+  });
+});
+
 describe("listPending filters terminal labels", () => {
   it("excludes Agent-Replied/Spam/Linked-Issue threads but keeps Needs-Human", async () => {
     cli._setFetchForTests(
@@ -276,23 +403,31 @@ describe("listPending filters terminal labels", () => {
           match: (url) => url.includes("/messages/view"),
           response: jsonResponse(200, {
             data: [
-              { threadId: "A", subject: "no labels", labels: [] },
+              { threadId: "A", messageId: "MA", subject: "no labels", labels: [] },
               {
                 threadId: "B",
+                messageId: "MB",
                 subject: "agent replied",
                 labels: [{ labelName: "Drafto/Support/Agent-Replied" }],
               },
               {
                 threadId: "C",
+                messageId: "MC",
                 subject: "needs human",
                 labels: [{ labelName: "Drafto/Support/Needs-Human" }],
               },
               {
                 threadId: "D",
+                messageId: "MD",
                 subject: "linked issue",
                 labels: [{ labelName: "Drafto/Support/Linked-Issue/42" }],
               },
-              { threadId: "E", subject: "spam", labels: [{ labelName: "Drafto/Support/Spam" }] },
+              {
+                threadId: "E",
+                messageId: "ME",
+                subject: "spam",
+                labels: [{ labelName: "Drafto/Support/Spam" }],
+              },
             ],
           }),
         },
@@ -301,5 +436,104 @@ describe("listPending filters terminal labels", () => {
     const out = await cli.listPending();
     const ids = out.map((m) => m.threadId).sort();
     assert.deepEqual(ids, ["A", "C"]);
+  });
+
+  // Inbox listing returns one entry per message — two messages in the same
+  // thread share a threadId and would otherwise be processed twice in one run.
+  // Filtering happens before dedupe; first occurrence wins (Zoho returns
+  // newest-first, so the most recent message represents the thread).
+  it("dedupes by threadId, keeping the first occurrence", async () => {
+    cli._setFetchForTests(
+      makeFetch([
+        tokenHandler,
+        {
+          match: (url, init) => url.endsWith("/folders") && (init.method ?? "GET") === "GET",
+          response: jsonResponse(200, { data: [{ folderName: "Inbox", folderId: "INBOX-1" }] }),
+        },
+        {
+          match: (url) => url.includes("/messages/view"),
+          response: jsonResponse(200, {
+            data: [
+              { threadId: "T1", messageId: "M1-newer", subject: "reply 2" },
+              { threadId: "T1", messageId: "M1-older", subject: "reply 1" },
+              { threadId: "T2", messageId: "M2", subject: "another thread" },
+              // No threadId at all — should fall back to messageId for keying.
+              { messageId: "M3", subject: "orphan" },
+            ],
+          }),
+        },
+      ]),
+    );
+    const out = await cli.listPending();
+    assert.equal(out.length, 3);
+    assert.equal(out[0].messageId, "M1-newer", "first-occurrence (newest) wins for T1");
+    assert.equal(out[1].threadId, "T2");
+    assert.equal(out[2].messageId, "M3");
+  });
+});
+
+describe("getThread", () => {
+  it("calls /messages/view with threadId query and returns the data array", async () => {
+    cli._setFetchForTests(
+      makeFetch([
+        tokenHandler,
+        {
+          match: (url) => url.includes("/messages/view") && url.includes("threadId=THREAD-7"),
+          response: jsonResponse(200, {
+            data: [
+              { messageId: "M1", threadId: "THREAD-7", folderId: "INBOX-1", subject: "first" },
+              { messageId: "M2", threadId: "THREAD-7", folderId: "INBOX-1", subject: "reply" },
+            ],
+          }),
+        },
+      ]),
+    );
+    const out = await cli.getThread("THREAD-7");
+    assert.equal(Array.isArray(out), true);
+    assert.equal(out.length, 2);
+    assert.equal(out[0].messageId, "M1");
+    assert.equal(out[1].subject, "reply");
+    const call = calls.find((c) => c.url.includes("/messages/view"));
+    assert.ok(call.url.includes("threadId=THREAD-7"));
+    assert.ok(!call.url.includes("folderId="));
+  });
+
+  it("rejects empty threadId before any HTTP call", async () => {
+    cli._setFetchForTests(makeFetch([]));
+    await assert.rejects(() => cli.getThread(""), /threadId required/);
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("getHeaders", () => {
+  it("uses the folder-scoped path and parses headerContent CRLF blob", async () => {
+    cli._setFetchForTests(
+      makeFetch([
+        tokenHandler,
+        {
+          match: (url) =>
+            url.includes("/folders/INBOX-1/messages/MSG-9/header") && !url.includes("?"),
+          response: jsonResponse(200, {
+            data: {
+              headerContent:
+                "Delivered-To: support@drafto.eu\r\nFrom: jane@example.com\r\nSubject: hi\r\nReceived: a\r\nReceived: b\r\n",
+            },
+          }),
+        },
+      ]),
+    );
+    const out = await cli.getHeaders("INBOX-1", "MSG-9");
+    assert.equal(out["Delivered-To"], "support@drafto.eu");
+    assert.equal(out.From, "jane@example.com");
+    assert.equal(out.Subject, "hi");
+    // Repeated header names are collapsed comma-separated by parseRawHeaders.
+    assert.equal(out.Received, "a, b");
+  });
+
+  it("requires both folderId and messageId", async () => {
+    cli._setFetchForTests(makeFetch([]));
+    await assert.rejects(() => cli.getHeaders("", "MSG-9"), /folderId required/);
+    await assert.rejects(() => cli.getHeaders("INBOX-1", ""), /messageId required/);
+    assert.equal(calls.length, 0);
   });
 });

--- a/scripts/lib/setup-zoho-oauth.mjs
+++ b/scripts/lib/setup-zoho-oauth.mjs
@@ -7,7 +7,10 @@
 //      (do NOT reuse the test client `1000.1WE9804R1QYUL3MHUF578XC2ZR554F`
 //      used during planning).
 //   2. Generating a 10-minute grant code for scopes
-//        ZohoMail.accounts.READ,ZohoMail.messages.ALL,ZohoMail.folders.ALL
+//        ZohoMail.accounts.READ,ZohoMail.messages.ALL,
+//        ZohoMail.folders.ALL,ZohoMail.labels.ALL
+//      (Phase B shipped without ZohoMail.labels.ALL; Phase C surfaced
+//      INVALID_OAUTHSCOPE on /labels — re-run this script with the full set.)
 //   3. Pasting client_id, client_secret, and grant code into the prompt.
 //
 // The script exchanges the grant code at accounts.zoho.<dc>/oauth/v2/token,
@@ -15,8 +18,8 @@
 // ~/drafto-secrets/zoho-oauth.json with {client_id, client_secret,
 // refresh_token, account_id, primary_email, datacenter}, perms 0600.
 //
-// Re-run this script if the refresh token is ever revoked or the Self Client
-// app is deleted.
+// Re-run this script if the refresh token is ever revoked, the Self Client
+// app is deleted, or the scope set changes.
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -51,8 +54,9 @@ async function main() {
         "Before continuing:",
         "  1. Open https://api-console.zoho.eu/ (or your data centre's console).",
         "  2. Create a new Self Client app for the support agent.",
-        "  3. Generate a grant code with all three scopes:",
-        "       ZohoMail.accounts.READ,ZohoMail.messages.ALL,ZohoMail.folders.ALL",
+        "  3. Generate a grant code with ALL FOUR scopes:",
+        "       ZohoMail.accounts.READ,ZohoMail.messages.ALL,",
+        "       ZohoMail.folders.ALL,ZohoMail.labels.ALL",
         "     and a 10-minute lifetime. Copy it now — it expires fast.",
         "",
       ].join("\n") + "\n",

--- a/scripts/lib/setup-zoho-oauth.mjs
+++ b/scripts/lib/setup-zoho-oauth.mjs
@@ -8,9 +8,10 @@
 //      used during planning).
 //   2. Generating a 10-minute grant code for scopes
 //        ZohoMail.accounts.READ,ZohoMail.messages.ALL,
-//        ZohoMail.folders.ALL,ZohoMail.labels.ALL
-//      (Phase B shipped without ZohoMail.labels.ALL; Phase C surfaced
-//      INVALID_OAUTHSCOPE on /labels — re-run this script with the full set.)
+//        ZohoMail.folders.ALL,ZohoMail.tags.ALL
+//      (Zoho's API calls them "labels" externally but the OAuth scope is
+//       `tags`. Phase B shipped without it; Phase C surfaced
+//       INVALID_OAUTHSCOPE on /labels — re-run this script with the full set.)
 //   3. Pasting client_id, client_secret, and grant code into the prompt.
 //
 // The script exchanges the grant code at accounts.zoho.<dc>/oauth/v2/token,
@@ -56,8 +57,9 @@ async function main() {
         "  2. Create a new Self Client app for the support agent.",
         "  3. Generate a grant code with ALL FOUR scopes:",
         "       ZohoMail.accounts.READ,ZohoMail.messages.ALL,",
-        "       ZohoMail.folders.ALL,ZohoMail.labels.ALL",
-        "     and a 10-minute lifetime. Copy it now — it expires fast.",
+        "       ZohoMail.folders.ALL,ZohoMail.tags.ALL",
+        "     (Zoho's UI calls labels 'labels', but the OAuth scope is 'tags'.)",
+        "     10-minute lifetime — copy the code now, it expires fast.",
         "",
       ].join("\n") + "\n",
     );

--- a/scripts/lib/zoho-auth.mjs
+++ b/scripts/lib/zoho-auth.mjs
@@ -4,15 +4,31 @@
 // setup-zoho-oauth.mjs) and trades the long-lived refresh_token for
 // short-lived (1h) access_tokens via accounts.zoho.<dc>/oauth/v2/token.
 //
-// Tokens are cached in-process. zoho-cli.mjs calls invalidate() when it sees
-// an INVALID_OAUTHTOKEN response from the API, then retries exactly once.
+// Tokens are cached in two layers:
+//   1. In-process (memory) — primary cache for repeated calls inside a single
+//      Node process.
+//   2. On disk at <oauth-dir>/zoho-token-cache.json (mode 0600) — survives
+//      across the multiple short-lived `node scripts/lib/zoho-cli.mjs ...`
+//      invocations that support-agent.sh fires per run. Without this, every
+//      launchd interval would burn 5+ OAuth refreshes (one per CLI call) and
+//      hit Zoho's "too many requests" cap.
+//
+// zoho-cli.mjs calls invalidate() when it sees an INVALID_OAUTHTOKEN response
+// from the API, then retries exactly once. invalidate() clears both caches.
 
-import { promises as fs } from "node:fs";
+import { promises as fs, unlinkSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
 export const DEFAULT_OAUTH_PATH =
   process.env.ZOHO_OAUTH_PATH ?? path.join(os.homedir(), "drafto-secrets", "zoho-oauth.json");
+
+function defaultTokenCachePath() {
+  return (
+    process.env.ZOHO_TOKEN_CACHE_PATH ??
+    path.join(path.dirname(DEFAULT_OAUTH_PATH), "zoho-token-cache.json")
+  );
+}
 
 const DATACENTER_HOSTS = {
   eu: { accounts: "accounts.zoho.eu", mail: "mail.zoho.eu" },
@@ -26,6 +42,9 @@ let cached = { config: null, token: null, fetchImpl: globalThis.fetch };
 
 export function _resetForTests({ fetchImpl } = {}) {
   cached = { config: null, token: null, fetchImpl: fetchImpl ?? globalThis.fetch };
+  // Tests share TMP_DIR across cases; without this the disk-cached token from
+  // one test would leak into the next and skip the expected refresh.
+  deleteTokenFromDiskSync();
 }
 
 export async function loadConfig(filePath = DEFAULT_OAUTH_PATH) {
@@ -62,9 +81,61 @@ export async function loadConfig(filePath = DEFAULT_OAUTH_PATH) {
   return cached.config;
 }
 
+// 30s safety buffer so we don't hand back a token that expires mid-request.
+const TOKEN_SAFETY_MS = 30_000;
+
+function tokenStillValid(t) {
+  return t && typeof t.value === "string" && Date.now() < t.expiresAt - TOKEN_SAFETY_MS;
+}
+
+async function readTokenFromDisk() {
+  const file = defaultTokenCachePath();
+  try {
+    const stat = await fs.stat(file);
+    if ((stat.mode & 0o077) !== 0) {
+      // Permissions drifted — refuse and force a refresh + rewrite.
+      return null;
+    }
+    const raw = await fs.readFile(file, "utf8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.value !== "string" || typeof parsed?.expiresAt !== "number") return null;
+    return { value: parsed.value, expiresAt: parsed.expiresAt };
+  } catch {
+    return null;
+  }
+}
+
+async function writeTokenToDisk(token) {
+  const file = defaultTokenCachePath();
+  const tmp = `${file}.${process.pid}.tmp`;
+  // Atomic write: open with 0600 so the tmp file is never world/group-readable
+  // even momentarily; then rename into place.
+  await fs.writeFile(tmp, JSON.stringify(token), { mode: 0o600 });
+  // Some filesystems / umasks ignore the mode flag — chmod explicitly.
+  await fs.chmod(tmp, 0o600);
+  await fs.rename(tmp, file);
+}
+
+function deleteTokenFromDiskSync() {
+  // Sync so invalidateAccessToken() — which is called right before a retry —
+  // takes effect before the next read. An async delete would race the retry's
+  // readTokenFromDisk() and let the dead token come back through the disk.
+  try {
+    unlinkSync(defaultTokenCachePath());
+  } catch {
+    /* swallow — file may not exist */
+  }
+}
+
 export async function getAccessToken() {
-  if (cached.token && Date.now() < cached.token.expiresAt - 30_000) {
-    return cached.token.value;
+  if (tokenStillValid(cached.token)) return cached.token.value;
+  // Try the on-disk cache before refreshing — this is what saves us from
+  // hammering accounts.zoho.eu when support-agent.sh invokes node multiple
+  // times per launchd interval.
+  const disk = await readTokenFromDisk();
+  if (tokenStillValid(disk)) {
+    cached.token = disk;
+    return disk.value;
   }
   const cfg = await loadConfig();
   const params = new URLSearchParams({
@@ -88,11 +159,22 @@ export async function getAccessToken() {
   }
   const expiresInMs = (body.expires_in ?? 3600) * 1000;
   cached.token = { value: body.access_token, expiresAt: Date.now() + expiresInMs };
+  // Persist to disk best-effort. If the write fails (permissions, full disk),
+  // log nothing — the in-memory token still works for this process and the
+  // next process will simply refresh again.
+  try {
+    await writeTokenToDisk(cached.token);
+  } catch {
+    /* swallow — disk cache is optional */
+  }
   return cached.token.value;
 }
 
 export function invalidateAccessToken() {
   cached.token = null;
+  // Drop the disk copy too so the next call doesn't return the same dead
+  // token from disk and immediately 401 again.
+  deleteTokenFromDiskSync();
 }
 
 export async function getMailHost() {

--- a/scripts/lib/zoho-auth.mjs
+++ b/scripts/lib/zoho-auth.mjs
@@ -108,6 +108,11 @@ async function readTokenFromDisk() {
 async function writeTokenToDisk(token) {
   const file = defaultTokenCachePath();
   const tmp = `${file}.${process.pid}.tmp`;
+  // The cache dir may not exist when ZOHO_TOKEN_CACHE_PATH overrides the
+  // default to a fresh location (per-app cache, tmpfs, CI runner). Without
+  // this, every refresh silently fails to persist and the script keeps
+  // burning OAuth refreshes on each launchd interval.
+  await fs.mkdir(path.dirname(file), { recursive: true });
   // Atomic write: open with 0600 so the tmp file is never world/group-readable
   // even momentarily; then rename into place.
   await fs.writeFile(tmp, JSON.stringify(token), { mode: 0o600 });

--- a/scripts/lib/zoho-cli.mjs
+++ b/scripts/lib/zoho-cli.mjs
@@ -2,19 +2,32 @@
 // Zoho Mail CLI used by the support agent.
 //
 // Subcommands (all argv-driven so Claude Code can invoke them via Bash):
-//   list-pending                            → JSON array of Inbox messages
-//                                             that don't yet carry a terminal
+//   list-pending                            → JSON array of Inbox threads
+//                                             (deduped by threadId) that don't
+//                                             yet carry a terminal
 //                                             Drafto/Support/* label.
-//   get-thread <threadId>                   → full thread JSON (messages + headers).
-//   get-headers <messageId>                 → parsed header object for one message.
+//   get-thread <threadId>                   → array of messages in the thread,
+//                                             oldest-first. Each entry carries
+//                                             messageId + folderId + subject
+//                                             + addresses (no headers).
+//   get-headers <folderId> <messageId>      → parsed header object for one
+//                                             message. Zoho's header endpoint
+//                                             requires the folder id of the
+//                                             message, so list-pending /
+//                                             get-thread surface it.
 //   reply <threadId> --body-file <path>     → posts a reply in-thread; sender is
 //                                             always the OAuth user (no --from).
 //   send --to <addr> --subject <s>          → sends a fresh non-reply email; sender
 //        --body-file <path>                   always the OAuth user. Used for admin
 //                                             notifications.
-//   add-label <threadId> <labelName>        → applies a label; refuses any name not
-//                                             under "Drafto/Support/". Creates the
-//                                             label lazily if it doesn't exist yet.
+//   add-label <threadId> <labelName>        → applies a label to a thread; refuses
+//                                             any name not under "Drafto/Support/".
+//                                             Creates the label lazily if it
+//                                             doesn't exist yet.
+//   add-message-label <messageId> <label>   → same as add-label but targets a
+//                                             single message (used for inbound
+//                                             singletons that Zoho hasn't yet
+//                                             assigned a threadId to).
 //   move-to-folder <threadId> <folder>      → moves a thread to a folder; refuses
 //                                             any name not under "Drafto/Support/".
 //                                             Creates the folder lazily.
@@ -25,8 +38,8 @@
 // All subcommands print JSON to stdout and exit 0 on success. On failure they
 // print a single-line JSON {"error": "..."} to stderr and exit non-zero.
 //
-// Endpoint paths reflect Zoho's documented Mail REST API. Phase A live
-// verification may surface small adjustments — keep the paths in
+// Endpoint paths reflect Zoho's documented Mail REST API as verified live
+// against account 8620967000000002002 in April 2026. Keep the paths in
 // ZOHO_API_PATHS centralised so they can be changed in one place.
 
 import { promises as fs } from "node:fs";
@@ -46,11 +59,15 @@ const SUPPORT_NAMESPACE = "Drafto/Support/";
 const ZOHO_API_PATHS = {
   folders: (accountId) => `/api/accounts/${accountId}/folders`,
   labels: (accountId) => `/api/accounts/${accountId}/labels`,
+  // Both Inbox listing and per-thread message listing go through the same
+  // endpoint, parameterised by query string (folderId vs threadId). Returns
+  // {data: [{messageId, threadId, folderId, subject, fromAddress, ...}]}.
   messagesView: (accountId) => `/api/accounts/${accountId}/messages/view`,
-  threadDetails: (accountId, threadId) =>
-    `/api/accounts/${accountId}/messages/${encodeURIComponent(threadId)}/details`,
-  messageHeader: (accountId, messageId) =>
-    `/api/accounts/${accountId}/messages/${encodeURIComponent(messageId)}/header`,
+  // The header endpoint is folder-scoped, not message-id-scoped. Hitting the
+  // unscoped variant returns 404 URL_RULE_NOT_CONFIGURED. The response is
+  // {data: {headerContent: "<CRLF-delimited raw headers>"}}.
+  messageHeader: (accountId, folderId, messageId) =>
+    `/api/accounts/${accountId}/folders/${encodeURIComponent(folderId)}/messages/${encodeURIComponent(messageId)}/header`,
   sendOrReply: (accountId) => `/api/accounts/${accountId}/messages`,
   updateThread: (accountId) => `/api/accounts/${accountId}/updatethread`,
   updateMessage: (accountId) => `/api/accounts/${accountId}/updatemessage`,
@@ -182,23 +199,51 @@ export async function listPending() {
     query: { folderId: inboxId, includeto: "true", limit: 200 },
   });
   const arr = res.data ?? res.messages ?? [];
-  return arr.filter((m) => !messageHasTerminalLabel(m));
+  // Inbox listing returns one entry per *message*; two messages in the same
+  // thread share a threadId and would otherwise be processed twice in one
+  // run. Filter terminal labels first, then dedupe by threadId (falling back
+  // to messageId when a message is not threaded), keeping the first
+  // occurrence — Zoho returns newest-first so that's the most recent message.
+  const filtered = arr.filter((m) => !messageHasTerminalLabel(m));
+  const seen = new Set();
+  const deduped = [];
+  for (const m of filtered) {
+    const key = m.threadId ?? m.messageId ?? m.id;
+    if (!key) continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(m);
+  }
+  return deduped;
 }
 
 export async function getThread(threadId) {
   if (!threadId) throw new Error("threadId required");
   const cfg = await loadConfig();
-  const res = await zohoApi("GET", ZOHO_API_PATHS.threadDetails(cfg.accountId, threadId));
-  return res.data ?? res;
+  // /messages/view?threadId=<id> returns {data: [<msg>, ...]} — one entry per
+  // message in the thread. The earlier /messages/{id}/details path tried
+  // during Phase A returned 404 URL_RULE_NOT_CONFIGURED.
+  const res = await zohoApi("GET", ZOHO_API_PATHS.messagesView(cfg.accountId), {
+    query: { threadId, includeto: "true", limit: 200 },
+  });
+  return res.data ?? res.messages ?? [];
 }
 
-export async function getHeaders(messageId) {
+export async function getHeaders(folderId, messageId) {
+  if (!folderId) throw new Error("folderId required");
   if (!messageId) throw new Error("messageId required");
   const cfg = await loadConfig();
-  const res = await zohoApi("GET", ZOHO_API_PATHS.messageHeader(cfg.accountId, messageId));
-  // Zoho returns headers as an object or as a CRLF-delimited string depending
-  // on the endpoint variant; normalise to a plain {Name: value} object.
-  const raw = res.data?.header ?? res.data ?? res.header ?? res;
+  const res = await zohoApi(
+    "GET",
+    ZOHO_API_PATHS.messageHeader(cfg.accountId, folderId, messageId),
+  );
+  // Zoho returns headers as a CRLF-delimited string under data.headerContent.
+  const headerContent = res.data?.headerContent ?? res.headerContent;
+  if (typeof headerContent === "string") return parseRawHeaders(headerContent);
+  // Defensive fallback: if the shape ever shifts (or in tests with a stub),
+  // treat a string `data` as raw headers and an object `data` as already
+  // parsed.
+  const raw = res.data ?? res;
   if (typeof raw === "string") return parseRawHeaders(raw);
   return raw;
 }
@@ -279,6 +324,22 @@ export async function addLabel(threadId, labelName) {
   return res.data ?? res;
 }
 
+// Zoho assigns a threadId only after a message has at least one reply; until
+// then a single inbound message has only a messageId. To prevent an unreplied
+// singleton from re-appearing in list-pending every poll, we label it via
+// /updatemessage instead of /updatethread.
+export async function addMessageLabel(messageId, labelName) {
+  if (!messageId) throw new Error("messageId required");
+  assertSupportNamespace(labelName, "label");
+  const cfg = await loadConfig();
+  const label = await ensureLabel(labelName);
+  const labelId = label.labelId ?? label.id;
+  const res = await zohoApi("PUT", ZOHO_API_PATHS.updateMessage(cfg.accountId), {
+    body: { mode: "applyLabel", messageId: [messageId], labelId: [labelId] },
+  });
+  return res.data ?? res;
+}
+
 export async function moveToFolder(threadId, folderName) {
   if (!threadId) throw new Error("threadId required");
   assertSupportNamespace(folderName, "folder");
@@ -337,20 +398,22 @@ async function main(argv) {
     case "get-thread":
       return getThread(positional[0]);
     case "get-headers":
-      return getHeaders(positional[0]);
+      return getHeaders(positional[0], positional[1]);
     case "reply":
       return replyToThread(positional[0], flags["body-file"]);
     case "send":
       return sendFresh({ to: flags.to, subject: flags.subject, bodyFile: flags["body-file"] });
     case "add-label":
       return addLabel(positional[0], positional[1]);
+    case "add-message-label":
+      return addMessageLabel(positional[0], positional[1]);
     case "move-to-folder":
       return moveToFolder(positional[0], positional[1]);
     case "--help":
     case "-h":
     case undefined:
       process.stdout.write(
-        "Usage: zoho-cli.mjs <list-pending|get-thread|get-headers|reply|send|add-label|move-to-folder> [args]\n",
+        "Usage: zoho-cli.mjs <list-pending|get-thread <threadId>|get-headers <folderId> <messageId>|reply <threadId> --body-file <path>|send --to <addr> --subject <s> --body-file <path>|add-label <threadId> <label>|add-message-label <messageId> <label>|move-to-folder <threadId> <folder>>\n",
       );
       return null;
     default:

--- a/scripts/lib/zoho-cli.mjs
+++ b/scripts/lib/zoho-cli.mjs
@@ -145,18 +145,36 @@ async function listLabels() {
   const arr = res.data ?? res.labels ?? [];
   _labelsByName = new Map();
   for (const l of arr) {
-    const name = l.labelName ?? l.name;
+    // Zoho's POST/GET use `displayName` for the label's human-readable name.
+    // Older docs / mocks may surface `labelName` or `name`; accept any.
+    const name = l.displayName ?? l.labelName ?? l.name;
     if (name) _labelsByName.set(name, l);
   }
   return _labelsByName;
+}
+
+// Inverse of listLabels — used when filtering messages by label, since
+// /messages/view returns labels as a flat `labelId: ["<id>", ...]` array.
+async function listLabelsById() {
+  const byName = await listLabels();
+  const byId = new Map();
+  for (const label of byName.values()) {
+    const id = label.labelId ?? label.tagId ?? label.id;
+    const name = label.displayName ?? label.labelName ?? label.name;
+    if (id !== undefined && id !== null && name) byId.set(String(id), name);
+  }
+  return byId;
 }
 
 async function ensureLabel(name) {
   const labels = await listLabels();
   if (labels.has(name)) return labels.get(name);
   const cfg = await loadConfig();
+  // POST /labels expects `displayName` (Zoho calls them "tags" internally;
+  // posting `labelName` returns 404 EXTRA_KEY_FOUND_IN_JSON).
+  // https://www.zoho.com/mail/help/api/post-create-new-label.html
   const created = await zohoApi("POST", ZOHO_API_PATHS.labels(cfg.accountId), {
-    body: { labelName: name },
+    body: { displayName: name },
   });
   const obj = created.data ?? created;
   labels.set(name, obj);
@@ -184,9 +202,17 @@ function isTerminalSupportLabel(labelName) {
   return labelName !== `${SUPPORT_NAMESPACE}Needs-Human`;
 }
 
-function messageHasTerminalLabel(msg) {
-  const labels = msg.labels ?? msg.labelInfo ?? [];
-  return labels.some((l) => isTerminalSupportLabel(l.labelName ?? l.name ?? l));
+function messageHasTerminalLabel(msg, idToName) {
+  // Real Zoho /messages/view surface: a flat `labelId: ["<id>", ...]` array.
+  // Resolve IDs via the labels cache.
+  const ids = Array.isArray(msg.labelId) ? msg.labelId : [];
+  for (const id of ids) {
+    const name = idToName.get(String(id));
+    if (name && isTerminalSupportLabel(name)) return true;
+  }
+  // Fallback for tests / endpoint variants that return label objects inline.
+  const objs = msg.labels ?? msg.labelInfo ?? [];
+  return objs.some((l) => isTerminalSupportLabel(l.displayName ?? l.labelName ?? l.name ?? l));
 }
 
 export async function listPending() {
@@ -195,6 +221,7 @@ export async function listPending() {
   const inbox = folders.get("Inbox");
   if (!inbox) throw new Error('Could not locate Zoho "Inbox" folder');
   const inboxId = inbox.folderId ?? inbox.id;
+  const idToName = await listLabelsById();
   const res = await zohoApi("GET", ZOHO_API_PATHS.messagesView(cfg.accountId), {
     query: { folderId: inboxId, includeto: "true", limit: 200 },
   });
@@ -204,7 +231,7 @@ export async function listPending() {
   // run. Filter terminal labels first, then dedupe by threadId (falling back
   // to messageId when a message is not threaded), keeping the first
   // occurrence — Zoho returns newest-first so that's the most recent message.
-  const filtered = arr.filter((m) => !messageHasTerminalLabel(m));
+  const filtered = arr.filter((m) => !messageHasTerminalLabel(m, idToName));
   const seen = new Set();
   const deduped = [];
   for (const m of filtered) {

--- a/scripts/support-agent.sh
+++ b/scripts/support-agent.sh
@@ -272,8 +272,13 @@ for THREAD_INDEX in $(seq 0 $((PENDING_COUNT - 1))); do
     # that entry IS the latest message in the thread. The header endpoint is
     # folder-scoped (see zoho-cli.mjs ZOHO_API_PATHS.messageHeader).
     if [[ -n "$MSG_ID" && -n "$FOLDER_ID" ]]; then
-      HEADERS_JSON=$(node "$SCRIPT_DIR/lib/zoho-cli.mjs" get-headers "$FOLDER_ID" "$MSG_ID" \
-        2>>"$LOG_FILE" || echo '{}')
+      if HEADERS_JSON=$(node "$SCRIPT_DIR/lib/zoho-cli.mjs" get-headers "$FOLDER_ID" "$MSG_ID" \
+          2>>"$LOG_FILE"); then
+        :
+      else
+        log "WARNING: get-headers failed for $TRACK_ID (folder=$FOLDER_ID, msg=$MSG_ID); headers omitted"
+        HEADERS_JSON='{}'
+      fi
     else
       log "WARNING: pending entry for $TRACK_ID has no folderId/messageId — headers omitted"
       HEADERS_JSON='{}'

--- a/scripts/support-agent.sh
+++ b/scripts/support-agent.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 # Real-time support agent — launchd entrypoint.
 #
-# Phase A scope: dry-run only. The script polls the Zoho Inbox via
-# zoho-cli.mjs list-pending, builds a context bundle per pending thread,
-# and prints the bundle(s) to stdout. It does NOT invoke Claude Code,
-# does NOT reply to threads, does NOT create GitHub issues, and does NOT
-# touch labels or folders. Phase C+ will lift these gates progressively
-# (read-only labels → escalate → auto-reply → full).
+# Phase C scope: live but inert. The script polls the Zoho Inbox via
+# zoho-cli.mjs list-pending and either prints a context bundle per pending
+# thread (dry-run) or applies the `Drafto/Support/Seen` label so the thread
+# disappears from the agent's pending set (label-only). It does NOT invoke
+# Claude Code, does NOT reply to threads, does NOT create GitHub issues,
+# and does NOT move folders. Phase D+ will lift these gates progressively
+# (escalate → auto-reply → full).
 #
-# Modes:
-#   --dry-run                  Phase A. Required until Phase C ships.
-#   --fixture <path>           Replay a captured Zoho list-pending JSON
-#                              instead of hitting the live API. Useful for
-#                              unit-test-style golden runs.
+# Modes (exactly one of --dry-run or --label-only is required):
+#   --dry-run                  Build and print bundles. No Zoho mutations.
+#                              Useful for golden-run testing and for
+#                              eyeballing live-API output.
+#   --label-only               Apply Drafto/Support/Seen to each pending
+#                              thread. Live API mutation, but inert from
+#                              the customer's perspective. Phase C live mode.
+#   --fixture <path>           (--dry-run only) Replay a captured Zoho
+#                              list-pending JSON instead of hitting the
+#                              live API. Refused under --label-only because
+#                              fixtures contain synthetic threadIds that
+#                              don't exist in the real mailbox.
 #
 # Failure mode: if the script exits non-zero, the cleanup trap files a
 # `nightly-failure`-labelled GitHub issue, mirroring the existing pattern
@@ -27,18 +35,25 @@ export LC_ALL=en_US.UTF-8
 
 # ── Args ────────────────────────────────────────────────────────────────────
 DRY_RUN=0
+LABEL_ONLY=0
 FIXTURE=""
 usage() {
   cat <<EOF
-Usage: $0 --dry-run [--fixture <path-to-list-pending.json>]
+Usage: $0 (--dry-run | --label-only) [--fixture <path-to-list-pending.json>]
 
-Phase A scope — dry-run is required. The agent does not yet make any
-changes to Zoho or GitHub.
+Exactly one of --dry-run or --label-only is required (Phase C). The agent
+does not yet reply, file issues, move folders, or invoke Claude.
+
+  --dry-run      Print the context bundle that Claude would receive.
+                 No Zoho mutations.
+  --label-only   Apply Drafto/Support/Seen to each pending thread.
+                 Live API mutation. Refuses --fixture.
 EOF
 }
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=1; shift ;;
+    --label-only) LABEL_ONLY=1; shift ;;
     --fixture)
       if [[ -z "${2:-}" || "${2:0:2}" == "--" ]]; then
         echo "ERROR: --fixture requires a path argument" >&2
@@ -53,9 +68,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ "$DRY_RUN" -ne 1 ]]; then
-  echo "ERROR: Phase A requires --dry-run." >&2
+if [[ "$DRY_RUN" -eq 0 && "$LABEL_ONLY" -eq 0 ]]; then
+  echo "ERROR: must specify --dry-run or --label-only (Phase C)." >&2
   usage >&2
+  exit 2
+fi
+if [[ "$DRY_RUN" -eq 1 && "$LABEL_ONLY" -eq 1 ]]; then
+  echo "ERROR: --dry-run and --label-only are mutually exclusive." >&2
+  exit 2
+fi
+if [[ "$LABEL_ONLY" -eq 1 && -n "$FIXTURE" ]]; then
+  echo "ERROR: --fixture cannot be combined with --label-only (would mutate Zoho with synthetic threadIds)." >&2
   exit 2
 fi
 
@@ -152,7 +175,7 @@ fi
 OAUTH_USER_EMAIL="${OAUTH_USER_EMAIL:-support@drafto.eu}"
 
 START_TIME=$(date +%s)
-log "=== support-agent run started (dry-run=$DRY_RUN, fixture=${FIXTURE:-none}) ==="
+log "=== support-agent run started (dry-run=$DRY_RUN, label-only=$LABEL_ONLY, fixture=${FIXTURE:-none}) ==="
 
 # ── Cheap pre-check: list-pending ───────────────────────────────────────────
 if [[ -n "$FIXTURE" ]]; then
@@ -178,42 +201,92 @@ if [[ "$PENDING_COUNT" -eq 0 ]]; then
   exit 0
 fi
 
-# ── Build & emit context bundles (Phase A: print only) ──────────────────────
+# ── Per-thread loop ─────────────────────────────────────────────────────────
+# list-pending dedupes in zoho-cli.mjs, so each iteration here corresponds to
+# a unique conversation. The list entry IS the latest message in that thread
+# (Zoho returns newest-first; lib keeps first occurrence). Singleton inbound
+# messages don't get a threadId assigned by Zoho until they're replied to —
+# we treat those as 1-message threads keyed off messageId for tracking, and
+# label them via add-message-label instead of add-label.
+LABEL_FAILURES=0
 for THREAD_INDEX in $(seq 0 $((PENDING_COUNT - 1))); do
-  THREAD_ID=$(echo "$PENDING" \
-    | jq -r ".[${THREAD_INDEX}].threadId // .[${THREAD_INDEX}].messageId // .[${THREAD_INDEX}].id // empty")
-  if [[ -z "$THREAD_ID" ]]; then
+  ENTRY=$(echo "$PENDING" | jq ".[${THREAD_INDEX}]")
+  THREAD_ID=$(echo "$ENTRY" | jq -r '.threadId // empty')
+  MSG_ID=$(echo "$ENTRY" | jq -r '.messageId // .id // empty')
+  FOLDER_ID=$(echo "$ENTRY" | jq -r '.folderId // empty')
+  TRACK_ID="${THREAD_ID:-$MSG_ID}"
+  if [[ -z "$TRACK_ID" ]]; then
     log "WARNING: pending entry $THREAD_INDEX has no threadId/messageId — skipping"
     continue
   fi
-  log "Building bundle for thread $THREAD_ID"
 
-  # In a real run we'd call zoho-cli.mjs get-thread + get-headers here. In
-  # dry-run with a fixture, the fixture entry IS the thread payload and we
-  # pass it through as-is. In dry-run against the live API, only fetch when
-  # we have OAuth (we already verified above).
-  if [[ -n "$FIXTURE" ]]; then
-    THREAD_JSON=$(echo "$PENDING" | jq ".[${THREAD_INDEX}]")
-    HEADERS_JSON=$(echo "$THREAD_JSON" | jq '.headers // {}')
-  else
-    if ! THREAD_JSON=$(node "$SCRIPT_DIR/lib/zoho-cli.mjs" get-thread "$THREAD_ID" 2>>"$LOG_FILE"); then
-      log "ERROR: get-thread failed for $THREAD_ID; skipping"
-      continue
+  if [[ "$LABEL_ONLY" -eq 1 ]]; then
+    if [[ -n "$THREAD_ID" ]]; then
+      log "Applying Drafto/Support/Seen to thread $THREAD_ID"
+      if node "$SCRIPT_DIR/lib/zoho-cli.mjs" add-label "$THREAD_ID" "Drafto/Support/Seen" \
+          >>"$LOG_FILE" 2>&1; then
+        log "Labelled thread $THREAD_ID"
+      else
+        LABEL_FAILURES=$((LABEL_FAILURES + 1))
+        log "ERROR: add-label failed for thread $THREAD_ID"
+      fi
+    elif [[ -n "$MSG_ID" ]]; then
+      log "Applying Drafto/Support/Seen to message $MSG_ID (singleton, no threadId)"
+      if node "$SCRIPT_DIR/lib/zoho-cli.mjs" add-message-label "$MSG_ID" "Drafto/Support/Seen" \
+          >>"$LOG_FILE" 2>&1; then
+        log "Labelled message $MSG_ID"
+      else
+        LABEL_FAILURES=$((LABEL_FAILURES + 1))
+        log "ERROR: add-message-label failed for message $MSG_ID"
+      fi
     fi
-    LATEST_MSG_ID=$(echo "$THREAD_JSON" | jq -r '.messages[-1].messageId // .messages[-1].id // empty')
-    if [[ -n "$LATEST_MSG_ID" ]]; then
-      HEADERS_JSON=$(node "$SCRIPT_DIR/lib/zoho-cli.mjs" get-headers "$LATEST_MSG_ID" 2>>"$LOG_FILE" || echo '{}')
+    continue
+  fi
+
+  # --dry-run path: build a context bundle and print it.
+  log "Building bundle for $TRACK_ID (threadId=${THREAD_ID:-<none>}, msgId=$MSG_ID)"
+  if [[ -n "$FIXTURE" ]]; then
+    # Fixtures already wrap messages in {threadId, messages, headers, ...}.
+    THREAD_JSON="$ENTRY"
+    HEADERS_JSON=$(echo "$ENTRY" | jq '.headers // {}')
+  else
+    if [[ -n "$THREAD_ID" ]]; then
+      # get-thread returns a raw [<msg>, ...] array. Wrap it as
+      # {threadId, messages} so bundle.thread has the same shape as fixtures.
+      if MSGS_JSON=$(node "$SCRIPT_DIR/lib/zoho-cli.mjs" get-thread "$THREAD_ID" 2>>"$LOG_FILE"); then
+        THREAD_JSON=$(jq -n \
+          --argjson messages "$MSGS_JSON" \
+          --arg threadId "$THREAD_ID" \
+          '{ threadId: $threadId, messages: $messages }')
+      else
+        log "WARNING: get-thread failed for $THREAD_ID; falling back to list-pending entry"
+        THREAD_JSON=$(jq -n --argjson entry "$ENTRY" --arg threadId "$THREAD_ID" \
+          '{ threadId: $threadId, messages: [$entry] }')
+      fi
     else
+      # No threadId yet — treat the list-pending entry as a 1-message thread.
+      THREAD_JSON=$(jq -n --argjson entry "$ENTRY" \
+        '{ threadId: null, messages: [$entry] }')
+    fi
+    # Headers come from the list-pending entry's message id+folder id, since
+    # that entry IS the latest message in the thread. The header endpoint is
+    # folder-scoped (see zoho-cli.mjs ZOHO_API_PATHS.messageHeader).
+    if [[ -n "$MSG_ID" && -n "$FOLDER_ID" ]]; then
+      HEADERS_JSON=$(node "$SCRIPT_DIR/lib/zoho-cli.mjs" get-headers "$FOLDER_ID" "$MSG_ID" \
+        2>>"$LOG_FILE" || echo '{}')
+    else
+      log "WARNING: pending entry for $TRACK_ID has no folderId/messageId — headers omitted"
       HEADERS_JSON='{}'
     fi
   fi
 
   # TODO(phase-D): replace the hardcoded `state` placeholders below with values
   # computed from scripts/lib/state.mjs + scripts/lib/policy.mjs before this
-  # bundle is fed to Claude. Phase A only prints bundles, so leaving the loop
-  # guard / human-intervention flags as constants is harmless — but they MUST
-  # be wired up before Phase D flips on auto-classify+escalate, otherwise
-  # rateLimitOk and humanIntervened will never trip.
+  # bundle is fed to Claude. Phase C only prints bundles in dry-run mode and
+  # only labels in --label-only, so leaving the loop guard / human-intervention
+  # flags as constants is harmless — but they MUST be wired up before Phase D
+  # flips on auto-classify+escalate, otherwise rateLimitOk and humanIntervened
+  # will never trip.
   BUNDLE=$(jq -n \
     --argjson thread "$THREAD_JSON" \
     --argjson headers "$HEADERS_JSON" \
@@ -233,14 +306,14 @@ for THREAD_INDEX in $(seq 0 $((PENDING_COUNT - 1))); do
        }
      }')
 
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    log "DRY-RUN: would invoke claude with the following bundle:"
-    echo "$BUNDLE" | tee -a "$LOG_FILE"
-    log "DRY-RUN: end of bundle for $THREAD_ID"
-  else
-    log "ERROR: live mode is not implemented yet (Phase C+)."
-    exit 1
-  fi
+  log "DRY-RUN: would invoke claude with the following bundle:"
+  echo "$BUNDLE" | tee -a "$LOG_FILE"
+  log "DRY-RUN: end of bundle for $TRACK_ID"
 done
+
+if [[ "$LABEL_ONLY" -eq 1 && "$LABEL_FAILURES" -gt 0 ]]; then
+  log "ERROR: $LABEL_FAILURES of $PENDING_COUNT label operations failed"
+  exit 1
+fi
 
 log "=== support-agent run completed in $(( $(date +%s) - START_TIME ))s ==="


### PR DESCRIPTION
## Summary

- Lands Phase C of the support-agent rollout (per `~/code/support-agent-plan.md`): real Zoho API endpoint paths, a live-but-inert `--label-only` mode, and a disk-cached OAuth access token so the launchd cadence doesn't trip Zoho's rate limit.
- Phase A's guessed paths (`/messages/{id}/details`, `/messages/{id}/header`) are replaced with verified ones (`/messages/view?threadId=…`, `/folders/{folderId}/messages/{messageId}/header`).
- `support-agent.sh` gains `--label-only` (applies `Drafto/Support/Seen` per thread) and a singleton path for messages Zoho hasn't yet assigned a threadId to.
- 54 unit tests passing (was 46). Live `--dry-run` against the real Inbox produces clean bundles with parsed headers and no `get-thread failed` errors.

## What's new

**Endpoint corrections** (`scripts/lib/zoho-cli.mjs`):
- `getThread` → `GET /messages/view?threadId=<id>` returning `{data: [<msg>, …]}`
- `getHeaders` → `GET /folders/{folderId}/messages/{messageId}/header` returning `{data: {headerContent: "<CRLF blob>"}}` — CLI signature is now `get-headers <folderId> <messageId>`
- `listPending` dedupes by `threadId ?? messageId` (Zoho returns one entry per message; two messages in one thread would otherwise process twice per run)
- New `add-message-label` subcommand for un-threaded singletons via `PUT /updatemessage mode=applyLabel`

**Live `--label-only` mode** (`scripts/support-agent.sh`):
- Applies `Drafto/Support/Seen` per pending thread (or per-message for singletons), then exits — no Claude, no replies, no folder moves, no GitHub
- Refuses `--fixture` so synthetic threadIds never reach the live API
- Threads `folderId` from each list-pending entry into `get-headers`
- Falls back to a 1-message thread bundle when Zoho hasn't assigned a threadId yet

**Disk-cached access token** (`scripts/lib/zoho-auth.mjs`):
- Persists access_token to `<oauth-dir>/zoho-token-cache.json` (mode 0600) so the multiple node-CLI invocations per launchd interval share one token. Without this, each run burned 5+ OAuth refreshes and tripped Zoho's "too many requests" cap during testing.
- Sync `unlinkSync` on invalidate keeps the on-401 retry honest
- `ZOHO_TOKEN_CACHE_PATH` env var for test isolation

**OAuth scope fix** (`scripts/lib/setup-zoho-oauth.mjs`):
- The Phase B refresh token was issued with `accounts.READ + messages.ALL + folders.ALL` only; `/labels` returns `INVALID_OAUTHSCOPE` without `ZohoMail.labels.ALL`. The bootstrap script's prompts and inline docs now list all four scopes.

## Operator follow-up

Before `--label-only` mode can run live, **re-run `node scripts/lib/setup-zoho-oauth.mjs`** with the fourth scope. The existing refresh token at `~/drafto-secrets/zoho-oauth.json` keeps Phase A/B working and the Phase C `--dry-run` path works without it — only label writes need the new scope.

## Test plan

- [x] `node --test scripts/__tests__/*.test.mjs` — all 54 tests pass (5 new for endpoint shapes + dedupe + addMessageLabel + disk cache)
- [x] `pnpm lint && pnpm typecheck && pnpm format:check` — clean
- [x] Live `bash scripts/support-agent.sh --dry-run` against the real Inbox: 2 unique threads, both with parsed headers, no `get-thread failed` errors, singleton (no-threadId) message bundles correctly with `threadId: null`
- [ ] Operator re-runs `setup-zoho-oauth.mjs` with `ZohoMail.labels.ALL` added
- [ ] Operator runs `bash scripts/support-agent.sh --label-only` and confirms the two pending threads land in the agent's Seen-labelled set
- [ ] Watch a 24h interval for unexpected behaviour before flipping Phase D

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add single-message labeling from the CLI and a folder-scoped header fetch that returns thread messages.
  * New `--label-only` mode for batch label operations.

* **Bug Fixes**
  * Deduplicate pending inbox results by thread (fallback to message when needed).
  * Improve token validity handling to avoid using near-expiry tokens.

* **Documentation**
  * OAuth guidance updated to require the label/tag scope.

* **Tests**
  * Expanded tests covering labeling, token disk-cache behavior, header parsing, and thread/listing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->