### PR TITLE
docs(claude): add infrastructure cost discipline guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,19 @@ Note-taking app at drafto.eu. Monorepo with pnpm workspaces + Turborepo. Web (Ne
 
 Historical plans live in [`docs/archive/`](./docs/archive/) — do not treat as source of truth.
 
+## Infrastructure cost discipline
+
+Drafto runs on free / already-paid-for tiers. Before proposing any new paid service (Cloudflare Workers, Postmark, Inngest, an additional Supabase project, etc.), exhaust what's already in place:
+
+- **Vercel free tier** for the web app (with the existing cron at `/api/cron/cleanup-trash`).
+- **Supabase free tier** for both prod (`tbmjbxxseonkciqovnpl`) and dev (`huhzactreblzcogqkbsd`) projects.
+- **Resend free tier** (3k/month, 100/day) for outbound transactional email — already verified on `drafto.eu`.
+- **Zoho Mail** for inbound `support@drafto.eu` — already configured; the support-agent automation runs against this mailbox.
+- **Mac mini** for scheduled agent work — already runs `scripts/nightly-support.sh` and `scripts/nightly-audit.sh` via launchd, has `gh` CLI authenticated, and runs Claude Code with `--dangerously-skip-permissions` on an existing paid subscription.
+- **GoDaddy** registrar / DNS (don't assume Cloudflare; Cloudflare is not the DNS provider).
+
+If a feature genuinely requires paid infrastructure, surface that explicitly as a tradeoff and let the user decide. Don't silently introduce new monthly line items.
+
 ## Worktree Workflow (Required)
 
 Never work directly on `main`. For every new task (feature, fix, chore, docs):


### PR DESCRIPTION
## Summary

- Adds a new top-level **Infrastructure cost discipline** section near the top of `CLAUDE.md` listing the free / already-paid-for tiers Drafto runs on, so future agents exhaust what's in place before proposing any new paid service.
- Items called out: Vercel free tier (with the existing `/api/cron/cleanup-trash` cron), Supabase free tier (prod + dev project refs), Resend free tier for transactional email, Zoho Mail for inbound `support@drafto.eu`, the Mac mini for scheduled agent work (already runs `nightly-support.sh` + `nightly-audit.sh` via launchd), and GoDaddy as the DNS registrar.
- No code changes; one doc section, 13 lines added.

## Test plan

- [x] Section renders correctly in markdown preview
- [x] Prettier passes (`pnpm exec prettier --check CLAUDE.md`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)