### PR TITLE
chore(safety): snapshot+diff DB row counts on every migration push

### DIFF
--- a/.claude/hooks/migration-stats-post.sh
+++ b/.claude/hooks/migration-stats-post.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Hook: Re-snapshot DB row counts AFTER a migration push and diff against
+# the matching pre-snapshot. Always exits 0 — observability tool, not a
+# guard. Migration is already done by the time this runs.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if ! echo "$COMMAND" | grep -qE '(^|[^[:alnum:]_])(supabase[[:space:]]+db[[:space:]]+(push|reset)|supabase[[:space:]]+migration[[:space:]]+up|pnpm[[:space:]]+supabase:push)([^[:alnum:]_]|$)'; then
+  exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+node "$REPO_ROOT/scripts/migration-stats.mjs" post || true
+exit 0

--- a/.claude/hooks/migration-stats-pre.sh
+++ b/.claude/hooks/migration-stats-pre.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Hook: Snapshot DB row counts BEFORE a migration push so we can diff after.
+# Triggered for every Bash tool invocation; no-op unless the command actually
+# runs a migration. Always exits 0 — observability tool, not a guard.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Match: `supabase db push`, `pnpm supabase:push`, `supabase migration up`,
+# `supabase db reset`. Whitespace-tolerant; doesn't match arbitrary strings
+# containing those substrings inside other args.
+if ! echo "$COMMAND" | grep -qE '(^|[^[:alnum:]_])(supabase[[:space:]]+db[[:space:]]+(push|reset)|supabase[[:space:]]+migration[[:space:]]+up|pnpm[[:space:]]+supabase:push)([^[:alnum:]_]|$)'; then
+  exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+node "$REPO_ROOT/scripts/migration-stats.mjs" pre || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,21 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/prevent-main-push.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/migration-stats-pre.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/migration-stats-post.sh"
           }
         ]
       }

--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -150,6 +150,7 @@ Production is on the Free tier today, so this is the _normal_ case for damage ol
 - `supabase projects list` before every prod push — confirms which ref is currently linked. Easy to forget when switching between dev and prod.
 - Require explicit user "yes" before any prod database operation; state the project ref, operation, and affected data first.
 - Apply every migration to dev first and verify before touching prod.
+- **Migration safety hook** (`.claude/hooks/migration-stats-{pre,post}.sh` + `scripts/migration-stats.mjs`) — Claude Code automatically snapshots row counts on critical tables (`notes`, `note_content_history`, `notebooks`, `attachments`, `profiles`, `api_keys`) before every `supabase db push` / `pnpm supabase:push` / `supabase db reset` and diffs them after. Decreases on user-data tables print a loud `⚠ DECREASE` alert. The hook is observability-only and never blocks the migration; it runs against whichever project is currently linked, so it works for both dev and prod.
 
 ## Related
 

--- a/scripts/migration-stats.mjs
+++ b/scripts/migration-stats.mjs
@@ -116,7 +116,8 @@ function snapshotPath(projectRef, mode) {
 }
 
 function describeProject(ref) {
-  if (ref === "tbmjbxxseonkciqovnpl") return `${COLOR.red}${COLOR.bold}PROD (drafto.eu)${COLOR.reset}`;
+  if (ref === "tbmjbxxseonkciqovnpl")
+    return `${COLOR.red}${COLOR.bold}PROD (drafto.eu)${COLOR.reset}`;
   if (ref === "huhzactreblzcogqkbsd") return `${COLOR.dim}dev${COLOR.reset}`;
   return ref;
 }
@@ -128,9 +129,7 @@ function diffSnapshots(pre, post) {
     const a = pre.tables[table];
     const b = post.tables[table];
     if (a?.error || b?.error) {
-      lines.push(
-        `  ${table}: skipped (${a?.error ?? ""}${b?.error ? ` / ${b.error}` : ""})`,
-      );
+      lines.push(`  ${table}: skipped (${a?.error ?? ""}${b?.error ? ` / ${b.error}` : ""})`);
       continue;
     }
     const before = a.count;

--- a/scripts/migration-stats.mjs
+++ b/scripts/migration-stats.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// Migration safety: snapshot DB row counts before/after a `supabase db push`,
+// diff them, and surface any unexpected data loss. Runs from a Claude Code
+// hook (.claude/hooks/migration-stats-{pre,post}.sh) or directly from the CLI.
+//
+// Usage:
+//   node scripts/migration-stats.mjs pre
+//   node scripts/migration-stats.mjs post
+//
+// `pre` writes a snapshot to /tmp/drafto-migration-stats-pre-<ref>.json.
+// `post` re-snapshots, diffs against the matching pre file, and prints a
+// [MIGRATION SAFETY] report to stderr. Exit code is always 0 — this is an
+// observability tool, not a guard. If you want to actually block a push,
+// react to the report.
+//
+// Behavior on missing inputs:
+//   - No linked project (supabase/.temp/project-ref absent): prints a
+//     dimmed [MIGRATION SAFETY] note and exits 0. Don't block migrations
+//     just because the snapshot couldn't run.
+//   - No service-role key: same.
+//   - Network failure: same. Best-effort, fail-open.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PROJECT_REF_FILE = path.join(REPO_ROOT, "supabase", ".temp", "project-ref");
+const KEY_FILE = path.join(os.homedir(), "drafto-secrets", "supabase service keys.txt");
+
+// Tables to snapshot. `keyAggregates` are PostgREST-friendly aggregations
+// (just row count today; extend with an RPC if/when content-size totals
+// matter enough to be worth the schema change).
+const TABLES = [
+  "notes",
+  "note_content_history",
+  "notebooks",
+  "attachments",
+  "profiles",
+  "api_keys",
+];
+
+// Drops that should always trigger an alert. Increases never alert
+// (concurrent user activity is normal); only decreases.
+const NEVER_DECREASE = new Set(["notes", "notebooks", "attachments", "profiles"]);
+
+const COLOR = process.stderr.isTTY
+  ? { red: "\x1b[31m", yellow: "\x1b[33m", dim: "\x1b[2m", reset: "\x1b[0m", bold: "\x1b[1m" }
+  : { red: "", yellow: "", dim: "", reset: "", bold: "" };
+
+function log(line) {
+  process.stderr.write(`[MIGRATION SAFETY] ${line}\n`);
+}
+
+async function readProjectRef() {
+  try {
+    return (await fs.readFile(PROJECT_REF_FILE, "utf8")).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function readServiceKey(projectRef) {
+  // The keys file uses "DEV: <key>" / "PROD: <key>" format. Map ref → tag.
+  let raw;
+  try {
+    raw = await fs.readFile(KEY_FILE, "utf8");
+  } catch {
+    return null;
+  }
+  const tag = projectRef === "tbmjbxxseonkciqovnpl" ? "PROD" : "DEV";
+  for (const line of raw.split("\n")) {
+    if (line.startsWith(`${tag}:`)) return line.slice(tag.length + 1).trim();
+  }
+  return null;
+}
+
+async function tableCount(projectRef, key, table) {
+  // PostgREST exact count via Prefer header. select=id&limit=0 minimises
+  // payload — we only need the Content-Range header.
+  const url = `https://${projectRef}.supabase.co/rest/v1/${table}?select=id&limit=0`;
+  const resp = await fetch(url, {
+    headers: {
+      apikey: key,
+      authorization: `Bearer ${key}`,
+      Prefer: "count=exact",
+    },
+  });
+  if (!resp.ok) {
+    return { error: `HTTP ${resp.status} ${await resp.text().catch(() => "")}` };
+  }
+  // Content-Range looks like "0-0/<total>" or "*/<total>" when empty.
+  const range = resp.headers.get("content-range") ?? "";
+  const match = range.match(/\/(\d+|\*)$/);
+  if (!match || match[1] === "*") return { error: `unparsable Content-Range: ${range}` };
+  return { count: Number(match[1]) };
+}
+
+async function snapshot(projectRef, key) {
+  const stats = {
+    project_ref: projectRef,
+    captured_at: new Date().toISOString(),
+    tables: {},
+  };
+  await Promise.all(
+    TABLES.map(async (table) => {
+      stats.tables[table] = await tableCount(projectRef, key, table);
+    }),
+  );
+  return stats;
+}
+
+function snapshotPath(projectRef, mode) {
+  return path.join(os.tmpdir(), `drafto-migration-stats-${mode}-${projectRef}.json`);
+}
+
+function describeProject(ref) {
+  if (ref === "tbmjbxxseonkciqovnpl") return `${COLOR.red}${COLOR.bold}PROD (drafto.eu)${COLOR.reset}`;
+  if (ref === "huhzactreblzcogqkbsd") return `${COLOR.dim}dev${COLOR.reset}`;
+  return ref;
+}
+
+function diffSnapshots(pre, post) {
+  const lines = [];
+  let alerts = 0;
+  for (const table of TABLES) {
+    const a = pre.tables[table];
+    const b = post.tables[table];
+    if (a?.error || b?.error) {
+      lines.push(
+        `  ${table}: skipped (${a?.error ?? ""}${b?.error ? ` / ${b.error}` : ""})`,
+      );
+      continue;
+    }
+    const before = a.count;
+    const after = b.count;
+    const delta = after - before;
+    let marker = "";
+    if (delta < 0 && NEVER_DECREASE.has(table)) {
+      marker = ` ${COLOR.red}${COLOR.bold}⚠ DECREASE${COLOR.reset}`;
+      alerts += 1;
+    } else if (delta < 0) {
+      marker = ` ${COLOR.yellow}↓${COLOR.reset}`;
+    } else if (delta > 0) {
+      marker = ` ${COLOR.dim}+${delta}${COLOR.reset}`;
+    } else {
+      marker = ` ${COLOR.dim}=${COLOR.reset}`;
+    }
+    lines.push(`  ${table.padEnd(22)} ${before} → ${after}${marker}`);
+  }
+  return { lines, alerts };
+}
+
+async function cmdPre() {
+  const ref = await readProjectRef();
+  if (!ref) {
+    log(`${COLOR.dim}skip pre-snapshot: no linked project${COLOR.reset}`);
+    return;
+  }
+  const key = await readServiceKey(ref);
+  if (!key) {
+    log(`${COLOR.dim}skip pre-snapshot: no service-role key for ${ref}${COLOR.reset}`);
+    return;
+  }
+  const stats = await snapshot(ref, key);
+  await fs.writeFile(snapshotPath(ref, "pre"), JSON.stringify(stats, null, 2));
+  const counts = Object.entries(stats.tables)
+    .map(([t, v]) => `${t}=${v.count ?? "?"}`)
+    .join(" ");
+  log(`pre-snapshot taken on ${describeProject(ref)} (${counts})`);
+}
+
+async function cmdPost() {
+  const ref = await readProjectRef();
+  if (!ref) {
+    log(`${COLOR.dim}skip post-snapshot: no linked project${COLOR.reset}`);
+    return;
+  }
+  const key = await readServiceKey(ref);
+  if (!key) {
+    log(`${COLOR.dim}skip post-snapshot: no service-role key for ${ref}${COLOR.reset}`);
+    return;
+  }
+
+  let pre;
+  try {
+    pre = JSON.parse(await fs.readFile(snapshotPath(ref, "pre"), "utf8"));
+  } catch {
+    log(
+      `${COLOR.yellow}post-snapshot: no matching pre-snapshot for ${ref}; running stand-alone post.${COLOR.reset}`,
+    );
+    const stats = await snapshot(ref, key);
+    await fs.writeFile(snapshotPath(ref, "post"), JSON.stringify(stats, null, 2));
+    return;
+  }
+
+  const post = await snapshot(ref, key);
+  await fs.writeFile(snapshotPath(ref, "post"), JSON.stringify(post, null, 2));
+
+  const ageSec = Math.round((Date.parse(post.captured_at) - Date.parse(pre.captured_at)) / 1000);
+  log(`post-diff on ${describeProject(ref)} (window: ${ageSec}s)`);
+  const { lines, alerts } = diffSnapshots(pre, post);
+  for (const line of lines) process.stderr.write(`  ${line}\n`);
+  if (alerts > 0) {
+    log(
+      `${COLOR.red}${COLOR.bold}⚠ ${alerts} table(s) lost rows that should never decrease. ` +
+        `Review note_content_history for what was archived; restore from there if needed.${COLOR.reset}`,
+    );
+  } else {
+    log(`${COLOR.dim}no row-count drops on protected tables${COLOR.reset}`);
+  }
+}
+
+const mode = process.argv[2];
+try {
+  if (mode === "pre") await cmdPre();
+  else if (mode === "post") await cmdPost();
+  else {
+    log("usage: migration-stats.mjs <pre|post>");
+    process.exit(0);
+  }
+} catch (err) {
+  // Never block migrations because the safety check itself errored.
+  log(`${COLOR.yellow}safety-check error (ignored): ${err.message}${COLOR.reset}`);
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

- Adds a **Claude Code hook** that fires before and after every \`supabase db push\` / \`pnpm supabase:push\` / \`supabase migration up\` / \`supabase db reset\` (dev or prod, whichever project is currently linked).
- Pre-snapshots row counts on the user-data tables (\`notes\`, \`note_content_history\`, \`notebooks\`, \`attachments\`, \`profiles\`, \`api_keys\`).
- Post-diffs and prints \`⚠ DECREASE\` if any of the protected tables lost rows.
- Strictly observability — **never blocks** the migration. Fail-open on missing project link / missing service-role key / network errors.

## Why

The 2026-04-27 erasure incident had us recovering data from \`note_content_history\` after the fact. Had this diff been running, the user would have seen the row-count drop the moment the next sync round-tripped to the server, instead of finding it via the editor UI hours later. Cheap signal, no blocking risk, works on both dev and prod.

## Files

- \`scripts/migration-stats.mjs\` — Node stdlib, no deps. Reads linked project from \`supabase/.temp/project-ref\`, picks the matching key from \`~/drafto-secrets/supabase service keys.txt\`, hits PostgREST with \`Prefer: count=exact\`. Writes snapshots to \`/tmp/drafto-migration-stats-{pre,post}-<ref>.json\`.
- \`.claude/hooks/migration-stats-pre.sh\` and \`.claude/hooks/migration-stats-post.sh\` — bash wrappers that match the migration commands by regex on \`tool_input.command\` and invoke the script. Same pattern as the existing \`prevent-main-{commit,push}.sh\` hooks.
- \`.claude/settings.json\` — registers both hooks (pre joins the existing PreToolUse Bash matcher; post is a new PostToolUse block).
- \`docs/operations/migrations.md\` — documents the hook in the "Preventative guardrails" section.

## Test plan

- [x] Pre-snapshot run against currently-linked prod: \`node scripts/migration-stats.mjs pre\` → captured \`notes=398 note_content_history=403 notebooks=148 attachments=9 profiles=5 api_keys=1\`.
- [x] Post-diff run with no-op gap: shows \`= = = = = =\` and \`no row-count drops on protected tables\`.
- [x] Hook regex correctly matches \`pnpm supabase:push\` and ignores \`echo hello\`.
- [ ] Real-world: next dev migration push will exercise the hook end-to-end.

## Out of scope

- Content-byte aggregation (e.g. \`sum(length(content::text))\` per user). Would require an RPC since PostgREST doesn't expose arbitrary aggregation; row counts catch the catastrophic case (mass deletes / truncates) on their own.
- Slack/Sentry alerting. Local stderr is sufficient for the agent loop today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)