### PR TITLE
fix(web): emit canonical link shape from Evernote importer + self-heal

### DIFF
--- a/apps/web/__tests__/unit/enml-to-blocknote.test.ts
+++ b/apps/web/__tests__/unit/enml-to-blocknote.test.ts
@@ -39,14 +39,41 @@ describe("convertEnmlToBlocks", () => {
     expect(content.find((c) => c.text === "underline")?.styles.underline).toBe(true);
   });
 
-  it("converts links", () => {
+  it("converts links into the canonical BlockNote shape", () => {
     const enml = '<en-note><p><a href="https://example.com">Link</a></p></en-note>';
     const blocks = convertEnmlToBlocks(enml, emptyMap);
 
-    const content = blocks[0].content as Array<{ type: string; text: string; href?: string }>;
+    const content = blocks[0].content as Array<{
+      type: string;
+      href?: string;
+      content?: Array<{ type: string; text: string; styles?: Record<string, boolean> }>;
+    }>;
     expect(content[0].type).toBe("link");
     expect(content[0].href).toBe("https://example.com");
-    expect(content[0].text).toBe("Link");
+    expect(content[0].content).toEqual([{ type: "text", text: "Link", styles: {} }]);
+    // The flat-shape `text` field must NOT be present at the top level —
+    // BlockNote rejects it and the editor crashes (regression: drafto.eu
+    // "Email śmietnik" / "Adresy" notes after Evernote import).
+    expect((content[0] as { text?: string }).text).toBeUndefined();
+  });
+
+  it("opens a div containing only a mailto link without producing a flat-shape link (Email śmietnik repro)", () => {
+    const enml =
+      '<en-note><div><a href="mailto:dev.smietnik@gmail.com">dev.smietnik@gmail.com</a></div></en-note>';
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("paragraph");
+    const content = blocks[0].content as Array<{
+      type: string;
+      href?: string;
+      content?: Array<{ text: string }>;
+    }>;
+    expect(content[0]).toEqual({
+      type: "link",
+      href: "mailto:dev.smietnik@gmail.com",
+      content: [{ type: "text", text: "dev.smietnik@gmail.com", styles: {} }],
+    });
   });
 
   it("converts unordered lists", () => {
@@ -178,14 +205,17 @@ describe("convertEnmlToBlocks", () => {
       rows: {
         cells: Array<{
           type: string;
-          text: string;
+          text?: string;
           href?: string;
           styles?: Record<string, boolean>;
+          content?: Array<{ type: string; text: string; styles?: Record<string, boolean> }>;
         }>[];
       }[];
     };
     const cell = content.rows[0].cells[1];
-    const flat = cell.map((i) => i.text).join("");
+    const flat = cell
+      .map((i) => (i.type === "link" ? (i.content?.[0]?.text ?? "") : (i.text ?? "")))
+      .join("");
     expect(flat).toContain("1. one");
     expect(flat).toContain("2. two");
     expect(flat).toContain("tail");
@@ -193,6 +223,7 @@ describe("convertEnmlToBlocks", () => {
     expect(bold?.styles?.bold).toBe(true);
     const link = cell.find((i) => i.type === "link");
     expect(link?.href).toBe("https://x.test");
+    expect(link?.content?.[0]?.text).toBe("l");
   });
 
   it("returns default paragraph for empty content", () => {
@@ -216,17 +247,21 @@ describe("convertEnmlToBlocks", () => {
     expect(content[0].styles.italic).toBe(true);
   });
 
-  it("converts non-image attachment as link when URL exists", () => {
+  it("converts non-image attachment as canonical link when URL exists", () => {
     const urlMap = new Map([["def456", "https://storage.example.com/doc.pdf"]]);
     const enml = '<en-note><en-media type="application/pdf" hash="def456"/></en-note>';
     const blocks = convertEnmlToBlocks(enml, urlMap);
 
     expect(blocks).toHaveLength(1);
     expect(blocks[0].type).toBe("paragraph");
-    const content = blocks[0].content as Array<{ type: string; text: string; href?: string }>;
+    const content = blocks[0].content as Array<{
+      type: string;
+      href?: string;
+      content?: Array<{ text: string }>;
+    }>;
     expect(content[0].type).toBe("link");
     expect(content[0].href).toBe("https://storage.example.com/doc.pdf");
-    expect(content[0].text).toContain("application/pdf");
+    expect(content[0].content?.[0]?.text).toContain("application/pdf");
   });
 
   it("converts hr to paragraph with ---", () => {
@@ -379,15 +414,17 @@ describe("convertEnmlToBlocks", () => {
     expect(blocks).toHaveLength(1);
     const content = blocks[0].content as Array<{
       type: string;
-      text: string;
+      text?: string;
       href?: string;
-      styles: Record<string, boolean>;
+      styles?: Record<string, boolean>;
+      content?: Array<{ text: string; styles?: Record<string, boolean> }>;
     }>;
     expect(content[0].type).toBe("link");
     expect(content[0].href).toBe("https://example.com");
+    expect(content[0].content?.[0]?.text).toBe("Link text");
     expect(content[1].text).toBe("\n");
     expect(content[2].text).toBe("bold");
-    expect(content[2].styles.bold).toBe(true);
+    expect(content[2].styles?.bold).toBe(true);
   });
 
   it("extracts text from ol > li > div (Evernote ordered list format)", () => {

--- a/apps/web/__tests__/unit/enml-to-blocknote.test.ts
+++ b/apps/web/__tests__/unit/enml-to-blocknote.test.ts
@@ -57,6 +57,18 @@ describe("convertEnmlToBlocks", () => {
     expect((content[0] as { text?: string }).text).toBeUndefined();
   });
 
+  it("propagates parent inline styles into the nested text of a link", () => {
+    const enml = '<en-note><p><b><a href="https://x.test">x</a></b></p></en-note>';
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+    const content = blocks[0].content as Array<{
+      type: string;
+      href?: string;
+      content?: Array<{ text: string; styles?: Record<string, boolean> }>;
+    }>;
+    expect(content[0].type).toBe("link");
+    expect(content[0].content?.[0]?.styles?.bold).toBe(true);
+  });
+
   it("opens a div containing only a mailto link without producing a flat-shape link (Email śmietnik repro)", () => {
     const enml =
       '<en-note><div><a href="mailto:dev.smietnik@gmail.com">dev.smietnik@gmail.com</a></div></en-note>';

--- a/apps/web/src/components/notes/note-editor-panel.tsx
+++ b/apps/web/src/components/notes/note-editor-panel.tsx
@@ -7,7 +7,12 @@ import { useAutoSave } from "@/hooks/use-auto-save";
 import { handleAuthError } from "@/lib/handle-auth-error";
 import type { Block } from "@blocknote/core";
 import type { BadgeVariant } from "@/components/ui/badge";
-import { MAX_TITLE_LENGTH, formatRelativeTime } from "@drafto/shared";
+import {
+  MAX_TITLE_LENGTH,
+  formatRelativeTime,
+  normalizeBlocks,
+  type BlockNoteBlock,
+} from "@drafto/shared";
 
 interface NoteEditorPanelProps {
   noteId: string;
@@ -162,7 +167,11 @@ export function NoteEditorPanel({
       <NoteEditor
         key={noteId}
         noteId={noteId}
-        initialContent={note.content as Block[] | undefined}
+        initialContent={
+          note.content
+            ? (normalizeBlocks(note.content as unknown as BlockNoteBlock[]) as unknown as Block[])
+            : undefined
+        }
         onChange={handleContentChange}
       />
     </div>

--- a/apps/web/src/lib/import/enml-to-blocknote.ts
+++ b/apps/web/src/lib/import/enml-to-blocknote.ts
@@ -2,11 +2,26 @@ import { parseHTML } from "linkedom";
 
 import type { EnexTask } from "@/lib/import/types";
 
-interface InlineContent {
-  type: "text" | "link";
+interface StyledText {
+  type: "text";
   text: string;
   styles?: Record<string, boolean>;
-  href?: string;
+}
+
+interface LinkInlineContent {
+  type: "link";
+  href: string;
+  content: StyledText[];
+}
+
+type InlineContent = StyledText | LinkInlineContent;
+
+function createLink(
+  text: string,
+  href: string,
+  styles: Record<string, boolean> = {},
+): LinkInlineContent {
+  return { type: "link", href, content: [{ type: "text", text, styles }] };
 }
 
 interface Block {
@@ -272,13 +287,13 @@ function extractListItemContent(li: Element): InlineContent[] {
         if (tag === "a") {
           const href = childEl.getAttribute("href") || "";
           const text = childEl.textContent || "";
-          result.push({ type: "link", text, href, styles });
+          result.push(createLink(text, href, styles));
         } else if (tag === "br") {
           result.push({ type: "text", text: "\n", styles: {} });
         } else {
           const innerContent = extractInlineContent(childEl);
           for (const item of innerContent) {
-            result.push({ ...item, styles: { ...item.styles, ...styles } });
+            result.push(applyStyles(item, styles));
           }
         }
       }
@@ -286,6 +301,16 @@ function extractListItemContent(li: Element): InlineContent[] {
   }
 
   return result;
+}
+
+function applyStyles(item: InlineContent, styles: Record<string, boolean>): InlineContent {
+  if (item.type === "link") {
+    return {
+      ...item,
+      content: item.content.map((t) => ({ ...t, styles: { ...t.styles, ...styles } })),
+    };
+  }
+  return { ...item, styles: { ...item.styles, ...styles } };
 }
 
 function convertEnMedia(el: Element, attachmentUrlMap: Map<string, string>): Block | null {
@@ -311,14 +336,7 @@ function convertEnMedia(el: Element, attachmentUrlMap: Map<string, string>): Blo
   }
 
   // Non-image attachment — render as text link
-  return createParagraph([
-    {
-      type: "link",
-      text: `[Attachment: ${type}]`,
-      href: url,
-      styles: {},
-    },
-  ]);
+  return createParagraph([createLink(`[Attachment: ${type}]`, url)]);
 }
 
 function convertTable(tableEl: Element): Block {
@@ -464,17 +482,12 @@ function extractCellInlineContent(cell: Element): InlineContent[] {
       const styles = getInlineStyles(childEl);
       if (tag === "a") {
         parts.push([
-          {
-            type: "link",
-            text: childEl.textContent || "",
-            href: childEl.getAttribute("href") || "",
-            styles,
-          },
+          createLink(childEl.textContent || "", childEl.getAttribute("href") || "", styles),
         ]);
       } else {
         const inner = extractInlineContent(childEl);
         if (inner.length > 0) {
-          parts.push(inner.map((item) => ({ ...item, styles: { ...item.styles, ...styles } })));
+          parts.push(inner.map((item) => applyStyles(item, styles)));
         }
       }
     }
@@ -515,16 +528,13 @@ function extractInlineContent(el: Element): InlineContent[] {
       if (tag === "a") {
         const href = childEl.getAttribute("href") || "";
         const text = childEl.textContent || "";
-        result.push({ type: "link", text, href, styles });
+        result.push(createLink(text, href, styles));
       } else if (tag === "br") {
         result.push({ type: "text", text: "\n", styles: {} });
       } else {
         // Merge styles into inner content
         for (const item of innerContent) {
-          result.push({
-            ...item,
-            styles: { ...item.styles, ...styles },
-          });
+          result.push(applyStyles(item, styles));
         }
       }
     }

--- a/packages/shared/src/editor/__tests__/normalize-blocks.test.ts
+++ b/packages/shared/src/editor/__tests__/normalize-blocks.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeBlocks } from "../normalize-blocks";
+import type { BlockNoteBlock } from "../types";
+
+describe("normalizeBlocks", () => {
+  it("rewrites flat-shape link into canonical shape", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "link",
+            text: "dev.smietnik@gmail.com",
+            href: "mailto:dev.smietnik@gmail.com",
+            styles: {},
+          },
+        ],
+      },
+    ];
+
+    const out = normalizeBlocks(blocks);
+    const link = (out[0].content as unknown as Array<Record<string, unknown>>)[0];
+    expect(link.type).toBe("link");
+    expect(link.href).toBe("mailto:dev.smietnik@gmail.com");
+    expect(link.content).toEqual([{ type: "text", text: "dev.smietnik@gmail.com", styles: {} }]);
+  });
+
+  it("preserves styles by moving them onto the nested text item", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "link",
+            text: "x",
+            href: "https://x.test",
+            styles: { bold: true },
+          },
+        ],
+      },
+    ];
+
+    const out = normalizeBlocks(blocks);
+    const link = (
+      out[0].content as Array<{ content: Array<{ styles: Record<string, boolean> }> }>
+    )[0];
+    expect(link.content[0].styles).toEqual({ bold: true });
+  });
+
+  it("is idempotent on canonical input", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "link",
+            href: "https://x.test",
+            content: [{ type: "text", text: "x", styles: {} }],
+          },
+        ],
+      },
+    ];
+
+    const once = normalizeBlocks(blocks);
+    const twice = normalizeBlocks(once);
+    expect(twice).toEqual(once);
+  });
+
+  it("recurses into block children and table cells", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "bulletListItem",
+        content: [{ type: "text", text: "outer", styles: {} }],
+        children: [
+          {
+            type: "paragraph",
+            content: [{ type: "link", text: "inner", href: "https://i.test", styles: {} }],
+          },
+        ],
+      },
+      {
+        type: "table",
+        content: {
+          type: "tableContent",
+          rows: [
+            {
+              cells: [[{ type: "link", text: "cell-link", href: "https://c.test", styles: {} }]],
+            },
+          ],
+        },
+      },
+    ];
+
+    const out = normalizeBlocks(blocks);
+
+    const childLink = (
+      out[0].children?.[0].content as Array<{ content: Array<{ text: string }> }>
+    )[0];
+    expect(childLink.content[0].text).toBe("inner");
+
+    const tableContent = out[1].content as {
+      rows: { cells: Array<{ content: Array<{ text: string }> }>[] }[];
+    };
+    expect(tableContent.rows[0].cells[0][0].content[0].text).toBe("cell-link");
+  });
+
+  it("leaves non-link inline items untouched", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "hello", styles: { bold: true } }],
+      },
+    ];
+
+    const out = normalizeBlocks(blocks);
+    expect(out).toEqual(blocks);
+  });
+});

--- a/packages/shared/src/editor/__tests__/normalize-blocks.test.ts
+++ b/packages/shared/src/editor/__tests__/normalize-blocks.test.ts
@@ -105,6 +105,43 @@ describe("normalizeBlocks", () => {
     expect(tableContent.rows[0].cells[0][0].content[0].text).toBe("cell-link");
   });
 
+  it("defaults missing text/href/styles when normalizing a partial flat-shape link", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [{ type: "link" }],
+      },
+    ];
+
+    const out = normalizeBlocks(blocks);
+    const link = (out[0].content as unknown as Array<Record<string, unknown>>)[0];
+    expect(link.href).toBe("");
+    expect(link.content).toEqual([{ type: "text", text: "", styles: {} }]);
+  });
+
+  it("treats a link with empty content array as flat and rewrites it", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "paragraph",
+        content: [{ type: "link", href: "https://x.test", text: "x", content: [] }],
+      },
+    ];
+
+    const out = normalizeBlocks(blocks);
+    const link = (out[0].content as unknown as Array<Record<string, unknown>>)[0];
+    expect(link.content).toEqual([{ type: "text", text: "x", styles: {} }]);
+  });
+
+  it("leaves blocks without content untouched (e.g. image blocks)", () => {
+    const blocks: BlockNoteBlock[] = [{ type: "image", props: { url: "https://x.test/a.png" } }];
+    const out = normalizeBlocks(blocks);
+    expect(out).toEqual(blocks);
+  });
+
+  it("returns the same shape for an empty input array", () => {
+    expect(normalizeBlocks([])).toEqual([]);
+  });
+
   it("leaves non-link inline items untouched", () => {
     const blocks: BlockNoteBlock[] = [
       {

--- a/packages/shared/src/editor/markdown-converter.ts
+++ b/packages/shared/src/editor/markdown-converter.ts
@@ -10,7 +10,7 @@ function inlineItemToMarkdown(item: BlockNoteInlineContent): string {
   let text =
     item.type === "link" && item.content?.length
       ? item.content.map(inlineItemToMarkdown).join("")
-      : item.text;
+      : (item.text ?? "");
 
   if (item.styles) {
     if (item.styles.code) text = `\`${text}\``;

--- a/packages/shared/src/editor/normalize-blocks.ts
+++ b/packages/shared/src/editor/normalize-blocks.ts
@@ -1,0 +1,60 @@
+import type { BlockNoteBlock, BlockNoteInlineContent, BlockNoteTableContent } from "./types";
+
+/**
+ * Normalize a BlockNote block tree so it conforms to the canonical inline
+ * schema BlockNote validates against on editor mount.
+ *
+ * The Evernote importer historically emitted link inline content in a flat
+ * shape — `{ type: "link", text, href, styles }` — that BlockNote rejects.
+ * The canonical shape is `{ type: "link", href, content: [{ type: "text",
+ * text, styles }] }`. Loading malformed content into `useCreateBlockNote`
+ * throws, which trips the Next.js global error boundary. This normalizer
+ * rewrites flat-link items into the canonical shape so existing notes
+ * self-heal on load. It is idempotent and safe to call on every fetch.
+ */
+export function normalizeBlocks(blocks: BlockNoteBlock[]): BlockNoteBlock[] {
+  return blocks.map(normalizeBlock);
+}
+
+function normalizeBlock(block: BlockNoteBlock): BlockNoteBlock {
+  const next: BlockNoteBlock = { ...block };
+  if (block.content) {
+    if (Array.isArray(block.content)) {
+      next.content = block.content.map(normalizeInline);
+    } else if (isTableContent(block.content)) {
+      next.content = {
+        ...block.content,
+        rows: block.content.rows.map((row) => ({
+          cells: row.cells.map((cell) => cell.map(normalizeInline)),
+        })),
+      };
+    }
+  }
+  if (block.children) {
+    next.children = block.children.map(normalizeBlock);
+  }
+  return next;
+}
+
+function normalizeInline(item: BlockNoteInlineContent): BlockNoteInlineContent {
+  if (item.type !== "link") return item;
+  if (Array.isArray(item.content) && item.content.length > 0) return item;
+  // Flat-link → canonical: pull `text`/`styles` into a nested StyledText.
+  return {
+    type: "link",
+    href: item.href ?? "",
+    content: [
+      {
+        type: "text",
+        text: item.text ?? "",
+        styles: item.styles ?? {},
+      },
+    ],
+  };
+}
+
+function isTableContent(
+  content: BlockNoteInlineContent[] | BlockNoteTableContent,
+): content is BlockNoteTableContent {
+  return !Array.isArray(content) && content.type === "tableContent";
+}

--- a/packages/shared/src/editor/types.ts
+++ b/packages/shared/src/editor/types.ts
@@ -1,7 +1,9 @@
 // BlockNote block types (web editor format)
 export interface BlockNoteInlineContent {
   type: "text" | "link";
-  text: string;
+  // Required for `type: "text"`; absent on canonical `type: "link"` items
+  // (those carry their text inside `content[].text` instead).
+  text?: string;
   styles?: Record<string, boolean>;
   href?: string;
   content?: BlockNoteInlineContent[];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,6 +29,7 @@ export {
   contentToBlocknote,
 } from "./editor/format-converter";
 export { extractTextFromContent } from "./editor/extract-text";
+export { normalizeBlocks } from "./editor/normalize-blocks";
 export { blockNoteToMarkdown, markdownToBlockNote } from "./editor/markdown-converter";
 export {
   toAttachmentUrl,


### PR DESCRIPTION
## Summary

- The Evernote importer (`apps/web/src/lib/import/enml-to-blocknote.ts`) emitted link inline content as `{ type: "link", text, href, styles }`, but BlockNote's schema (`@blocknote/core`, mirrored in `packages/shared/src/editor/types.ts`) requires `{ type: "link", href, content: [{ type: "text", text, styles }] }`. Loading a note dominated by links — e.g. `<en-note><div><a href="mailto:…">…</a></div></en-note>` — threw inside `useCreateBlockNote` and tripped the global error boundary ("Something went wrong! Try again"). Reproduced in prod with two notes from the previous Ford Probe Klub Polska.enex import.
- Fixed the converter at all four emit sites (`extractInlineContent`, `extractListItemContent`, `extractCellInlineContent`, `convertEnMedia`) via a `createLink` helper and a discriminated-union local `InlineContent` so the wrong shape is unrepresentable. Inline-merge loops now propagate parent styles into the nested text inside link items via a new `applyStyles` helper.
- Existing prod data self-heals: a new `normalizeBlocks` helper in `@drafto/shared` walks blocks before they reach the editor and rewrites any flat-shape link items into canonical shape. `note-editor-panel.tsx` runs it on every fetch. Idempotent; recurses into block children and table cells. Once the user edits and saves, BlockNote persists the corrected shape.

## Test plan

- [x] `pnpm --filter=@drafto/web test` — 708/708 pass; updated 4 existing link assertions and added a regression test mirroring the "Email śmietnik" repro.
- [x] `pnpm --filter=@drafto/shared test` — 233/233 pass; new `normalize-blocks.test.ts` covers idempotency, recursion into children + table cells, and style preservation.
- [x] `pnpm --filter=@drafto/web typecheck` & `pnpm --filter=@drafto/shared typecheck`
- [x] `pnpm lint` — only pre-existing warnings
- [x] `pnpm format:check`
- [x] **Browser self-heal**: signed in to dev, opened the previously-broken `Email śmietnik` and `Adresy` notes — both render correctly without re-import (normalizer fixed the on-disk flat-link shape on load).
- [x] **Browser fresh import**: re-imported `Ford Probe Klub Polska.enex`, opened all 5 notes — `Email śmietnik` shows the email address, `Adresy` shows all 6 lines of credentials, `Plan migracji forum` still renders the bulleted list (no regression from PR #378).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ENML link conversion to ensure consistent link structure and formatting across the application.
  * Enhanced markdown export handling for links with missing or empty text.

* **New Features**
  * Implemented automatic content normalization on note load for improved data consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->