### PR TITLE
fix(support-agent): bound claude -p wall time so a hung API call cannot freeze the loop

### DIFF
--- a/scripts/__tests__/run-claude.test.mjs
+++ b/scripts/__tests__/run-claude.test.mjs
@@ -86,20 +86,18 @@ describe("runClaudeWithTimeout (mocked spawn)", () => {
     const scenario = { spawnCalls: [], children: [] };
     const promise = lib.runClaudeWithTimeout({
       args: [],
-      timeoutMs: 30, // very short; never receives an exit before
-      killGraceMs: 1000,
-      spawn: makeSpawn(scenario),
+      timeoutMs: 200, // small but wide enough that GC pauses on a loaded
+      killGraceMs: 2000, // CI runner won't make the SIGTERM-driven exit
+      spawn: makeSpawn(scenario), // race against the wall timer
     });
-    // Simulate child responding to SIGTERM by exiting after ~10ms.
-    scenario.children[0].on("newListener", () => {});
-    // Wait for the timer to fire and the wrapper to issue SIGTERM, then have
-    // the child report exit. Doing this via setTimeout so the wrapper's own
-    // setTimeout(timeoutMs=30) gets a chance to run first.
+    // Wait for the wall timer to fire and the wrapper to issue SIGTERM,
+    // then have the child report exit. setTimeout(500) is intentionally
+    // ~2.5x timeoutMs so wallTimer always wins ordering.
     setTimeout(() => {
       const c = scenario.children[0];
       assert.ok(c.killSignals.includes("SIGTERM"), "should send SIGTERM");
       c.emit("exit", null, "SIGTERM");
-    }, 80);
+    }, 500);
     const result = await promise;
     assert.equal(result.exitCode, 124);
     assert.equal(result.timedOut, true);
@@ -109,17 +107,18 @@ describe("runClaudeWithTimeout (mocked spawn)", () => {
     const scenario = { spawnCalls: [], children: [] };
     const promise = lib.runClaudeWithTimeout({
       args: [],
-      timeoutMs: 30,
-      killGraceMs: 60,
+      timeoutMs: 200,
+      killGraceMs: 400,
       spawn: makeSpawn(scenario),
     });
     // Stubborn child: ignores SIGTERM, only exits after SIGKILL fires.
+    // 1000ms is well past timeoutMs (200) + killGraceMs (400) = 600ms.
     setTimeout(() => {
       const c = scenario.children[0];
       assert.ok(c.killSignals.includes("SIGTERM"));
       assert.ok(c.killSignals.includes("SIGKILL"), "should escalate to SIGKILL");
       c.emit("exit", null, "SIGKILL");
-    }, 200);
+    }, 1000);
     const result = await promise;
     assert.equal(result.exitCode, 124);
     assert.equal(result.timedOut, true);

--- a/scripts/__tests__/run-claude.test.mjs
+++ b/scripts/__tests__/run-claude.test.mjs
@@ -1,0 +1,162 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+
+let lib;
+
+beforeEach(async () => {
+  // Import fresh so the module-level `_spawnForTests` shim resets.
+  lib = await import(`../lib/run-claude.mjs?t=${Date.now()}-${Math.random()}`);
+});
+
+// Minimal ChildProcess fake. We only need .kill() and the "exit"/"error"
+// events the wrapper subscribes to.
+function makeFakeChild() {
+  const child = new EventEmitter();
+  child.killed = false;
+  child.killSignals = [];
+  child.kill = (sig) => {
+    child.killSignals.push(sig);
+    child.killed = true;
+    return true;
+  };
+  return child;
+}
+
+function makeSpawn(scenario) {
+  return (cmd, args, opts) => {
+    scenario.spawnCalls.push({ cmd, args, opts });
+    const child = makeFakeChild();
+    scenario.children.push(child);
+    // Allow the test to drive the lifecycle by exposing the child.
+    if (scenario.onSpawn) scenario.onSpawn(child);
+    return child;
+  };
+}
+
+describe("resolveTimeoutSec (pure)", () => {
+  it("returns the default (180) when env var is missing or empty", async () => {
+    assert.equal(lib.resolveTimeoutSec({}), 180);
+    assert.equal(lib.resolveTimeoutSec({ CLAUDE_CALL_TIMEOUT_SEC: "" }), 180);
+  });
+
+  it("returns the parsed value when set to a positive integer", async () => {
+    assert.equal(lib.resolveTimeoutSec({ CLAUDE_CALL_TIMEOUT_SEC: "60" }), 60);
+    assert.equal(lib.resolveTimeoutSec({ CLAUDE_CALL_TIMEOUT_SEC: "1" }), 1);
+  });
+
+  it("falls back to default for non-numeric / non-positive values (defensive)", async () => {
+    assert.equal(lib.resolveTimeoutSec({ CLAUDE_CALL_TIMEOUT_SEC: "0" }), 180);
+    assert.equal(lib.resolveTimeoutSec({ CLAUDE_CALL_TIMEOUT_SEC: "-5" }), 180);
+    assert.equal(lib.resolveTimeoutSec({ CLAUDE_CALL_TIMEOUT_SEC: "abc" }), 180);
+  });
+});
+
+describe("runClaudeWithTimeout (mocked spawn)", () => {
+  it("propagates the child's exit code unchanged on normal exit", async () => {
+    const scenario = { spawnCalls: [], children: [] };
+    const promise = lib.runClaudeWithTimeout({
+      args: ["-p", "hello"],
+      timeoutMs: 1000,
+      spawn: makeSpawn(scenario),
+    });
+    // Drive: child exits 0 immediately.
+    setImmediate(() => scenario.children[0].emit("exit", 0, null));
+    const result = await promise;
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.timedOut, false);
+    assert.equal(scenario.children[0].killed, false);
+    assert.deepEqual(scenario.spawnCalls[0].args, ["-p", "hello"]);
+  });
+
+  it("propagates non-zero exit codes (NOT 124) when child errors quickly", async () => {
+    const scenario = { spawnCalls: [], children: [] };
+    const promise = lib.runClaudeWithTimeout({
+      args: [],
+      timeoutMs: 1000,
+      spawn: makeSpawn(scenario),
+    });
+    setImmediate(() => scenario.children[0].emit("exit", 1, null));
+    const result = await promise;
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.timedOut, false);
+  });
+
+  it("kills the child with SIGTERM and exits 124 when timeout fires", async () => {
+    const scenario = { spawnCalls: [], children: [] };
+    const promise = lib.runClaudeWithTimeout({
+      args: [],
+      timeoutMs: 30, // very short; never receives an exit before
+      killGraceMs: 1000,
+      spawn: makeSpawn(scenario),
+    });
+    // Simulate child responding to SIGTERM by exiting after ~10ms.
+    scenario.children[0].on("newListener", () => {});
+    // Wait for the timer to fire and the wrapper to issue SIGTERM, then have
+    // the child report exit. Doing this via setTimeout so the wrapper's own
+    // setTimeout(timeoutMs=30) gets a chance to run first.
+    setTimeout(() => {
+      const c = scenario.children[0];
+      assert.ok(c.killSignals.includes("SIGTERM"), "should send SIGTERM");
+      c.emit("exit", null, "SIGTERM");
+    }, 80);
+    const result = await promise;
+    assert.equal(result.exitCode, 124);
+    assert.equal(result.timedOut, true);
+  });
+
+  it("escalates to SIGKILL after the grace window if SIGTERM is ignored", async () => {
+    const scenario = { spawnCalls: [], children: [] };
+    const promise = lib.runClaudeWithTimeout({
+      args: [],
+      timeoutMs: 30,
+      killGraceMs: 60,
+      spawn: makeSpawn(scenario),
+    });
+    // Stubborn child: ignores SIGTERM, only exits after SIGKILL fires.
+    setTimeout(() => {
+      const c = scenario.children[0];
+      assert.ok(c.killSignals.includes("SIGTERM"));
+      assert.ok(c.killSignals.includes("SIGKILL"), "should escalate to SIGKILL");
+      c.emit("exit", null, "SIGKILL");
+    }, 200);
+    const result = await promise;
+    assert.equal(result.exitCode, 124);
+    assert.equal(result.timedOut, true);
+  });
+
+  it("returns 127 when spawn itself fails (e.g. ENOENT — claude not on PATH)", async () => {
+    const scenario = { spawnCalls: [], children: [] };
+    const promise = lib.runClaudeWithTimeout({
+      args: [],
+      timeoutMs: 1000,
+      spawn: makeSpawn(scenario),
+    });
+    setImmediate(() => {
+      const err = new Error("spawn claude ENOENT");
+      err.code = "ENOENT";
+      scenario.children[0].emit("error", err);
+    });
+    const result = await promise;
+    assert.equal(result.exitCode, 127);
+    assert.equal(result.timedOut, false);
+  });
+
+  it("forwards argv verbatim to spawn (passthrough invariant)", async () => {
+    const scenario = { spawnCalls: [], children: [] };
+    const promise = lib.runClaudeWithTimeout({
+      command: "claude",
+      args: ["-p", "long input with spaces", "--dangerously-skip-permissions"],
+      timeoutMs: 1000,
+      spawn: makeSpawn(scenario),
+    });
+    setImmediate(() => scenario.children[0].emit("exit", 0, null));
+    await promise;
+    assert.deepEqual(scenario.spawnCalls[0].args, [
+      "-p",
+      "long input with spaces",
+      "--dangerously-skip-permissions",
+    ]);
+    assert.equal(scenario.spawnCalls[0].cmd, "claude");
+  });
+});

--- a/scripts/lib/run-claude.mjs
+++ b/scripts/lib/run-claude.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Thin wrapper around `claude -p` that bounds wall time. macOS doesn't ship
+// `timeout(1)` and we don't want a new Homebrew dep on the Mac mini, so we
+// implement the exit-124-on-cap convention in Node.
+//
+// Why this exists: 2026-05-05 23:24 — `support-agent.sh --auto-classify`
+// invoked `claude -p`, the child opened an HTTPS connection to the Anthropic
+// API, and the read hung for 7+ hours (15 s CPU, S state). The parent bash
+// `wait()`ed forever, holding the loop's mkdir mutex, so every subsequent
+// 60-second launchd tick was a no-op. There's no `claude --timeout` flag,
+// and the script's existing "claude exited non-zero → log + continue" path
+// works fine — it just never fires when the call hangs. This wrapper closes
+// that gap.
+//
+// Behaviour:
+//   - On normal child exit: propagate the child's exit code unchanged.
+//   - On wall-time cap (CLAUDE_CALL_TIMEOUT_SEC, default 180): SIGTERM the
+//     child, escalate to SIGKILL after 5 s if it didn't exit, and exit 124.
+//     124 matches coreutils `timeout(1)` so the bash caller can branch on it.
+//   - All argv after the script name is forwarded verbatim to `claude`.
+//
+// stdio is `inherit`ed so the bash caller's existing redirects keep working
+// (stdout → tempfile, stderr → log). The wrapper itself prints nothing.
+
+import { spawn as nodeSpawn } from "node:child_process";
+import { isMainModule } from "./is-main.mjs";
+
+const DEFAULT_TIMEOUT_SEC = 180;
+const KILL_GRACE_MS = 5000;
+const TIMEOUT_EXIT_CODE = 124;
+
+// Pure: read the budget from env, falling back to the default. Exported so
+// tests can verify the env-override path without spawning anything.
+export function resolveTimeoutSec(env = process.env) {
+  const raw = env.CLAUDE_CALL_TIMEOUT_SEC;
+  if (raw == null || raw === "") return DEFAULT_TIMEOUT_SEC;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_TIMEOUT_SEC;
+  return n;
+}
+
+// Inject-able for tests. Mirrors the `_setExecFileForTests` pattern in
+// scripts/lib/github-sync.mjs.
+let _spawnForTests = null;
+export function _setSpawnForTests(impl) {
+  _spawnForTests = impl;
+}
+
+// Core: spawn `command` with `args`, kill it after `timeoutMs`, return a
+// promise resolving to {exitCode, timedOut}. exitCode is the raw child exit
+// code on normal exit; on timeout it's TIMEOUT_EXIT_CODE (124). The caller
+// is responsible for translating that into a process.exit() if running as
+// a CLI.
+export function runClaudeWithTimeout({
+  command = "claude",
+  args = [],
+  timeoutMs,
+  killGraceMs = KILL_GRACE_MS,
+  spawn = _spawnForTests ?? nodeSpawn,
+} = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: "inherit" });
+    let timedOut = false;
+    let killTimer = null;
+
+    const fireTimeout = () => {
+      timedOut = true;
+      // SIGTERM first; if the child is genuinely stuck in a syscall it may
+      // ignore it, in which case SIGKILL after the grace window guarantees
+      // we exit. .unref() so the SIGKILL timer doesn't hold the event loop
+      // open if the child exits cleanly under SIGTERM.
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* child already exited */
+      }
+      killTimer = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* child already exited */
+        }
+      }, killGraceMs);
+      killTimer.unref?.();
+    };
+
+    const wallTimer = setTimeout(fireTimeout, timeoutMs);
+    wallTimer.unref?.();
+
+    child.once("exit", (code, signal) => {
+      clearTimeout(wallTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (timedOut) {
+        resolve({ exitCode: TIMEOUT_EXIT_CODE, timedOut: true, signal });
+        return;
+      }
+      // Normal exit: propagate the child's exit code. If killed by an
+      // external signal (not us), surface 128+sig like a shell would.
+      if (code != null) {
+        resolve({ exitCode: code, timedOut: false, signal });
+      } else if (signal) {
+        resolve({ exitCode: 128, timedOut: false, signal });
+      } else {
+        resolve({ exitCode: 1, timedOut: false, signal });
+      }
+    });
+
+    child.once("error", (err) => {
+      clearTimeout(wallTimer);
+      if (killTimer) clearTimeout(killTimer);
+      // spawn() failed (e.g. ENOENT — `claude` not on PATH). Surface a
+      // distinct exit code so the bash caller doesn't confuse it with a
+      // claude-side error or a timeout.
+      process.stderr.write(`run-claude: spawn failed: ${err.message}\n`);
+      resolve({ exitCode: 127, timedOut: false, signal: null });
+    });
+  });
+}
+
+// CLI entrypoint. Invoked by support-agent.sh as:
+//   node scripts/lib/run-claude.mjs -p "$INPUT" --dangerously-skip-permissions
+async function main() {
+  const args = process.argv.slice(2);
+  const timeoutSec = resolveTimeoutSec();
+  const { exitCode } = await runClaudeWithTimeout({
+    args,
+    timeoutMs: timeoutSec * 1000,
+  });
+  process.exit(exitCode);
+}
+
+if (isMainModule(import.meta.url)) {
+  main();
+}

--- a/scripts/lib/run-claude.mjs
+++ b/scripts/lib/run-claude.mjs
@@ -23,6 +23,7 @@
 // (stdout → tempfile, stderr → log). The wrapper itself prints nothing.
 
 import { spawn as nodeSpawn } from "node:child_process";
+import { constants as osConstants } from "node:os";
 import { isMainModule } from "./is-main.mjs";
 
 const DEFAULT_TIMEOUT_SEC = 180;
@@ -39,24 +40,17 @@ export function resolveTimeoutSec(env = process.env) {
   return n;
 }
 
-// Inject-able for tests. Mirrors the `_setExecFileForTests` pattern in
-// scripts/lib/github-sync.mjs.
-let _spawnForTests = null;
-export function _setSpawnForTests(impl) {
-  _spawnForTests = impl;
-}
-
 // Core: spawn `command` with `args`, kill it after `timeoutMs`, return a
 // promise resolving to {exitCode, timedOut}. exitCode is the raw child exit
 // code on normal exit; on timeout it's TIMEOUT_EXIT_CODE (124). The caller
 // is responsible for translating that into a process.exit() if running as
-// a CLI.
+// a CLI. Tests inject a fake `spawn` via the parameter directly.
 export function runClaudeWithTimeout({
   command = "claude",
   args = [],
   timeoutMs,
   killGraceMs = KILL_GRACE_MS,
-  spawn = _spawnForTests ?? nodeSpawn,
+  spawn = nodeSpawn,
 } = {}) {
   return new Promise((resolve) => {
     const child = spawn(command, args, { stdio: "inherit" });
@@ -68,13 +62,21 @@ export function runClaudeWithTimeout({
       // SIGTERM first; if the child is genuinely stuck in a syscall it may
       // ignore it, in which case SIGKILL after the grace window guarantees
       // we exit. .unref() so the SIGKILL timer doesn't hold the event loop
-      // open if the child exits cleanly under SIGTERM.
+      // open if the child exits cleanly under SIGTERM. The stderr trace is
+      // symmetric with the spawn-failure path below — readers of
+      // `support-agent-*.log` can attribute exit 124 without guessing.
+      process.stderr.write(
+        `run-claude: wall-time cap reached after ${timeoutMs}ms; sending SIGTERM\n`,
+      );
       try {
         child.kill("SIGTERM");
       } catch {
         /* child already exited */
       }
       killTimer = setTimeout(() => {
+        process.stderr.write(
+          `run-claude: child ignored SIGTERM for ${killGraceMs}ms; escalating to SIGKILL\n`,
+        );
         try {
           child.kill("SIGKILL");
         } catch {
@@ -95,11 +97,15 @@ export function runClaudeWithTimeout({
         return;
       }
       // Normal exit: propagate the child's exit code. If killed by an
-      // external signal (not us), surface 128+sig like a shell would.
+      // external signal (not us), surface 128+signum like a POSIX shell —
+      // os.constants.signals provides the platform's name→number map; fall
+      // back to bare 128 for the rare case the signal name isn't in the
+      // table (shouldn't happen on macOS/Linux but cheap to be defensive).
       if (code != null) {
         resolve({ exitCode: code, timedOut: false, signal });
       } else if (signal) {
-        resolve({ exitCode: 128, timedOut: false, signal });
+        const signum = osConstants.signals[signal] ?? 0;
+        resolve({ exitCode: 128 + signum, timedOut: false, signal });
       } else {
         resolve({ exitCode: 1, timedOut: false, signal });
       }

--- a/scripts/support-agent.sh
+++ b/scripts/support-agent.sh
@@ -374,9 +374,15 @@ if [[ "$COMMENT_SYNC" -eq 1 ]]; then
       "$PROMPT_TEXT" "$BUNDLE")
     log "Invoking claude for issue #$ISSUE_NUMBER (comment-sync, phase=$PHASE)"
     CLAUDE_OUTPUT_FILE=$(mktemp -t support-agent-out.XXXXXX)
-    if ! claude -p "$CLAUDE_INPUT" --dangerously-skip-permissions \
-        >"$CLAUDE_OUTPUT_FILE" 2>>"$LOG_FILE"; then
-      log "ERROR: claude exited non-zero for issue #$ISSUE_NUMBER comment-sync"
+    EXIT_CODE=0
+    node "$SCRIPT_DIR/lib/run-claude.mjs" -p "$CLAUDE_INPUT" --dangerously-skip-permissions \
+        >"$CLAUDE_OUTPUT_FILE" 2>>"$LOG_FILE" || EXIT_CODE=$?
+    if [[ $EXIT_CODE -eq 124 ]]; then
+      log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC:-180}s) for issue #$ISSUE_NUMBER comment-sync — skipping; next tick retries"
+      rm -f "$CLAUDE_OUTPUT_FILE"
+      continue
+    elif [[ $EXIT_CODE -ne 0 ]]; then
+      log "ERROR: claude exited non-zero ($EXIT_CODE) for issue #$ISSUE_NUMBER comment-sync"
       cat "$CLAUDE_OUTPUT_FILE" >>"$LOG_FILE" 2>/dev/null || true
       rm -f "$CLAUDE_OUTPUT_FILE"
       continue
@@ -524,9 +530,15 @@ if [[ "$STATE_SYNC" -eq 1 ]]; then
       "$PROMPT_TEXT" "$BUNDLE")
     log "Invoking claude for issue #$ISSUE_NUMBER (state-sync, phase=$PHASE)"
     CLAUDE_OUTPUT_FILE=$(mktemp -t support-agent-out.XXXXXX)
-    if ! claude -p "$CLAUDE_INPUT" --dangerously-skip-permissions \
-        >"$CLAUDE_OUTPUT_FILE" 2>>"$LOG_FILE"; then
-      log "ERROR: claude exited non-zero for issue #$ISSUE_NUMBER state-sync"
+    EXIT_CODE=0
+    node "$SCRIPT_DIR/lib/run-claude.mjs" -p "$CLAUDE_INPUT" --dangerously-skip-permissions \
+        >"$CLAUDE_OUTPUT_FILE" 2>>"$LOG_FILE" || EXIT_CODE=$?
+    if [[ $EXIT_CODE -eq 124 ]]; then
+      log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC:-180}s) for issue #$ISSUE_NUMBER state-sync — skipping; next tick retries"
+      rm -f "$CLAUDE_OUTPUT_FILE"
+      continue
+    elif [[ $EXIT_CODE -ne 0 ]]; then
+      log "ERROR: claude exited non-zero ($EXIT_CODE) for issue #$ISSUE_NUMBER state-sync"
       cat "$CLAUDE_OUTPUT_FILE" >>"$LOG_FILE" 2>/dev/null || true
       rm -f "$CLAUDE_OUTPUT_FILE"
       continue
@@ -848,9 +860,15 @@ for THREAD_INDEX in $(seq 0 $((PENDING_COUNT - 1))); do
 
   log "Invoking claude for $TRACK_ID (phase=$PHASE)"
   CLAUDE_OUTPUT_FILE=$(mktemp -t support-agent-out.XXXXXX)
-  if ! claude -p "$CLAUDE_INPUT" --dangerously-skip-permissions \
-      >"$CLAUDE_OUTPUT_FILE" 2>>"$LOG_FILE"; then
-    log "ERROR: claude exited non-zero for $TRACK_ID"
+  EXIT_CODE=0
+  node "$SCRIPT_DIR/lib/run-claude.mjs" -p "$CLAUDE_INPUT" --dangerously-skip-permissions \
+      >"$CLAUDE_OUTPUT_FILE" 2>>"$LOG_FILE" || EXIT_CODE=$?
+  if [[ $EXIT_CODE -eq 124 ]]; then
+    log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC:-180}s) for $TRACK_ID — skipping; next tick retries"
+    rm -f "$CLAUDE_OUTPUT_FILE"
+    continue
+  elif [[ $EXIT_CODE -ne 0 ]]; then
+    log "ERROR: claude exited non-zero ($EXIT_CODE) for $TRACK_ID"
     cat "$CLAUDE_OUTPUT_FILE" >>"$LOG_FILE" 2>/dev/null || true
     rm -f "$CLAUDE_OUTPUT_FILE"
     continue

--- a/scripts/support-agent.sh
+++ b/scripts/support-agent.sh
@@ -76,6 +76,15 @@ export PATH="$HOME/.local/bin:$PATH"
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
+# ── Claude call timeout ─────────────────────────────────────────────────────
+# Single source of truth for the wall-time cap on each `claude -p` invocation.
+# scripts/lib/run-claude.mjs reads this from the env (defaulting to 180s if
+# unset there too — see DEFAULT_TIMEOUT_SEC). Defining it here and exporting
+# means (a) the bash log lines below use the same value the wrapper actually
+# enforces, and (b) operators can override per-launchd-job by editing the
+# plist's EnvironmentVariables block.
+export CLAUDE_CALL_TIMEOUT_SEC="${CLAUDE_CALL_TIMEOUT_SEC:-180}"
+
 # ── Args ────────────────────────────────────────────────────────────────────
 DRY_RUN=0
 LABEL_ONLY=0
@@ -378,7 +387,7 @@ if [[ "$COMMENT_SYNC" -eq 1 ]]; then
     node "$SCRIPT_DIR/lib/run-claude.mjs" -p "$CLAUDE_INPUT" --dangerously-skip-permissions \
         >"$CLAUDE_OUTPUT_FILE" 2>>"$LOG_FILE" || EXIT_CODE=$?
     if [[ $EXIT_CODE -eq 124 ]]; then
-      log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC:-180}s) for issue #$ISSUE_NUMBER comment-sync — skipping; next tick retries"
+      log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC}s) for issue #$ISSUE_NUMBER comment-sync — skipping; next tick retries"
       rm -f "$CLAUDE_OUTPUT_FILE"
       continue
     elif [[ $EXIT_CODE -ne 0 ]]; then
@@ -534,7 +543,7 @@ if [[ "$STATE_SYNC" -eq 1 ]]; then
     node "$SCRIPT_DIR/lib/run-claude.mjs" -p "$CLAUDE_INPUT" --dangerously-skip-permissions \
         >"$CLAUDE_OUTPUT_FILE" 2>>"$LOG_FILE" || EXIT_CODE=$?
     if [[ $EXIT_CODE -eq 124 ]]; then
-      log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC:-180}s) for issue #$ISSUE_NUMBER state-sync — skipping; next tick retries"
+      log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC}s) for issue #$ISSUE_NUMBER state-sync — skipping; next tick retries"
       rm -f "$CLAUDE_OUTPUT_FILE"
       continue
     elif [[ $EXIT_CODE -ne 0 ]]; then
@@ -864,7 +873,7 @@ for THREAD_INDEX in $(seq 0 $((PENDING_COUNT - 1))); do
   node "$SCRIPT_DIR/lib/run-claude.mjs" -p "$CLAUDE_INPUT" --dangerously-skip-permissions \
       >"$CLAUDE_OUTPUT_FILE" 2>>"$LOG_FILE" || EXIT_CODE=$?
   if [[ $EXIT_CODE -eq 124 ]]; then
-    log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC:-180}s) for $TRACK_ID — skipping; next tick retries"
+    log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC}s) for $TRACK_ID — skipping; next tick retries"
     rm -f "$CLAUDE_OUTPUT_FILE"
     continue
   elif [[ $EXIT_CODE -ne 0 ]]; then


### PR DESCRIPTION
## Summary

- New `scripts/lib/run-claude.mjs` — thin Node wrapper that spawns `claude` as a passthrough but kills it (SIGTERM, then SIGKILL after 5s grace) once `CLAUDE_CALL_TIMEOUT_SEC` (default 180s) elapses, exiting 124 like coreutils `timeout(1)`.
- Three identical edits in `scripts/support-agent.sh` (comment-sync, state-sync, auto-classify call sites) — wrap `claude -p` with the new helper and treat exit 124 as `WARNING: claude timed out` + `continue`. Same path as the existing non-zero handling, so no spurious `nightly-failure` issues fire.
- 9 new unit tests using `node:test` against an injected `spawn` (mirrors the `_setExecFileForTests` pattern in `github-sync.mjs`).

## Why

On 2026-05-05 23:24:56 the live agent's `claude -p` call opened an HTTPS connection to the Anthropic API and the read hung for 7+ hours (15s CPU, S state). The parent bash `wait()`'d forever, holding the loop's `mkdir` mutex, so every subsequent 60s launchd tick was a no-op. No failure issue was filed — there was no exit to detect. macOS doesn't ship `timeout(1)` and adding a Homebrew `coreutils` dependency on the Mac mini just for this isn't worth it.

## Decision points

- **Default 180s, not 600s.** Healthy auto-classify is 25–35s. The loop runs three modes serially under one mutex, so a hung call at 600s blocks ~9 launchd ticks; at 180s the worst case is ~9 minutes of starvation. Recoverable false-positives — next tick retries the same unit because the cursor isn't advanced on failure. Override via `CLAUDE_CALL_TIMEOUT_SEC` env var.
- **Node wrapper, not perl/bash.** Existing test pattern is `node:test` against `.mjs`. Adding a `.mjs` keeps the harness uniform and gives mockable `spawn` for unit tests — no need to spawn real bash from tests.
- **Bigger architectural fix (port auto-classify to Anthropic SDK + AbortController) deferred.** Bash wrap is the right ROI for an event we've seen once.

## Test plan

- [x] `node --test scripts/__tests__/run-claude.test.mjs` — 9/9 pass
- [x] `node --test scripts/__tests__/*.test.mjs` — full scripts suite green
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `bash -n scripts/support-agent.sh` — syntax OK
- [x] End-to-end smoke: `CLAUDE_CALL_TIMEOUT_SEC=2 node scripts/lib/run-claude.mjs` against a stub `claude` that sleeps 30s — exits 124 in 2s
- [ ] Post-merge production verification: 30 minutes of healthy `support-agent-loop.sh` ticks with no `claude exited non-zero` from a hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Claude command execution now supports configurable timeout limits (default 180 seconds, overridable via CLAUDE_CALL_TIMEOUT_SEC environment variable).
  * Support agent gracefully handles execution timeouts and continues processing instead of failing.

* **Bug Fixes**
  * Enhanced signal handling and error reporting for improved command execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->