### PR TITLE
fix(support-agent): retry transient gh CLI errors instead of exiting

### DIFF
--- a/scripts/__tests__/github-sync.test.mjs
+++ b/scripts/__tests__/github-sync.test.mjs
@@ -160,6 +160,107 @@ describe("filterNewComments (pure)", () => {
   });
 });
 
+describe("runGh retry behaviour (transient gh failures)", () => {
+  function makeFlakyExec(failures, finalResponse) {
+    let calls = 0;
+    return async (cmd, args) => {
+      execCalls.push({ cmd, args });
+      calls += 1;
+      if (calls <= failures.length) {
+        throw failures[calls - 1];
+      }
+      return finalResponse;
+    };
+  }
+
+  function transientErr(message) {
+    const e = new Error(`Command failed: gh ...\n${message}`);
+    e.stderr = message;
+    return e;
+  }
+
+  function permanentErr(message) {
+    const e = new Error(`Command failed: gh ...\n${message}`);
+    e.stderr = message;
+    return e;
+  }
+
+  it("retries on HTTP 504 from GitHub and returns the eventual success", async () => {
+    lib._setSleepForTests(async () => {});
+    lib._setExecFileForTests(
+      makeFlakyExec(
+        [transientErr("HTTP 504: 504 Gateway Timeout (https://api.github.com/graphql)")],
+        { stdout: JSON.stringify([{ number: 1 }]) },
+      ),
+    );
+    const issues = await lib.listSupportIssues({ state: "all" });
+    assert.equal(issues.length, 1);
+    assert.equal(execCalls.length, 2);
+  });
+
+  it("retries on HTTP 502 / 503 / 429 / connection reset / i/o timeout", async () => {
+    const transients = [
+      "HTTP 502: 502 Bad Gateway",
+      "HTTP 503: Service Unavailable",
+      "HTTP 429: Too Many Requests",
+      "dial tcp: connection reset by peer",
+      'Get "https://api.github.com/...": net/http: TLS handshake timeout (i/o timeout)',
+      "ETIMEDOUT",
+      "EAI_AGAIN getaddrinfo",
+    ];
+    for (const msg of transients) {
+      lib._setSleepForTests(async () => {});
+      lib._setExecFileForTests(makeFlakyExec([transientErr(msg)], { stdout: JSON.stringify([]) }));
+      execCalls = [];
+      const issues = await lib.listSupportIssues({ state: "all" });
+      assert.equal(issues.length, 0, `should retry on: ${msg}`);
+      assert.equal(execCalls.length, 2, `should retry exactly once for: ${msg}`);
+    }
+  });
+
+  it("does NOT retry on permanent errors (HTTP 404 / auth / parse)", async () => {
+    lib._setSleepForTests(async () => {});
+    lib._setExecFileForTests(
+      makeFlakyExec([permanentErr("HTTP 404: Not Found")], { stdout: JSON.stringify([]) }),
+    );
+    await assert.rejects(() => lib.listSupportIssues({ state: "all" }), /404/);
+    assert.equal(execCalls.length, 1);
+  });
+
+  it("gives up after the configured retry budget and surfaces the last error", async () => {
+    lib._setSleepForTests(async () => {});
+    lib._setExecFileForTests(
+      makeFlakyExec(
+        [
+          transientErr("HTTP 504: Gateway Timeout"),
+          transientErr("HTTP 504: Gateway Timeout"),
+          transientErr("HTTP 504: Gateway Timeout"),
+          transientErr("HTTP 504: Gateway Timeout"),
+        ],
+        { stdout: "[]" },
+      ),
+    );
+    await assert.rejects(() => lib.listSupportIssues({ state: "all" }), /504/);
+    // 1 initial attempt + 3 retries = 4 calls total
+    assert.equal(execCalls.length, 4);
+  });
+
+  it("backs off between retries (sleep is invoked with growing delays)", async () => {
+    const delays = [];
+    lib._setSleepForTests(async (ms) => {
+      delays.push(ms);
+    });
+    lib._setExecFileForTests(
+      makeFlakyExec(
+        [transientErr("HTTP 504: Gateway Timeout"), transientErr("HTTP 504: Gateway Timeout")],
+        { stdout: "[]" },
+      ),
+    );
+    await lib.listSupportIssues({ state: "all" });
+    assert.deepEqual(delays, [1000, 2000]);
+  });
+});
+
 describe("listSupportIssues (mocked gh)", () => {
   it("invokes `gh issue list` with the right flags and parses the JSON", async () => {
     lib._setExecFileForTests(

--- a/scripts/lib/github-sync.mjs
+++ b/scripts/lib/github-sync.mjs
@@ -58,17 +58,55 @@ const DEFAULT_BOT_USER = "JakubAnderwald";
 export const PROGRESS_MARKER = "<!-- drafto-progress -->";
 
 let _execFileForTests = null;
+let _sleepForTests = null;
 
 export function _setExecFileForTests(impl) {
   _execFileForTests = impl;
 }
 
+export function _setSleepForTests(impl) {
+  _sleepForTests = impl;
+}
+
+// Transient errors we should retry rather than surface to the caller. Real
+// case from 2026-05-05: GitHub returned `HTTP 504: 504 Gateway Timeout` to
+// `gh issue list`, the support-agent's --state-sync mode exited 1, and the
+// failure-issue trap filed issue #376. The next 5-minute tick would have
+// succeeded — retrying inline keeps a transient hiccup from spamming
+// nightly-failure issues.
+function isTransientGhError(err) {
+  const text = `${err?.message ?? ""} ${err?.stderr ?? ""} ${err?.stdout ?? ""}`;
+  if (/\bHTTP\s+(?:429|500|502|503|504)\b/i.test(text)) return true;
+  if (/\bgateway\s+time-?out\b/i.test(text)) return true;
+  if (/\b(?:ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN|ENETUNREACH|ECONNREFUSED)\b/i.test(text)) {
+    return true;
+  }
+  // gh prints a generic "connection reset"/"i/o timeout" line on flaky
+  // networks where the upstream HTTP code is unavailable.
+  if (/\b(?:connection reset|i\/o timeout|temporary failure)\b/i.test(text)) return true;
+  return false;
+}
+
+const RETRY_DELAYS_MS = [1000, 2000, 4000];
+
 async function runGh(args) {
   const fn = _execFileForTests ?? execFileP;
-  // 16 MiB output cap — gh api --paginate can return large JSON arrays for
-  // long-lived issues; the default 1 MiB cap was hit during dev.
-  const { stdout } = await fn("gh", args, { maxBuffer: 16 * 1024 * 1024 });
-  return stdout;
+  const sleep = _sleepForTests ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  let lastError;
+  // One initial attempt + up to RETRY_DELAYS_MS.length retries.
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      // 16 MiB output cap — gh api --paginate can return large JSON arrays for
+      // long-lived issues; the default 1 MiB cap was hit during dev.
+      const { stdout } = await fn("gh", args, { maxBuffer: 16 * 1024 * 1024 });
+      return stdout;
+    } catch (err) {
+      lastError = err;
+      if (attempt === RETRY_DELAYS_MS.length || !isTransientGhError(err)) throw err;
+      await sleep(RETRY_DELAYS_MS[attempt]);
+    }
+  }
+  throw lastError;
 }
 
 export async function listSupportIssues({ state = "all", limit = 200 } = {}) {


### PR DESCRIPTION
## Summary

- The real-time support agent's `runGh` wrapper now retries when `gh` returns a transient error (HTTP 429/5xx, gateway timeout, connection reset, DNS/network failure) with 1s/2s/4s exponential backoff before surfacing the error.
- Permanent errors (HTTP 404, parse, auth) still fail fast — no retry budget wasted.
- Five new tests cover: success-after-retry, the full transient-error matrix, no-retry on permanent errors, retry-budget exhaustion, and backoff-delay ordering.

## Why

On 2026-05-05 the GitHub API returned `HTTP 504: 504 Gateway Timeout` to `gh issue list --label support`. `support-agent.sh --state-sync` exited 1, the launchd watcher filed [#376](https://github.com/JakubAnderwald/drafto/issues/376) with the `nightly-failure` label, and the next 5-minute tick succeeded as if nothing had happened — pure noise. This makes a single transient hiccup self-heal instead of paging.

## Test plan

- [x] `node --test scripts/__tests__/github-sync.test.mjs` — 32/32 pass (5 new)
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm --filter=root test` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)