### PR TITLE
fix(desktop): close note-erasure path and tag every client write

### DIFF
--- a/apps/desktop/__tests__/components/notes/note-editor-tripwire.test.ts
+++ b/apps/desktop/__tests__/components/notes/note-editor-tripwire.test.ts
@@ -1,4 +1,4 @@
-import { isCatastrophicEraseSave } from "../../../src/components/notes/erase-tripwire";
+import { isCatastrophicEraseSave } from "@/components/notes/erase-tripwire";
 
 const FORTY_KB_NOTE = JSON.stringify(
   Array.from({ length: 200 }, (_, i) => ({

--- a/apps/desktop/__tests__/components/notes/note-editor-tripwire.test.ts
+++ b/apps/desktop/__tests__/components/notes/note-editor-tripwire.test.ts
@@ -1,0 +1,72 @@
+import { isCatastrophicEraseSave } from "../../../src/components/notes/erase-tripwire";
+
+const FORTY_KB_NOTE = JSON.stringify(
+  Array.from({ length: 200 }, (_, i) => ({
+    type: "paragraph",
+    content: [{ type: "text", text: `paragraph ${i} `.repeat(20) }],
+    children: [],
+  })),
+);
+
+const SMALL_REAL_NOTE = JSON.stringify([
+  { type: "paragraph", content: [{ type: "text", text: "hello" }], children: [] },
+]);
+
+const EMPTY_BLOCKNOTE = JSON.stringify([{ type: "paragraph", content: [], children: [] }]);
+const EMPTY_BLOCKNOTE_NO_CHILDREN = JSON.stringify([{ type: "paragraph", content: [] }]);
+const EMPTY_ARRAY = JSON.stringify([]);
+
+describe("isCatastrophicEraseSave", () => {
+  it("blocks the exact 49-byte empty-BlockNote signature against a 40 KB note", () => {
+    expect(isCatastrophicEraseSave(FORTY_KB_NOTE, EMPTY_BLOCKNOTE)).toBe(true);
+  });
+
+  it("blocks empty-paragraph variants without children prop", () => {
+    expect(isCatastrophicEraseSave(FORTY_KB_NOTE, EMPTY_BLOCKNOTE_NO_CHILDREN)).toBe(true);
+  });
+
+  it("blocks an empty array against a substantial note", () => {
+    expect(isCatastrophicEraseSave(FORTY_KB_NOTE, EMPTY_ARRAY)).toBe(true);
+  });
+
+  it("permits the same erase pattern when existing content is small", () => {
+    expect(isCatastrophicEraseSave(SMALL_REAL_NOTE, EMPTY_BLOCKNOTE)).toBe(false);
+  });
+
+  it("permits a legitimate small but non-empty save against a large note", () => {
+    expect(isCatastrophicEraseSave(FORTY_KB_NOTE, SMALL_REAL_NOTE)).toBe(false);
+  });
+
+  it("permits any save when the existing record is empty/null", () => {
+    expect(isCatastrophicEraseSave(null, EMPTY_BLOCKNOTE)).toBe(false);
+    expect(isCatastrophicEraseSave(undefined, EMPTY_BLOCKNOTE)).toBe(false);
+    expect(isCatastrophicEraseSave("", EMPTY_BLOCKNOTE)).toBe(false);
+  });
+
+  it("permits non-paragraph single-block writes (heading, image, etc.)", () => {
+    const headingOnly = JSON.stringify([
+      { type: "heading", props: { level: 1 }, content: [], children: [] },
+    ]);
+    expect(isCatastrophicEraseSave(FORTY_KB_NOTE, headingOnly)).toBe(false);
+  });
+
+  it("permits writes with multiple blocks even if each is short", () => {
+    const twoEmptyParagraphs = JSON.stringify([
+      { type: "paragraph", content: [], children: [] },
+      { type: "paragraph", content: [], children: [] },
+    ]);
+    expect(isCatastrophicEraseSave(FORTY_KB_NOTE, twoEmptyParagraphs)).toBe(false);
+  });
+
+  it("permits writes that fail to parse as JSON (the editor would never produce these)", () => {
+    expect(isCatastrophicEraseSave(FORTY_KB_NOTE, "not-json")).toBe(false);
+    expect(isCatastrophicEraseSave(FORTY_KB_NOTE, "")).toBe(false);
+  });
+
+  it("uses the 1000-byte protection threshold inclusively", () => {
+    const justUnder = "x".repeat(999);
+    const justOver = "x".repeat(1000);
+    expect(isCatastrophicEraseSave(justUnder, EMPTY_BLOCKNOTE)).toBe(false);
+    expect(isCatastrophicEraseSave(justOver, EMPTY_BLOCKNOTE)).toBe(true);
+  });
+});

--- a/apps/desktop/src/components/notes/erase-tripwire.ts
+++ b/apps/desktop/src/components/notes/erase-tripwire.ts
@@ -1,0 +1,30 @@
+// Shrinkage tripwire for note content saves. Refuses a save that would
+// replace substantial existing content with the empty-BlockNote signature.
+// The 2026-04-24 (PR #323) and 2026-04-27 incidents both produced this
+// exact pattern — a ~50-byte write wiping 20–40 KB notes. The check is
+// intentionally narrow: it only fires on the catastrophic-erase signature,
+// never on legitimate user shrinkage. See ADR 0022 for the recovery
+// infrastructure that backs this up.
+
+const TRIPWIRE_PROTECTED_BYTES = 1000;
+
+export function isCatastrophicEraseSave(
+  oldContent: string | null | undefined,
+  newContent: string,
+): boolean {
+  if (!oldContent || oldContent.length < TRIPWIRE_PROTECTED_BYTES) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(newContent);
+  } catch {
+    return false;
+  }
+  if (!Array.isArray(parsed)) return false;
+  if (parsed.length === 0) return true;
+  if (parsed.length > 1) return false;
+  const block = parsed[0] as { type?: string; content?: unknown; text?: string };
+  if (block?.type !== "paragraph") return false;
+  const isEmptyContent =
+    !block.content || (Array.isArray(block.content) && block.content.length === 0);
+  return isEmptyContent && !block.text;
+}

--- a/apps/desktop/src/components/notes/note-editor-panel.tsx
+++ b/apps/desktop/src/components/notes/note-editor-panel.tsx
@@ -24,6 +24,7 @@ import { CalendarIcon } from "@/components/ui/icons/calendar-icon";
 import { ClockIcon } from "@/components/ui/icons/clock-icon";
 import { NoteEditor } from "@/components/editor/note-editor";
 import { AttachmentPicker } from "@/components/editor/attachment-picker";
+import { isCatastrophicEraseSave } from "./erase-tripwire";
 
 type SaveStatusKey = "saving" | "saved" | "error";
 
@@ -96,6 +97,15 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
 
   const handleSaveContent = useCallback(async (payload: ContentSavePayload) => {
     const record = await database.get<Note>("notes").find(payload.noteId);
+    if (isCatastrophicEraseSave(record.content, payload.content)) {
+      console.warn(
+        "[note-editor] tripwire blocked catastrophic-erase save",
+        `noteId=${payload.noteId}`,
+        `existing=${record.content?.length ?? 0}B`,
+        `incoming=${payload.content.length}B`,
+      );
+      return;
+    }
     await database.write(async () => {
       await record.update((n) => {
         n.content = payload.content;
@@ -241,11 +251,19 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
           editor.setContent(resolved);
           markLoaded();
         } catch (err) {
-          console.warn("Failed to set editor content:", err);
-          if (!cancelled) {
-            editor.setContent("");
-            markLoaded();
-          }
+          // Intentionally do NOT call editor.setContent("") or markLoaded()
+          // here. Wiping the editor would only cosmetically clear the WebView;
+          // calling markLoaded would open the autosave gate, allowing the
+          // editor's empty bootstrap onChange to persist an empty BlockNote
+          // and overwrite real DB content. The 2026-04-24 and 2026-04-27
+          // incidents both took this exact path. Leaving the gate closed on
+          // load failure means a stuck editor (the user can close+reopen),
+          // never a destructively-persisted empty doc.
+          console.warn(
+            "[note-editor] content load failed; leaving autosave gated",
+            `noteId=${targetNoteId}`,
+            err,
+          );
         }
       })();
 

--- a/apps/desktop/src/components/notes/note-editor-panel.tsx
+++ b/apps/desktop/src/components/notes/note-editor-panel.tsx
@@ -24,7 +24,7 @@ import { CalendarIcon } from "@/components/ui/icons/calendar-icon";
 import { ClockIcon } from "@/components/ui/icons/clock-icon";
 import { NoteEditor } from "@/components/editor/note-editor";
 import { AttachmentPicker } from "@/components/editor/attachment-picker";
-import { isCatastrophicEraseSave } from "./erase-tripwire";
+import { isCatastrophicEraseSave } from "@/components/notes/erase-tripwire";
 
 type SaveStatusKey = "saving" | "saved" | "error";
 

--- a/apps/desktop/src/lib/supabase.ts
+++ b/apps/desktop/src/lib/supabase.ts
@@ -22,4 +22,11 @@ export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
     detectSessionInUrl: false,
     flowType: "pkce",
   },
+  // Tag every request so note_content_history.archived_by records which
+  // platform did a write (see ADR 0023). The desktop app today targets
+  // macOS only — if a future build lands on Windows/Linux, broaden this
+  // mapping rather than emitting a NULL.
+  global: {
+    headers: { "x-drafto-client": "desktop-macos" },
+  },
 });

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -17,11 +17,22 @@ if (!supabaseUrl || !supabaseAnonKey) {
   );
 }
 
+// Tag every request so note_content_history.archived_by records which
+// platform did a write (see ADR 0023). Platform.OS is "ios" | "android" |
+// "web" — the mobile app ships only on iOS and Android, so anything
+// unexpected falls back to a generic "mobile" tag rather than silently
+// emitting a NULL.
+const clientTag =
+  Platform.OS === "ios" ? "mobile-ios" : Platform.OS === "android" ? "mobile-android" : "mobile";
+
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
   auth: {
     storage: secureStoreAdapter,
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: Platform.OS === "web",
+  },
+  global: {
+    headers: { "x-drafto-client": clientTag },
   },
 });

--- a/apps/web/src/app/api/cron/cleanup-trash/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-trash/route.ts
@@ -10,7 +10,7 @@ export async function POST(request: NextRequest) {
 
   if (cronSecret && authHeader === `Bearer ${cronSecret}`) {
     // Cron secret authenticated — use server client directly
-    const supabase = await createClient();
+    const supabase = await createClient("web-cron");
     const { data, error } = await supabase.rpc("cleanup_trashed_notes");
 
     if (error) {

--- a/apps/web/src/lib/api/mcp-auth.ts
+++ b/apps/web/src/lib/api/mcp-auth.ts
@@ -36,9 +36,12 @@ export async function authenticateMcpRequest(authHeader: string | null): Promise
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 
-  // Use service role client to look up the key (bypasses RLS)
+  // Use service role client to look up the key (bypasses RLS).
+  // Tag as web-mcp so note_content_history.archived_by distinguishes
+  // MCP-driven writes from regular admin/cron paths (see ADR 0023).
   const adminClient = createClient<Database>(env.NEXT_PUBLIC_SUPABASE_URL, serviceRoleKey, {
     auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { "x-drafto-client": "web-mcp" } },
   });
 
   // Look up key by hash

--- a/apps/web/src/lib/supabase/admin.ts
+++ b/apps/web/src/lib/supabase/admin.ts
@@ -4,21 +4,35 @@ import { env } from "@/env";
 import type { Database } from "@/lib/supabase/database.types";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-let cached: SupabaseClient<Database> | null = null;
+const cache = new Map<string, SupabaseClient<Database>>();
 
 /**
  * Service-role Supabase client. Bypasses RLS. Callers MUST authorize
  * the request themselves before using this client (e.g. verified admin
  * session, verified webhook signature, verified signed token).
+ *
+ * `clientTag` is sent as the `x-drafto-client` header on every request.
+ * The PostgREST pre_request hook copies it into `app.client` so the
+ * note_content_history trigger can record which subsystem performed an
+ * overwrite. Pass a more specific tag than the default `web-admin` when
+ * the call site is meaningfully distinct (e.g. `web-mcp`, `web-cron`).
  */
-export function createAdminClient(): SupabaseClient<Database> {
+export function createAdminClient(clientTag: string = "web-admin"): SupabaseClient<Database> {
   if (!env.SUPABASE_SERVICE_ROLE_KEY) {
     throw new Error("SUPABASE_SERVICE_ROLE_KEY is not configured");
   }
-  if (!cached) {
-    cached = createClient<Database>(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+  const cached = cache.get(clientTag);
+  if (cached) return cached;
+  const client = createClient<Database>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.SUPABASE_SERVICE_ROLE_KEY,
+    {
       auth: { autoRefreshToken: false, persistSession: false },
-    });
-  }
-  return cached;
+      global: {
+        headers: { "x-drafto-client": clientTag },
+      },
+    },
+  );
+  cache.set(clientTag, client);
+  return client;
 }

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -6,5 +6,10 @@ export function createClient() {
   return createBrowserClient<Database>(
     env.NEXT_PUBLIC_SUPABASE_URL,
     env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      global: {
+        headers: { "x-drafto-client": "web" },
+      },
+    },
   );
 }

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -39,6 +39,9 @@ export async function updateSession(request: NextRequest) {
     env.NEXT_PUBLIC_SUPABASE_URL,
     env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
+      global: {
+        headers: { "x-drafto-client": "web" },
+      },
       cookies: {
         getAll() {
           return request.cookies.getAll();

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -3,13 +3,16 @@ import { cookies } from "next/headers";
 import { env } from "@/env";
 import type { Database } from "@/lib/supabase/database.types";
 
-export async function createClient() {
+export async function createClient(clientTag: string = "web") {
   const cookieStore = await cookies();
 
   return createServerClient<Database>(
     env.NEXT_PUBLIC_SUPABASE_URL,
     env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
+      global: {
+        headers: { "x-drafto-client": clientTag },
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll();

--- a/docs/adr/0023-per-request-client-tagging.md
+++ b/docs/adr/0023-per-request-client-tagging.md
@@ -1,0 +1,76 @@
+# 0023 — Per-Request Client Tagging
+
+- **Status**: Accepted
+- **Date**: 2026-04-27
+- **Authors**: Jakub Anderwald
+
+## Context
+
+The 2026-04-24 incident (PR #323) and a recurrence on 2026-04-27 both produced the same byte signature in `notes.content` — the empty BlockNote document `[{"type":"paragraph","content":[],"children":[]}]` (~50 bytes) overwriting real user content. The recovery infrastructure from ADR 0022 (`note_content_history` + `scripts/recover-from-wal.py`) is doing its job — both incidents were recovered — but `note_content_history.archived_by` was `NULL` on every row in both cases, so there was no record of which client emitted the bad write.
+
+ADR 0022 anticipated this: `archived_by` is filled from `current_setting('app.client', true)` and is "best-effort … clients aren't required to set it." Until clients do set it, every recovery starts from "we know a client did this, but we don't know which one."
+
+This ADR closes that gap. It defines the tagging mechanism, the canonical tag values, and the deployment expectation: **all** Supabase-writing clients tag themselves. Half-coverage is worse than no coverage — a `NULL` becomes ambiguous (uncovered client vs. tagged client that misfired the SET) and rules nothing in.
+
+## Decision
+
+Adopt per-request tagging via PostgREST's `db_pre_request` hook, driven by a custom HTTP header that every Supabase client sets in its factory config.
+
+### Mechanism
+
+1. **HTTP header** — every `createClient(...)` call passes `global: { headers: { 'x-drafto-client': '<tag>' } }`. The header rides every request the client makes (REST + RPC + Realtime). For WatermelonDB-driven syncs, the same client instance is reused, so sync writes get tagged automatically.
+2. **`pre_request` plpgsql function** (`public.set_request_app_client`) — reads `request.headers->>'x-drafto-client'` and copies it into the transaction-local GUC `app.client` via `set_config(..., true)`. Returns void.
+3. **Authenticator role config** — `ALTER ROLE authenticator SET pgrst.db_pre_request = 'public.set_request_app_client'` plus `NOTIFY pgrst, 'reload config'` ships in the same migration so PostgREST picks it up without a dashboard step.
+4. **Existing trigger reads it as before** — `archive_note_content()` (from ADR 0022) already calls `nullif(current_setting('app.client', true), '')`. No trigger change required.
+
+### Canonical tag values
+
+| Tag               | Source                                                             |
+| ----------------- | ------------------------------------------------------------------ |
+| `web`             | Browser/server clients in `apps/web` (user-driven)                 |
+| `web-cron`        | Vercel cron routes (`/api/cron/*`)                                 |
+| `web-mcp`         | MCP server in `apps/web/src/lib/api/mcp-auth.ts`                   |
+| `web-admin`       | Service-role admin client in `apps/web/src/lib/supabase/admin.ts`  |
+| `desktop-macos`   | `apps/desktop/src/lib/supabase.ts`                                 |
+| `mobile-ios`      | `apps/mobile/src/lib/supabase.ts` when `Platform.OS === 'ios'`     |
+| `mobile-android`  | `apps/mobile/src/lib/supabase.ts` when `Platform.OS === 'android'` |
+| `script-backfill` | `scripts/backfill-inline-attachments.ts`                           |
+
+Values are deliberately stable strings — the next incident will be `grep`-driven, not parsed. Sub-distinctions (e.g. `desktop-macos-beta-26`) are out of scope; build version is already in Sentry/PostHog when needed.
+
+### Migration scope
+
+One migration adds the `pre_request` function and configures the role. No existing data is touched. The only behavioral change visible outside this ADR is that `note_content_history.archived_by` will now contain a value on every new row.
+
+## Consequences
+
+**Positive**
+
+- Every future content overwrite is attributable to a specific client class. The next "the desktop app erased my note again" report starts with `select archived_by from note_content_history where note_id = ...` rather than a code audit across 4 platforms.
+- Distinguishing user-driven writes (`web`) from automated writes (`web-cron`, `web-mcp`, `web-admin`, `script-*`) makes a service-role-key bug visually distinct from a UI bug in `archived_by`.
+- Implementation is one migration plus six client-factory edits — no schema changes, no app-code refactoring, no client-side state to manage.
+
+**Negative**
+
+- Adds one plpgsql function call per PostgREST request. The function is a single `set_config` call; cost is negligible, but it does run on every API hit (including reads).
+- A client that fails to set the header silently emits `NULL` rather than an error. We accept this — emitting an error would block legitimate writes for an observability nicety, which is the wrong trade. The `NULL` itself becomes a signal ("untagged client") once full coverage ships.
+- `pgrst.db_pre_request` is a singleton — if a future feature wants its own pre-request hook, it has to compose with `set_request_app_client` rather than replace it. Acceptable for now; revisit if and when that constraint binds.
+
+**Neutral**
+
+- The header `x-drafto-client` is visible to anyone inspecting network traffic from a user's browser/device. It carries no secret information; it is purely descriptive. Spoofing it would let a malicious client tag itself as `web-cron`, but that doesn't grant any privilege — RLS and service-role auth are still the actual security boundary.
+- Service-role keys keep working unchanged; the header rides alongside the existing `Authorization: Bearer <key>`.
+
+## Alternatives Considered
+
+- **JWT claim instead of header.** Would require minting custom JWTs from each client, conflicts with Supabase's auth flow, and doesn't cover service-role calls (which use a flat key, not a JWT). Rejected.
+- **RPC-only writes.** Wrap every `notes` UPDATE in an RPC that takes a `client_tag` argument. Forces a refactor of every write site, including WatermelonDB sync. Rejected as disproportionate to the goal.
+- **Sentry / PostHog as the source of truth.** Both already attribute events to clients, but only when the client is online and the SDK fired. The trigger captures every overwrite, including ones from offline-then-sync paths and from server-side jobs that don't run a frontend SDK. Database-level attribution is the right layer.
+- **Tag per-build (e.g. `desktop-macos-0.3.1-26`).** Useful, but build version is already correlated via Sentry release + commit timestamps when an incident is being investigated. Adding it to `archived_by` increases churn (every release flips the tag, complicating `grep`) without adding investigative power. Rejected for now; the table is one migration away from supporting it later.
+- **Stricter `NOT NULL` on `archived_by` once coverage lands.** Would surface untagged clients loudly. Rejected because the `archive_note_content()` trigger is `SECURITY DEFINER` and runs from contexts (manual SQL editor, future migrations, support scripts) where setting the header isn't always feasible. Soft `NULL` semantics are more honest.
+
+## Related
+
+- [ADR 0022 — Note Content History Table](./0022-note-content-history.md) — defines `archived_by`, anticipated this ADR
+- [`supabase/migrations/20260425000001_note_content_history.sql`](../../supabase/migrations/20260425000001_note_content_history.sql) — trigger that reads `app.client`
+- PostgREST `db_pre_request` configuration: https://postgrest.org/en/stable/references/configuration.html#db-pre-request

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,3 +55,4 @@ Every ADR follows the template in [0000-adr-template.md](./0000-adr-template.md)
 | [0020](./0020-email-design-tokens.md)                    | Email Design Tokens                            | Accepted           | 2026-04-21 |
 | [0021](./0021-shared-design-tokens.md)                   | Shared Design Tokens in `@drafto/shared`       | Accepted           | 2026-04-21 |
 | [0022](./0022-note-content-history.md)                   | Note Content History Table                     | Accepted           | 2026-04-25 |
+| [0023](./0023-per-request-client-tagging.md)             | Per-Request Client Tagging                     | Accepted           | 2026-04-27 |

--- a/scripts/backfill-inline-attachments.ts
+++ b/scripts/backfill-inline-attachments.ts
@@ -104,6 +104,7 @@ async function main() {
 
   const supabase = createClient(supabaseUrl, serviceKey, {
     auth: { persistSession: false },
+    global: { headers: { "x-drafto-client": "script-backfill" } },
   });
 
   console.log(`[backfill] target=${supabaseUrl} dry-run=${dryRun}`);

--- a/supabase/migrations/20260427000001_client_tagging_pre_request.sql
+++ b/supabase/migrations/20260427000001_client_tagging_pre_request.sql
@@ -1,0 +1,62 @@
+-- Per-request client tagging for note_content_history.archived_by.
+--
+-- ADR 0023 (docs/adr/0023-per-request-client-tagging.md): every Supabase
+-- client sends an x-drafto-client HTTP header (e.g. 'web', 'desktop-macos',
+-- 'mobile-ios', 'mobile-android', 'web-cron', 'web-mcp'). PostgREST runs
+-- the function below before each request, copying the header into the
+-- transaction-local GUC `app.client`. The trigger from
+-- 20260425000001_note_content_history.sql then reads that GUC into
+-- note_content_history.archived_by, giving every future content overwrite
+-- a client attribution.
+--
+-- Soft-failure semantics: a missing or empty header leaves app.client
+-- unset (still NULL via nullif in the trigger). We do not error on
+-- untagged requests — observability must not block legitimate writes.
+
+-- =============================================================================
+-- PRE-REQUEST FUNCTION
+-- =============================================================================
+
+create or replace function public.set_request_app_client()
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $$
+declare
+  client_tag text;
+begin
+  -- request.headers is a JSON object PostgREST exposes per request.
+  -- current_setting(..., true) returns NULL if the GUC is unset (e.g. when
+  -- the function is invoked outside a PostgREST context, like a direct
+  -- psql session); we treat that as 'no tag' rather than erroring.
+  begin
+    client_tag := current_setting('request.headers', true)::jsonb->>'x-drafto-client';
+  exception when others then
+    client_tag := null;
+  end;
+
+  -- Transaction-local: scoped to the current PostgREST transaction, never
+  -- leaks across requests. Empty string and NULL both result in app.client
+  -- staying empty, which the trigger normalizes to NULL via nullif.
+  perform set_config('app.client', coalesce(client_tag, ''), true);
+end;
+$$;
+
+comment on function public.set_request_app_client() is
+  'PostgREST pre_request hook. Copies x-drafto-client request header into '
+  'app.client GUC for the current transaction so the note_content_history '
+  'trigger can record which client wrote a content overwrite. See ADR 0023.';
+
+-- =============================================================================
+-- WIRE INTO POSTGREST
+-- =============================================================================
+
+-- The authenticator role is the one PostgREST connects as; setting the
+-- pgrst.db_pre_request GUC on it makes PostgREST invoke the function on
+-- every incoming request.
+alter role authenticator set pgrst.db_pre_request = 'public.set_request_app_client';
+
+-- Ask PostgREST to reload its config so the change applies without a
+-- restart. Idempotent and safe to run multiple times.
+notify pgrst, 'reload config';


### PR DESCRIPTION
## Summary

- Closes the desktop **note-erasure path** that reproduced on 2026-04-27 despite PR #323's `loadedNoteIdRef` gate. The catch branch in the editor's load pipeline was calling `editor.setContent("")` and `markLoaded()` on failure, opening the autosave gate so the WebView's empty bootstrap onChange persisted the empty BlockNote signature over real DB content. Catch now leaves the gate closed and only logs.
- Adds a **shrinkage tripwire** (`apps/desktop/src/components/notes/erase-tripwire.ts`) called from `handleSaveContent`. Refuses any save that matches the catastrophic-erase signature (empty array / single empty paragraph) when existing content > 1 KB. Narrow on purpose — never blocks legitimate user shrinkage.
- Wires **per-request client tagging** across all 8 Supabase factories per ADR 0023: `web`, `web-cron`, `web-mcp`, `web-admin`, `desktop-macos`, `mobile-ios`, `mobile-android`, `script-backfill`. PostgREST `db_pre_request` hook copies the `x-drafto-client` header into the `app.client` GUC, which the existing `note_content_history` trigger already reads into `archived_by`.

## Context

The 2026-04-24 incident (PR #323) and a recurrence on 2026-04-27 both produced the same byte signature in \`notes.content\` — \`[{"type":"paragraph","content":[],"children":[]}]\` (~50 bytes) wiping a 40 KB note. ADR 0022's \`note_content_history\` table recovered the 2026-04-27 note in seconds, but \`archived_by\` was \`NULL\` on every history row, so we had no way to tell which client wrote the bad value. This PR closes both gaps: stop the destructive code path on desktop, and tag every future write so the next investigation starts from a known client.

## Migration

Migration \`20260427000001_client_tagging_pre_request.sql\` adds:
- \`public.set_request_app_client()\` plpgsql function that reads the \`x-drafto-client\` header.
- \`ALTER ROLE authenticator SET pgrst.db_pre_request = 'public.set_request_app_client'\`.
- \`NOTIFY pgrst, 'reload config'\`.

**Applied to dev and end-to-end verified**: a PATCH against \`notes\` with \`x-drafto-client: tagging-e2e-test\` populated \`note_content_history.archived_by\` correctly. **Not yet applied to prod** — that's a gated step after this PR merges.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green (only pre-existing warnings)
- [x] \`pnpm format:check\` — green
- [x] \`pnpm --filter=@drafto/desktop test\` — 281/281 pass (10 new tripwire tests)
- [x] \`pnpm --filter=@drafto/web test\` — 679/679 pass
- [x] Migration applied to dev project \`huhzactreblzcogqkbsd\` and end-to-end verified
- [ ] After merge: apply migration to prod \`tbmjbxxseonkciqovnpl\` (gated on explicit user yes)
- [ ] After merge: smoke test on web — edit a note, confirm \`note_content_history.archived_by = 'web'\`
- [ ] After next desktop release: smoke test by editing a note from desktop, confirm \`archived_by = 'desktop-macos'\`

## Related

- ADR 0022 (\`docs/adr/0022-note-content-history.md\`) — defined \`archived_by\`
- ADR 0023 (this PR, \`docs/adr/0023-per-request-client-tagging.md\`) — tagging mechanism + canonical values
- Incident timelines: 2026-04-24 (PR #323), 2026-04-27 (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection against accidental catastrophic note deletion
  * Implemented client identification for all note modifications across desktop, mobile, and web

* **Bug Fixes**
  * Improved note editor error handling when content fails to load, preventing unintended data loss

* **Tests**
  * Added comprehensive test coverage for deletion protection scenarios

* **Documentation**
  * Documented client attribution mechanism for audit and recovery purposes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->