### PR TITLE
fix(support-agent): bypass shebang in loop wrapper to avoid macOS dyld hang

### DIFF
--- a/scripts/support-agent-loop.sh
+++ b/scripts/support-agent-loop.sh
@@ -10,6 +10,16 @@
 #
 # Mutex: macOS lacks flock(1), so we use a mkdir-based lock. If the previous
 # tick is still running, this run exits cleanly without waiting.
+#
+# Shebang bypass: we invoke the agent as `bash "$AGENT"` instead of letting
+# the kernel resolve the script's `#!/bin/bash` shebang. On macOS 26.3.1
+# (and likely related builds), launching a `#!/bin/bash` script from a
+# child of a launchd-spawned bash hangs at `_dyld_start` indefinitely
+# (sample shows the universal-binary slice mis-selected as plain ARM64
+# rather than the available ARM64E). Calling `bash <path>` explicitly
+# sidesteps that resolution path. Verified by side-by-side test:
+# `bash -c 'support-agent.sh ...'` hangs; `bash -c 'bash support-agent.sh ...'`
+# completes immediately.
 
 set -euo pipefail
 
@@ -24,6 +34,6 @@ trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
 
 # Each mode is independent; if one fails, still try the others so a transient
 # Zoho hiccup doesn't starve the GitHub-side sweeps.
-"$AGENT" --auto-classify --phase G || true
-"$AGENT" --comment-sync  --phase G || true
-"$AGENT" --state-sync    --phase G || true
+bash "$AGENT" --auto-classify --phase G || true
+bash "$AGENT" --comment-sync  --phase G || true
+bash "$AGENT" --state-sync    --phase G || true

--- a/scripts/support-agent-loop.sh
+++ b/scripts/support-agent-loop.sh
@@ -33,7 +33,9 @@ fi
 trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
 
 # Each mode is independent; if one fails, still try the others so a transient
-# Zoho hiccup doesn't starve the GitHub-side sweeps.
-bash "$AGENT" --auto-classify --phase G || true
-bash "$AGENT" --comment-sync  --phase G || true
-bash "$AGENT" --state-sync    --phase G || true
+# Zoho hiccup doesn't starve the GitHub-side sweeps. Use the absolute
+# `/bin/bash` rather than relying on PATH — launchd's PATH is minimal and a
+# missing `bash` lookup here would silently no-op the whole tick.
+/bin/bash "$AGENT" --auto-classify --phase G || true
+/bin/bash "$AGENT" --comment-sync  --phase G || true
+/bin/bash "$AGENT" --state-sync    --phase G || true


### PR DESCRIPTION
## Summary

Fixes a hang in `scripts/support-agent-loop.sh` where the wrapper's child `support-agent.sh` invocation wedges at `_dyld_start` indefinitely on macOS 26.3.1 — the launchd plist installed yesterday never produced a single log line because of this.

`sample` on the hung pid shows the universal-binary slice mis-selected as plain ARM64 instead of the available ARM64E. The process never reaches `main()` — no log lines, no children, 0% CPU.

Side-by-side reproduction (with `set -euo pipefail` on the parent bash):

```bash
# Hangs forever:
bash -c '/Users/jakub/code/drafto/scripts/support-agent.sh --state-sync --phase G'

# Completes in 1 second:
bash -c 'bash /Users/jakub/code/drafto/scripts/support-agent.sh --state-sync --phase G'
```

The only difference is whether the kernel resolves the script's `#!/bin/bash` shebang or whether we call `bash <path>` explicitly. Switching the wrapper to the latter sidesteps the broken resolution path. End-to-end verified locally on the Mac mini: the wrapper now runs all three modes (`--auto-classify`, `--comment-sync`, `--state-sync`) and processes the live Zoho inbox + GitHub support queue as intended.

## Test plan

- [x] `bash -n scripts/support-agent-loop.sh` (syntax check)
- [x] `bash scripts/support-agent-loop.sh` (manual run on Mac mini) — runs all three modes, lock acquired/released cleanly
- [ ] After merge: re-bootstrap `~/Library/LaunchAgents/eu.drafto.support-agent.plist` and confirm a 60-second tick lands a complete cycle in `logs/support/support-agent-<date>.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a macOS-specific compatibility issue that could cause the support agent process to hang, improving overall system reliability and consistent performance across all platforms.

* **Documentation**
  * Enhanced script documentation with clarifications on platform-specific compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->