### PR TITLE
chore(support-agent): add 60s loop wrapper for launchd

### DIFF
--- a/scripts/support-agent-loop.sh
+++ b/scripts/support-agent-loop.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# launchd entrypoint that runs support-agent.sh's three live modes back-to-back
+# under a single mutex, so a 60-second cron tick walks the full Zoho → GitHub
+# → customer-email pipeline once per minute.
+#
+# Modes (per scripts/support-agent.sh):
+#   --auto-classify  Phase D+: classify pending Zoho threads, escalate or auto-reply.
+#   --comment-sync   Phase F+: forward GitHub support-issue comments to Zoho.
+#   --state-sync     Phase G+: forward GitHub issue lifecycle (closed/reopened) to Zoho.
+#
+# Mutex: macOS lacks flock(1), so we use a mkdir-based lock. If the previous
+# tick is still running, this run exits cleanly without waiting.
+
+set -euo pipefail
+
+LOCK_DIR="/tmp/drafto-support-agent.lock"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENT="$SCRIPT_DIR/support-agent.sh"
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+# Each mode is independent; if one fails, still try the others so a transient
+# Zoho hiccup doesn't starve the GitHub-side sweeps.
+"$AGENT" --auto-classify --phase G || true
+"$AGENT" --comment-sync  --phase G || true
+"$AGENT" --state-sync    --phase G || true


### PR DESCRIPTION
## Summary

Adds `scripts/support-agent-loop.sh` so we can schedule the support agent every minute via launchd on the Mac mini.

PR #352 shipped Phase G `--state-sync` and `--comment-sync` modes in `support-agent.sh`, but `support-agent.sh` was never actually scheduled — `launchctl list` only shows `eu.drafto.nightly-support` and `eu.drafto.nightly-audit`. As a result, customer-facing comms (the "Working on it now" / "Fix in review: PR #N" / "It'll go out with our next release" messages PR #352 added) never reached the customer's Zoho thread.

This wrapper runs the three live modes back-to-back under a single mutex:

- `--auto-classify --phase G` — sweep pending Zoho threads (Phase D+).
- `--comment-sync --phase G` — forward GitHub support-issue comments to Zoho (Phase F+).
- `--state-sync --phase G` — forward GitHub issue lifecycle (closed/reopened) emails (Phase G+).

Mutex notes: macOS doesn't ship `flock(1)`, so we use an atomic mkdir on `/tmp/drafto-support-agent.lock`. If a tick is still running when the next minute fires, the new invocation exits cleanly rather than stacking. Each mode is wrapped in `|| true` so a transient Zoho/GitHub hiccup in one phase doesn't starve the others.

The launchd plist that drives this lives outside the repo at `~/Library/LaunchAgents/eu.drafto.support-agent.plist` on the Mac mini and will be installed in a follow-up step.

## Test plan

- [x] `bash -n scripts/support-agent-loop.sh` (syntax)
- [ ] Manual invocation on the Mac mini after merge — confirm `logs/support/support-agent-<date>.log` records one auto-classify + one comment-sync + one state-sync sweep, and the lock file is removed on exit.
- [ ] `launchctl bootstrap` the plist; verify a tick runs at the next minute boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)