### PR TITLE
fix(web): preserve list content from Evernote table cells

### DIFF
--- a/apps/web/__tests__/unit/enml-to-blocknote.test.ts
+++ b/apps/web/__tests__/unit/enml-to-blocknote.test.ts
@@ -121,6 +121,9 @@ describe("convertEnmlToBlocks", () => {
     const secondContent = bullets[1].content as Array<{ text: string }>;
     expect(firstContent.map((i) => i.text).join("")).toBe("first");
     expect(secondContent.map((i) => i.text).join("")).toBe("second");
+    // The empty <td><div><br/></div></td> spacer cell must not leak through
+    // as a paragraph containing only whitespace.
+    expect(blocks.every((b) => b.type === "bulletListItem")).toBe(true);
   });
 
   it("flattens nested lists in genuine multi-column tables instead of dropping them", () => {

--- a/apps/web/__tests__/unit/enml-to-blocknote.test.ts
+++ b/apps/web/__tests__/unit/enml-to-blocknote.test.ts
@@ -142,6 +142,56 @@ describe("convertEnmlToBlocks", () => {
     expect(listText).toBe("• x\n• y");
   });
 
+  it("keeps a real table when any row has a header cell", () => {
+    const enml = `<en-note><table>
+      <tr><th>Header</th></tr>
+      <tr><td><ul><li>x</li></ul></td></tr>
+    </table></en-note>`;
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+    expect(blocks.find((b) => b.type === "table")).toBeDefined();
+    expect(blocks.find((b) => b.type === "bulletListItem")).toBeUndefined();
+  });
+
+  it("keeps a real table when a single-column cell contains inline text mixed with blocks", () => {
+    const enml = `<en-note><table>
+      <tr><td>inline text<ul><li>a</li></ul></td></tr>
+    </table></en-note>`;
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+    const table = blocks.find((b) => b.type === "table");
+    expect(table).toBeDefined();
+    const content = table?.content as { rows: { cells: Array<{ text: string }>[] }[] };
+    const cellText = content.rows[0].cells[0].map((i) => i.text).join("");
+    expect(cellText).toBe("inline text\n• a");
+  });
+
+  it("flattens ordered lists, links, paragraphs and inline styles in cells", () => {
+    const enml = `<en-note><table>
+      <tr><td>k</td><td><ol><li>one</li><li>two</li></ol><p>tail</p><b>bold</b><a href="https://x.test">l</a></td></tr>
+    </table></en-note>`;
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+    const table = blocks.find((b) => b.type === "table");
+    expect(table).toBeDefined();
+    const content = table?.content as {
+      rows: {
+        cells: Array<{
+          type: string;
+          text: string;
+          href?: string;
+          styles?: Record<string, boolean>;
+        }>[];
+      }[];
+    };
+    const cell = content.rows[0].cells[1];
+    const flat = cell.map((i) => i.text).join("");
+    expect(flat).toContain("1. one");
+    expect(flat).toContain("2. two");
+    expect(flat).toContain("tail");
+    const bold = cell.find((i) => i.text === "bold");
+    expect(bold?.styles?.bold).toBe(true);
+    const link = cell.find((i) => i.type === "link");
+    expect(link?.href).toBe("https://x.test");
+  });
+
   it("returns default paragraph for empty content", () => {
     const blocks = convertEnmlToBlocks("", emptyMap);
     expect(blocks).toHaveLength(1);

--- a/apps/web/__tests__/unit/enml-to-blocknote.test.ts
+++ b/apps/web/__tests__/unit/enml-to-blocknote.test.ts
@@ -106,6 +106,42 @@ describe("convertEnmlToBlocks", () => {
     expect(content.rows[0].cells).toHaveLength(2);
   });
 
+  it("unwraps single-column layout tables of bullet lists into a flat list", () => {
+    const enml = `<en-note><table>
+      <tr><td><ul><li>first</li></ul></td></tr>
+      <tr><td><ul><li>second</li></ul></td></tr>
+      <tr><td><div><br/></div></td></tr>
+    </table></en-note>`;
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    expect(blocks.find((b) => b.type === "table")).toBeUndefined();
+    const bullets = blocks.filter((b) => b.type === "bulletListItem");
+    expect(bullets).toHaveLength(2);
+    const firstContent = bullets[0].content as Array<{ text: string }>;
+    const secondContent = bullets[1].content as Array<{ text: string }>;
+    expect(firstContent.map((i) => i.text).join("")).toBe("first");
+    expect(secondContent.map((i) => i.text).join("")).toBe("second");
+  });
+
+  it("flattens nested lists in genuine multi-column tables instead of dropping them", () => {
+    const enml = `<en-note><table>
+      <tr><td>label</td><td><ul><li>x</li><li>y</li></ul></td></tr>
+    </table></en-note>`;
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    const table = blocks.find((b) => b.type === "table");
+    expect(table).toBeDefined();
+    const content = table?.content as {
+      rows: { cells: Array<{ text: string }>[] }[];
+    };
+    expect(content.rows).toHaveLength(1);
+    expect(content.rows[0].cells).toHaveLength(2);
+    const labelText = content.rows[0].cells[0].map((i) => i.text).join("");
+    const listText = content.rows[0].cells[1].map((i) => i.text).join("");
+    expect(labelText).toBe("label");
+    expect(listText).toBe("• x\n• y");
+  });
+
   it("returns default paragraph for empty content", () => {
     const blocks = convertEnmlToBlocks("", emptyMap);
     expect(blocks).toHaveLength(1);

--- a/apps/web/src/lib/import/enml-to-blocknote.ts
+++ b/apps/web/src/lib/import/enml-to-blocknote.ts
@@ -176,8 +176,11 @@ function convertElement(
     case "en-media":
       return convertEnMedia(el, attachmentUrlMap);
 
-    case "table":
+    case "table": {
+      const unwrapped = tryUnwrapLayoutTable(el, attachmentUrlMap, taskMap);
+      if (unwrapped !== null) return unwrapped;
       return convertTable(el);
+    }
 
     case "br":
       return null;
@@ -326,7 +329,7 @@ function convertTable(tableEl: Element): Block {
     const cells: InlineContent[][] = [];
     const cellElements = tr.querySelectorAll("td, th");
     for (const cell of cellElements) {
-      cells.push(extractInlineContent(cell));
+      cells.push(extractCellInlineContent(cell));
     }
     if (cells.length > 0) {
       rows.push({ cells });
@@ -337,6 +340,147 @@ function convertTable(tableEl: Element): Block {
     type: "table",
     content: { type: "tableContent", rows },
   };
+}
+
+const BLOCK_TAGS = new Set([
+  "ul",
+  "ol",
+  "div",
+  "p",
+  "table",
+  "en-media",
+  "en-todo",
+  "blockquote",
+  "h1",
+  "h2",
+  "h3",
+  "hr",
+]);
+
+/**
+ * Detect tables used purely for layout (Evernote often wraps a column of
+ * lists in a single-column table). When detected, unwrap each cell's
+ * children into top-level blocks so lists/divs render naturally instead of
+ * being lost inside cells (BlockNote table cells only allow inline content).
+ *
+ * Heuristic: no <th>, every <tr> has at most one <td>, and every non-empty
+ * cell contains only block-level children (no meaningful inline text).
+ * Returns null when the table doesn't match — caller falls back to a real table.
+ */
+function tryUnwrapLayoutTable(
+  tableEl: Element,
+  attachmentUrlMap: Map<string, string>,
+  taskMap: Map<string, EnexTask[]>,
+): Block[] | null {
+  if (tableEl.querySelector("th")) return null;
+
+  const rows = tableEl.querySelectorAll("tr");
+  if (rows.length === 0) return null;
+
+  const cells: Element[] = [];
+  for (const tr of rows) {
+    const tds = tr.querySelectorAll("td");
+    if (tds.length > 1) return null;
+    if (tds.length === 1) cells.push(tds[0]);
+  }
+
+  for (const cell of cells) {
+    if (!isBlockOnlyCell(cell)) return null;
+  }
+
+  const blocks: Block[] = [];
+  for (const cell of cells) {
+    blocks.push(...processChildren(cell, attachmentUrlMap, taskMap));
+  }
+  return blocks;
+}
+
+function isBlockOnlyCell(cell: Element): boolean {
+  for (const node of Array.from(cell.childNodes)) {
+    if (node.nodeType === 3) {
+      // Inline text in a cell disqualifies it from layout-table treatment.
+      if ((node as Text).textContent?.trim()) return false;
+    } else if (node.nodeType === 1) {
+      const tag = (node as Element).tagName.toLowerCase();
+      // <br> alone (e.g. <div><br/></div>) is fine; any other inline tag means
+      // the cell mixes inline content and shouldn't be unwrapped.
+      if (tag === "br") continue;
+      if (!BLOCK_TAGS.has(tag)) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Extract inline content from a table cell. Unlike extractInlineContent,
+ * this recurses into block-level children (divs, paragraphs, lists) so their
+ * text isn't silently dropped. Lists are flattened with bullet/number prefixes
+ * and newline separators.
+ */
+function extractCellInlineContent(cell: Element): InlineContent[] {
+  const parts: InlineContent[][] = [];
+
+  for (const node of Array.from(cell.childNodes)) {
+    if (node.nodeType === 3) {
+      const text = (node as Text).textContent || "";
+      if (text.trim()) parts.push([{ type: "text", text, styles: {} }]);
+      continue;
+    }
+    if (node.nodeType !== 1) continue;
+    const childEl = node as Element;
+    const tag = childEl.tagName.toLowerCase();
+
+    if (tag === "ul" || tag === "ol") {
+      const ordered = tag === "ol";
+      let n = 0;
+      for (const li of Array.from(childEl.children)) {
+        if (li.tagName.toLowerCase() !== "li") continue;
+        n += 1;
+        const prefix = ordered ? `${n}. ` : "• ";
+        const inner = extractCellInlineContent(li);
+        if (inner.length === 0) {
+          parts.push([{ type: "text", text: prefix, styles: {} }]);
+        } else {
+          parts.push([{ type: "text", text: prefix, styles: {} }, ...inner]);
+        }
+      }
+    } else if (tag === "div" || tag === "p" || tag === "blockquote") {
+      const inner = extractCellInlineContent(childEl);
+      if (inner.length > 0) parts.push(inner);
+    } else if (tag === "table" || tag === "en-media") {
+      // Genuinely unrepresentable as inline; skip.
+      continue;
+    } else if (tag === "br") {
+      parts.push([{ type: "text", text: "\n", styles: {} }]);
+    } else {
+      // Inline tag — apply the same logic extractInlineContent uses per element.
+      const styles = getInlineStyles(childEl);
+      if (tag === "a") {
+        parts.push([
+          {
+            type: "link",
+            text: childEl.textContent || "",
+            href: childEl.getAttribute("href") || "",
+            styles,
+          },
+        ]);
+      } else {
+        const inner = extractInlineContent(childEl);
+        if (inner.length > 0) {
+          parts.push(inner.map((item) => ({ ...item, styles: { ...item.styles, ...styles } })));
+        }
+      }
+    }
+  }
+
+  if (parts.length === 0) return [];
+
+  const result: InlineContent[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    if (i > 0) result.push({ type: "text", text: "\n", styles: {} });
+    result.push(...parts[i]);
+  }
+  return result;
 }
 
 function extractInlineContent(el: Element): InlineContent[] {

--- a/apps/web/src/lib/import/enml-to-blocknote.ts
+++ b/apps/web/src/lib/import/enml-to-blocknote.ts
@@ -390,9 +390,16 @@ function tryUnwrapLayoutTable(
 
   const blocks: Block[] = [];
   for (const cell of cells) {
-    blocks.push(...processChildren(cell, attachmentUrlMap, taskMap));
+    for (const block of processChildren(cell, attachmentUrlMap, taskMap)) {
+      if (!isBlankParagraph(block)) blocks.push(block);
+    }
   }
   return blocks;
+}
+
+function isBlankParagraph(block: Block): boolean {
+  if (block.type !== "paragraph" || !Array.isArray(block.content)) return false;
+  return block.content.every((item) => item.type === "text" && !item.text.trim());
 }
 
 function isBlockOnlyCell(cell: Element): boolean {


### PR DESCRIPTION
## Summary

- Evernote often wraps a column of bullet lists in a single-column `<table>` for layout. The web import (`apps/web/src/lib/import/enml-to-blocknote.ts`) called `extractInlineContent` for each `<td>`, which explicitly skips block-level tags (`ul`, `ol`, `div`) — every `<td><ul><li>…</li></ul></td>` cell came out empty.
- When a `<table>` is purely layout (no `<th>`, every row has at most one `<td>`, and every cell contains only block-level children), unwrap the rows into top-level blocks so the list renders naturally as a normal bulleted list.
- For genuine multi-column tables that happen to contain a list in one cell, a new `extractCellInlineContent` helper recurses into `<div>`/`<p>`/`<blockquote>` and flattens nested `<ul>`/`<ol>` into bullet/numbered text with newlines so data is never silently dropped.

Reproduces with `Ford Probe Klub Polska.enex` → "Plan migracji forum" — previously a column of empty boxes, now a clean bulleted list.

## Test plan

- [x] `pnpm --filter=@drafto/web test` — 704/704 pass, including 3 new tests in `enml-to-blocknote.test.ts` (layout unwrap, empty-cell skip, multi-column flatten fallback)
- [x] `pnpm --filter=@drafto/web typecheck`
- [x] `pnpm --filter=@drafto/web lint` (only pre-existing warnings)
- [x] `pnpm format:check`
- [x] Manual end-to-end: signed in to dev, App menu → Import from Evernote → `Ford Probe Klub Polska.enex`, opened "Plan migracji forum". Every previously-empty cell now renders the correct bulleted item (Ajax Shoutbox, Auto Groups, Board Announcements, Fade header, Google Analytics, Link menu, Site logo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tables during content import, with better preservation of nested lists and block content within table cells. Single-column tables with lists now unwrap appropriately.

* **Tests**
  * Added test coverage for table-to-list conversion scenarios across single-column and multi-column configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->