### PR TITLE
fix(web): strip non-ASCII chars from attachment storage keys

### DIFF
--- a/apps/web/__tests__/unit/sanitize-filename.test.ts
+++ b/apps/web/__tests__/unit/sanitize-filename.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeAndBuildPath } from "@/lib/api/sanitize-filename";
+
+const USER_ID = "3b39a3fa-d37e-478e-aa3c-d7377c465529";
+const NOTE_ID = "99ba04b8-949a-4727-a464-345fdaa7441d";
+
+describe("sanitizeAndBuildPath", () => {
+  it("normalises accented characters to their ASCII base (DRAFTO-P regression)", () => {
+    const { fileName, filePath } = sanitizeAndBuildPath(
+      "partikelverb Aöb(1).pdf",
+      USER_ID,
+      NOTE_ID,
+    );
+
+    expect(fileName).toMatch(/^partikelverb Aob\(1\)-\d+-[0-9a-f]{8}\.pdf$/);
+    expect(fileName).not.toMatch(/ö/);
+    expect(filePath).toBe(`${USER_ID}/${NOTE_ID}/${fileName}`);
+    // The whole key must be printable ASCII — that's what Supabase Storage requires.
+    expect(filePath).toMatch(/^[\x20-\x7e]+$/);
+  });
+
+  it("replaces emoji and other non-ASCII codepoints with underscores", () => {
+    const { fileName } = sanitizeAndBuildPath("hello 👋 漢字.png", USER_ID, NOTE_ID);
+
+    expect(fileName).toMatch(/^hello __ __-\d+-[0-9a-f]{8}\.png$/);
+  });
+
+  it("strips path traversal sequences", () => {
+    const { fileName, filePath } = sanitizeAndBuildPath("../etc/passwd", USER_ID, NOTE_ID);
+
+    expect(fileName).not.toContain("..");
+    expect(fileName).not.toContain("/");
+    expect(filePath.startsWith(`${USER_ID}/${NOTE_ID}/`)).toBe(true);
+    expect(filePath.split("/")).toHaveLength(3);
+  });
+
+  it("keeps the file name within the Supabase 255-char limit", () => {
+    const longBase = "a".repeat(400);
+    const { fileName } = sanitizeAndBuildPath(`${longBase}.pdf`, USER_ID, NOTE_ID);
+
+    expect(fileName.length).toBeLessThanOrEqual(255);
+    expect(fileName.endsWith(".pdf")).toBe(true);
+  });
+
+  it("handles names without an extension", () => {
+    const { fileName } = sanitizeAndBuildPath("README", USER_ID, NOTE_ID);
+
+    expect(fileName).toMatch(/^README-\d+-[0-9a-f]{8}$/);
+    expect(fileName.startsWith(".")).toBe(false);
+  });
+
+  it("produces a unique path on every call (collision-safe suffix)", () => {
+    const a = sanitizeAndBuildPath("photo.jpg", USER_ID, NOTE_ID);
+    const b = sanitizeAndBuildPath("photo.jpg", USER_ID, NOTE_ID);
+
+    expect(a.filePath).not.toBe(b.filePath);
+  });
+});

--- a/apps/web/src/lib/api/sanitize-filename.ts
+++ b/apps/web/src/lib/api/sanitize-filename.ts
@@ -13,10 +13,10 @@ export function sanitizeAndBuildPath(
     // Decompose accented chars (e.g. "ö" → "o" + U+0308) and strip the combining marks,
     // so the readable base letter survives instead of being replaced with "_".
     .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
+    .replaceAll(/[\u0300-\u036f]/g, "")
     // Supabase Storage rejects non-ASCII keys — replace any remaining
     // non-printable-ASCII (emoji, CJK, surrogates, control chars).
-    .replace(/[^\x20-\x7e]/g, "_")
+    .replaceAll(/[^\x20-\x7e]/g, "_")
     .replace(/[/\\]/g, "_") // no path separators
     .replace(/\.\./g, "_") // no directory traversal
     .replace(/[<>:"|?*\x00-\x1f]/g, "_"); // no shell/HTML-special chars

--- a/apps/web/src/lib/api/sanitize-filename.ts
+++ b/apps/web/src/lib/api/sanitize-filename.ts
@@ -10,6 +10,13 @@ export function sanitizeAndBuildPath(
   noteId: string,
 ): { fileName: string; filePath: string } {
   const sanitized = rawName
+    // Decompose accented chars (e.g. "ö" → "o" + U+0308) and strip the combining marks,
+    // so the readable base letter survives instead of being replaced with "_".
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    // Supabase Storage rejects non-ASCII keys — replace any remaining
+    // non-printable-ASCII (emoji, CJK, surrogates, control chars).
+    .replace(/[^\x20-\x7e]/g, "_")
     .replace(/[/\\]/g, "_") // no path separators
     .replace(/\.\./g, "_") // no directory traversal
     .replace(/[<>:"|?*\x00-\x1f]/g, "_"); // no shell/HTML-special chars


### PR DESCRIPTION
## Summary

- Sentry **DRAFTO-P** (`Error: Upload failed: Invalid key: …/partikelverb Aöb(1)-…pdf`) is an unhandled rejection thrown when Supabase Storage rejects keys containing non-ASCII bytes.
- The web sanitiser at `apps/web/src/lib/api/sanitize-filename.ts` previously only stripped path separators, traversal, and a few shell-special chars — accented letters, emoji, CJK, etc. all passed through into the storage key.
- This PR brings the web sanitiser in line with the existing mobile/desktop one (`apps/mobile/src/lib/data/attachment-queue.ts:19-35`, `apps/desktop/src/lib/data/attachment-utils.ts:1-17`): NFD-decompose + strip combining marks (so `ö` → `o`), then replace any remaining non-printable-ASCII with `_`.
- New unit test covers the regression input plus emoji, path traversal, length cap, no-extension, and collision-safety cases.

Mobile/desktop already sanitised correctly on the client and were not affected by DRAFTO-P.

## Test plan

- [x] `pnpm --filter @drafto/web test sanitize-filename` — 6/6 pass
- [x] `pnpm test` (all packages) — 702 web tests + mobile + desktop + shared all green
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — passes
- [ ] Manual smoke after deploy: drop a file named `Café Übung 漢字 (2).pdf` into a note's editor in prod, confirm upload succeeds and no new Sentry capture for DRAFTO-P

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename sanitization to properly handle accented characters, converting them to ASCII equivalents.
  * Enhanced special character handling by replacing emoji and non-ASCII characters with underscores.
  * Strengthened path security controls and validation.

* **Tests**
  * Added comprehensive unit test suite for filename sanitization and path validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->