### PR TITLE
chore(docs): merge Claude auto-memory content into project docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ When planning, fan out independent actions into a single batched message — don
 
 **Worktree gotcha**: `Edit`/`Write` require a prior `Read` of the _exact_ path. Reading `/Users/…/drafto/foo.ts` does NOT satisfy an edit against `/Users/…/drafto-worktree/foo.ts`. Pattern when starting work in a worktree: one batched `Read` for every worktree file you'll touch, then one batched `Edit`/`Write` for all the changes.
 
+**Plan structure**: Multi-PR or multi-step plans should also exploit parallelism — group independent work into "waves" (Wave 1 fully parallel, Wave 2 after Wave 1, etc.) and assign each independent unit to its own subagent. End any plan that ships a cross-platform release with the explicit per-platform release commands as a final wave: web (Vercel auto-deploys on merge), `cd apps/mobile && pnpm release:prod:android`, `pnpm release:prod:ios`, `cd apps/desktop && pnpm release:production`. The three store releases run concurrently in their own subagents. Note any required version bumps (`pnpm version:mobile|desktop patch|minor|major`) before the release wave.
+
 ## SOLID Principles (Enforced)
 
 Every module must follow SOLID:
@@ -127,6 +129,12 @@ Common CI failure patterns:
 - Pre-commit hooks run lint-staged (ESLint + Prettier)
 - **Never commit or push directly to `main`** unless the user explicitly requests it. All work goes through feature branches and PRs.
 - **All pushes must use the `/push` command** — this ensures commits are pushed, CI/CD checks are polled until green, review comments are addressed, and failures are fixed automatically
+
+## Release Authorization
+
+Beta TestFlight builds (Mac App Store Connect, iOS, Android internal track) are **pre-authorized** — ship them without asking. Communicate what's going out (version + build number, what's in it) but don't gate on permission. A bad TestFlight build is reversible: the next build supersedes it, and old builds can be expired in App Store Connect.
+
+Production / public-store releases (`pnpm release:prod:*`, `pnpm release:production`, App Store / Play Store submission) still require explicit user approval — those affect non-tester users.
 
 ## Cross-Platform Feature Workflow
 

--- a/docs/features/offline-sync.md
+++ b/docs/features/offline-sync.md
@@ -121,6 +121,41 @@ it, so regenerating the Supabase types automatically propagates to both clients.
 - `supabase/migrations/*` (when columns change)
 - `packages/shared/src/types/supabase.ts` (regenerated types)
 
+## Incident: note content erasure
+
+The desktop app has overwritten `notes.content` with the BlockNote empty doc (`[{"type":"paragraph","content":[],"children":[]}]`, 49–54 bytes) at least twice in production:
+
+1. **2026-04-24** — first occurrence, traced to PR #323 (attachments refactor) running on a dev build. Motivated the recovery infrastructure shipped in commit `50a890f` on 2026-04-25: the `note_content_history` trigger, [`scripts/recover-from-wal.py`](../../scripts/recover-from-wal.py), and [ADR 0022](../adr/0022-note-content-history.md).
+2. **2026-04-27 17:45:31 UTC** — note `4261ef83-3431-4a77-9adc-9251d8b0642c` overwritten from 40,826 bytes to 54 bytes; recovered same day from the 17:44:43 autosave row in `note_content_history`. `archived_by` was `NULL` because clients aren't tagging themselves yet.
+
+PRs #323 and #341 narrowed the surface but a path that produces this exact failure mode still exists. Treat as a live bug, not a one-off.
+
+### Recovery procedure
+
+When a user reports an erased note, recovery is mechanical. Service-role key lives in `~/drafto-secrets/supabase service keys.txt`; target the prod Supabase project (`tbmjbxxseonkciqovnpl`).
+
+```sql
+UPDATE notes
+SET content = (
+  SELECT content
+  FROM note_content_history
+  WHERE note_id = '<uuid>'
+    AND length(content::text) > 200
+  ORDER BY created_at DESC
+  LIMIT 1
+)
+WHERE id = '<uuid>';
+```
+
+Pick the most recent history row whose content length is non-trivial. Confirm the byte size matches the user's expectation before committing.
+
+### Open investigation
+
+Desktop is the only platform that has reproduced this — `apps/desktop/src/db/sync.ts` does server-side deletion detection that `apps/mobile/src/db/sync.ts` does not, which makes the desktop sync wrapper a prime suspect. Two follow-ups still open:
+
+- Wire `SET app.client = 'desktop'` (and `'mobile'` / `'web'`) on every client write so future `note_content_history` rows populate `archived_by` and pinpoint the responsible client.
+- A third recurrence is the trigger to file a tracked GitHub issue with timestamps + pre/post diff and stop guessing.
+
 ## Verify
 
 ```bash

--- a/docs/operations/builds-and-releases.md
+++ b/docs/operations/builds-and-releases.md
@@ -57,6 +57,49 @@ export ASC_API_KEY_P8_PATH="/path/to/AuthKey.p8"
 
 These are sourced automatically from `~/drafto-secrets/android-env.sh` on local machines set up per [local dev setup](./local-dev-setup.md).
 
+## Known release gotchas
+
+Recurring issues hit when running release lanes locally. Check these first if a release fails on a fresh machine or worktree.
+
+### `MATCH_PASSWORD` not picked up by desktop fastlane
+
+`bundle exec fastlane mac beta` (and `mac production`) bails at the `match` step with `Neither the MATCH_PASSWORD environment variable nor the local keychain contained a password.` `~/drafto-secrets/match-env.sh` is a single-line `MATCH_PASSWORD=…` assignment without `export`, and `load_local_secrets` in `apps/desktop/fastlane/Fastfile` only sources `android-env.sh`. Plain `source` therefore creates a shell var, not an env var, and fastlane can't see it.
+
+Prefix the command with `set -a` so subsequent assignments are exported:
+
+```bash
+set -a; source ~/drafto-secrets/match-env.sh; set +a
+cd apps/desktop && bundle exec fastlane mac beta
+```
+
+Permanent fix: extend `load_local_secrets` to source `match-env.sh`, or add `export` to the secrets file.
+
+### "3rd Party Mac Developer Installer" cert missing
+
+`fastlane mac beta` signs the `.pkg` with `productbuild --sign "3rd Party Mac Developer Installer: …"`. This cert is **not** managed by Match (the Matchfile uses `type("appstore")`, which only fetches the "Apple Distribution" code-signing cert). It must be installed manually per machine via Xcode → Settings → Accounts → Manage Certificates… → `+` → "Mac Installer Distribution".
+
+Verify before running the lane:
+
+```bash
+security find-identity -v -p basic | grep "3rd Party Mac Developer Installer"
+```
+
+If missing, `productbuild` fails with `Could not find appropriate signing identity`. One-time per machine; worktrees inherit the host's keychain.
+
+### `post-release-notes.mjs` 400 on List Builds (non-fatal)
+
+After `upload_to_testflight`, `apps/desktop/scripts/post-release-notes.mjs` fails with:
+
+> TestFlight error: List builds failed: 400 PARAMETER_ERROR.ILLEGAL "The parameter 'sort' can not be used with this request"
+
+App Store Connect no longer accepts the `sort` query param on List Builds. The TestFlight upload itself succeeded — fastlane logs `Release notes posting failed (non-fatal)` and continues. Fix is to drop the `sort` param (or switch endpoints) in the script.
+
+### Missing `.env` / `.env.production` files
+
+`pnpm release:beta:*` and `pnpm release:prod:*` need `apps/mobile/.env` (dev) and `apps/mobile/.env.production` (prod); desktop equivalents at `apps/desktop/.env{,.production}`. Without them, `expo prebuild` fails with `google-signin without Firebase config plugin: Missing iosUrlScheme in provided options`.
+
+These files hold Expo public env vars (Supabase URL/anon key, Google iOS URL scheme) and are gitignored. They are **not** in `~/drafto-secrets/` — restore from a personal backup. Worktree copy steps for these files are in [`CLAUDE.md`](../../CLAUDE.md) → "Worktree Workflow".
+
 ## Android
 
 App package: `eu.drafto.mobile`


### PR DESCRIPTION
## Summary

- Salvages operationally useful entries from Claude Code's auto-memory directory (`~/.claude/projects/.../memory/`) into the canonical project docs, so nothing is lost when auto-memory is disabled and the memory directory is archived.
- `CLAUDE.md`: adds a **Plan structure** sub-note in Parallel Tool Execution (parallel waves + explicit final per-platform release wave) and a new top-level **Release Authorization** section (beta TestFlight pre-authorized; production / public-store releases still require explicit approval).
- `docs/operations/builds-and-releases.md`: adds a **Known release gotchas** section covering `MATCH_PASSWORD` sourcing for desktop fastlane, the manual "3rd Party Mac Developer Installer" cert, the non-fatal `post-release-notes.mjs` 400 on List Builds, and the missing-`.env`-files prerequisite (cross-linking CLAUDE.md instead of duplicating).
- `docs/features/offline-sync.md`: adds an **Incident: note content erasure** section with both the 2026-04-24 and 2026-04-27 timestamps, the recovery SQL, and the open investigation thread (desktop sync wrapper as prime suspect, `SET app.client` tagging follow-up).

The actual `autoMemoryEnabled: false` setting lives in `~/.claude/settings.json` (outside this repo) and was applied separately. The memory directory will be renamed to `memory.archived-2026-04-28/` once this merges, so it can be spot-checked before final deletion.

## Test plan

- [x] `pnpm exec prettier --check` passes on all three modified docs
- [x] ADR cross-link target verified (`docs/adr/0022-note-content-history.md`)
- [x] `scripts/recover-from-wal.py` cross-link verified
- [ ] CI passes
- [ ] Markdown rendering looks correct in PR preview (relative links resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)