### PR TITLE
feat(dark-factory): foundations — labels, board, mirror workflow, docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/factory-feature.yml
+++ b/.github/ISSUE_TEMPLATE/factory-feature.yml
@@ -1,0 +1,82 @@
+name: Factory feature spec
+description: A feature or change spec the dark factory can read end-to-end.
+title: "feat: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for any change you want the factory to plan / implement
+        autonomously. The factory's `--plan` mode validates that every section
+        below is filled in; missing sections cause the card to be moved to
+        **Blocked** with a "spec incomplete" comment.
+
+        See `docs/features/dark-factory.md` for the full lifecycle.
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: One paragraph user-facing description. What changes for the user?
+      placeholder: |
+        e.g. "Add a 'duplicate note' action to the note list context menu so users
+        can fork a note as a template."
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Bulleted, testable. The factory uses these as the pass/fail bar.
+      placeholder: |
+        - Right-clicking a note shows "Duplicate note".
+        - The duplicated note appears in the same notebook with title "<original> (copy)".
+        - The duplicate is a deep copy — editing it does not affect the original.
+    validations:
+      required: true
+  - type: checkboxes
+    id: platforms
+    attributes:
+      label: Affected platforms
+      description: |
+        Drives the parity check. The factory's plan-vs-diff post-check fails the
+        card if a checked platform has no corresponding code changes. Use one
+        of the parity:* labels to override for legitimate single-platform work.
+      options:
+        - label: web (`apps/web`)
+        - label: iOS / Android (`apps/mobile`)
+        - label: macOS (`apps/desktop`)
+    validations:
+      required: true
+  - type: dropdown
+    id: schema
+    attributes:
+      label: Schema changes?
+      description: |
+        If "yes", the factory adds `needs-migration-review` and the Approved
+        gate requires a `migration-approved` label before merging.
+      options:
+        - "no"
+        - "yes"
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: ui
+    attributes:
+      label: UI design (if applicable)
+      description: |
+        If this changes user-facing UI, paste a screenshot, mockup, or Figma URL.
+        Skip if the change has no visible UI.
+      placeholder: "https://www.figma.com/file/... or paste a screenshot"
+    validations:
+      required: false
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: Explicit non-goals. What should the factory NOT do?
+      placeholder: |
+        - No bulk-duplicate (multiple notes at once).
+        - No cross-notebook duplication.
+    validations:
+      required: true

--- a/.github/workflows/factory-status-mirror.yml
+++ b/.github/workflows/factory-status-mirror.yml
@@ -1,0 +1,168 @@
+name: Factory Status Mirror
+
+# Mirrors the Project v2 Status field on the Drafto Factory board into
+# `status:*` labels on the linked issue / PR. The factory agent on the Mac
+# mini polls labels (not the Project v2 API), so this workflow is the bridge
+# between human drag-and-drop on the board and the factory's queue.
+#
+# Why a workflow and not direct API polling from the Mac mini?
+#   - GitHub fires `project_v2_item.edited` within seconds of a drag, so
+#     reaction time is sub-minute (vs. up to 5 min for the launchd tick).
+#   - It runs in GitHub-controlled infra, so the Mac mini can be offline
+#     (e.g. boot reboot) without losing state-transition signals — the
+#     workflow still applies the label and the factory picks it up later.
+#
+# Permissions:
+#   The default GITHUB_TOKEN cannot read Project v2 items. We use a PAT
+#   stored in the FACTORY_PROJECT_TOKEN secret (scopes: project, repo).
+#   See docs/operations/factory-runbook.md → "Initial setup".
+
+on:
+  project_v2_item:
+    types: [edited, reopened, restored]
+
+concurrency:
+  # Serialise per-item so a rapid drag-drop sequence doesn't race.
+  group: factory-status-mirror-${{ github.event.projects_v2_item.id }}
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: Mirror Status → label
+    runs-on: ubuntu-latest
+    # Keep this scoped to the JakubAnderwald/Drafto Factory project. If the
+    # PAT is ever attached to additional projects we don't want this workflow
+    # mutating their linked issues.
+    if: github.event.projects_v2_item.project_node_id != ''
+    steps:
+      - name: Resolve item, status, and target issue
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_PROJECT_TOKEN }}
+          ITEM_ID: ${{ github.event.projects_v2_item.node_id }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::FACTORY_PROJECT_TOKEN secret is not set."
+            exit 1
+          fi
+          if [[ -z "$ITEM_ID" ]]; then
+            echo "::warning::No projects_v2_item.node_id in event payload; skipping."
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          QUERY='
+            query($id: ID!) {
+              node(id: $id) {
+                ... on ProjectV2Item {
+                  content {
+                    __typename
+                    ... on Issue       { number repository { nameWithOwner } }
+                    ... on PullRequest { number repository { nameWithOwner } }
+                  }
+                  fieldValues(first: 50) {
+                    nodes {
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        name
+                        field {
+                          ... on ProjectV2SingleSelectField { name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }'
+          RESP=$(gh api graphql -f query="$QUERY" -f id="$ITEM_ID")
+
+          REPO=$(echo "$RESP" | jq -r '.data.node.content.repository.nameWithOwner // empty')
+          NUMBER=$(echo "$RESP" | jq -r '.data.node.content.number // empty')
+          STATUS=$(echo "$RESP" | jq -r '
+            .data.node.fieldValues.nodes
+            | map(select(.field.name == "Status"))
+            | (.[0].name // empty)')
+
+          if [[ -z "$REPO" || -z "$NUMBER" ]]; then
+            echo "::warning::Item has no linked issue/PR (draft item?); skipping."
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "$STATUS" ]]; then
+            echo "::notice::Item #$NUMBER has no Status set; skipping (no label change)."
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Map Status → label. Backlog has no label — it's the implicit
+          # "factory ignores" state. Anything not in the map is rejected so
+          # a typo on a field rename doesn't silently mislabel issues.
+          case "$STATUS" in
+            "Backlog")     LABEL="" ;;
+            "Ready")       LABEL="status:ready" ;;
+            "Planning")    LABEL="status:planning" ;;
+            "Plan Review") LABEL="status:plan-review" ;;
+            "In Progress") LABEL="status:in-progress" ;;
+            "In Review")   LABEL="status:in-review" ;;
+            "In Test")     LABEL="status:in-test" ;;
+            "Approved")    LABEL="status:approved" ;;
+            "Released")    LABEL="status:released" ;;
+            "Done")        LABEL="status:done" ;;
+            "Blocked")     LABEL="status:blocked" ;;
+            *)
+              echo "::error::Unknown Status value '$STATUS'. Add it to setup-factory-board.sh and this workflow's case statement, then re-run setup."
+              exit 1
+              ;;
+          esac
+
+          echo "repo=$REPO"     >>"$GITHUB_OUTPUT"
+          echo "number=$NUMBER" >>"$GITHUB_OUTPUT"
+          echo "status=$STATUS" >>"$GITHUB_OUTPUT"
+          echo "label=$LABEL"   >>"$GITHUB_OUTPUT"
+          echo "skip=false"     >>"$GITHUB_OUTPUT"
+
+      - name: Apply label (idempotent)
+        if: steps.resolve.outputs.skip == 'false'
+        env:
+          # Issue label edits also need repo scope; the PAT has both.
+          GH_TOKEN: ${{ secrets.FACTORY_PROJECT_TOKEN }}
+          REPO: ${{ steps.resolve.outputs.repo }}
+          NUMBER: ${{ steps.resolve.outputs.number }}
+          STATUS: ${{ steps.resolve.outputs.status }}
+          LABEL: ${{ steps.resolve.outputs.label }}
+        run: |
+          set -euo pipefail
+          # Read current labels so we can (a) detect "already correct" and
+          # (b) remove any *other* status:* labels the issue still carries
+          # from a previous Status value.
+          CURRENT=$(gh issue view "$NUMBER" --repo "$REPO" --json labels \
+            | jq -r '.labels[].name')
+
+          # Compute the set of status:* labels that should NOT be on the issue.
+          TO_REMOVE=()
+          while IFS= read -r name; do
+            [[ -z "$name" ]] && continue
+            if [[ "$name" == status:* && "$name" != "$LABEL" ]]; then
+              TO_REMOVE+=("$name")
+            fi
+          done <<<"$CURRENT"
+
+          ALREADY=0
+          if [[ -n "$LABEL" ]] && grep -Fxq "$LABEL" <<<"$CURRENT"; then
+            ALREADY=1
+          fi
+
+          for stale in "${TO_REMOVE[@]:-}"; do
+            [[ -z "$stale" ]] && continue
+            echo "  removing stale label: $stale"
+            gh issue edit "$NUMBER" --repo "$REPO" --remove-label "$stale" >/dev/null
+          done
+
+          if [[ -n "$LABEL" && "$ALREADY" -eq 0 ]]; then
+            echo "  adding label: $LABEL"
+            gh issue edit "$NUMBER" --repo "$REPO" --add-label "$LABEL" >/dev/null
+          elif [[ -n "$LABEL" ]]; then
+            echo "  $LABEL already present — no-op"
+          else
+            echo "  Status=$STATUS maps to no label (Backlog); only removed stale labels"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Note-taking app at drafto.eu. Monorepo with pnpm workspaces + Turborepo. Web (Ne
 | Builds, Fastlane, App Store / Play / Mac releases | [`docs/operations/builds-and-releases.md`](./docs/operations/builds-and-releases.md) |
 | Supabase migration safety workflow                | [`docs/operations/migrations.md`](./docs/operations/migrations.md)                   |
 | Why a tech / pattern was chosen                   | [`docs/adr/`](./docs/adr/README.md)                                                  |
+| Dark factory pipeline (kanban-driven autopilot)   | [`docs/features/dark-factory.md`](./docs/features/dark-factory.md)                   |
 | Full index                                        | [`docs/README.md`](./docs/README.md)                                                 |
 
 Historical plans live in [`docs/archive/`](./docs/archive/) — do not treat as source of truth.
@@ -148,6 +149,16 @@ Common CI failure patterns:
 Beta TestFlight builds (Mac App Store Connect, iOS, Android internal track) are **pre-authorized** — ship them without asking. Communicate what's going out (version + build number, what's in it) but don't gate on permission. A bad TestFlight build is reversible: the next build supersedes it, and old builds can be expired in App Store Connect.
 
 Production / public-store releases (`pnpm release:prod:*`, `pnpm release:production`, App Store / Play Store submission) still require explicit user approval — those affect non-tester users.
+
+## Dark Factory
+
+Drafto runs an unattended development pipeline on the Mac mini ("dark factory") that watches a GitHub Projects v2 board and drives issues through plan → implement → preview → ship. State lives in `status:*` labels mirrored from the board's Status field, plus `logs/factory-state.json`. See [`docs/features/dark-factory.md`](./docs/features/dark-factory.md) for the operator manual, [`docs/operations/factory-runbook.md`](./docs/operations/factory-runbook.md) for phase promotion + rollback, and [ADR-0026](./docs/adr/0026-dark-factory-pipeline.md) for the decision.
+
+**Two human gates** the factory will never bypass: Plan Review → In Progress (plan-approval) and In Test → Approved (merge + ship). Both are reachable via the kanban board for any reporter, and via email reply for allowlisted reporters (Jakub + his wife). The migration gate (`migration-approved` label required when a PR touches `supabase/migrations/**`) is a hard stop on the Approved transition for everyone.
+
+**Kill switches**: per-card via `factory-pause` label or dragging to **Blocked**; global via `node scripts/lib/state-cli.mjs factory:pause`; emergency via `launchctl unload ~/Library/LaunchAgents/eu.drafto.factory.plist`.
+
+**Parity-mandate enforcement**: the factory's `--implement` post-check diffs the PR against the issue's "Affected platforms" checkboxes and blocks the card if a claimed platform has no code changes. To run a legitimate single-platform feature, apply `parity:web-only` / `parity:mobile-only` / `parity:desktop-only` to the issue.
 
 ## Cross-Platform Feature Workflow
 

--- a/docs/adr/0026-dark-factory-pipeline.md
+++ b/docs/adr/0026-dark-factory-pipeline.md
@@ -1,0 +1,97 @@
+# 0026 — Dark Factory Unattended Development Pipeline
+
+- **Status**: Accepted
+- **Date**: 2026-05-06
+- **Authors**: Jakub Anderwald
+
+## Context
+
+After [ADR-0024](./0024-realtime-support-agent.md) (real-time support agent) and [ADR-0025](./0025-support-allowlist-from-zoho-sender.md) (sender-gated auto-implementation), Drafto already routes allowlisted bug reports through `support-agent.sh` (Phase 1 — file + acknowledge) and `nightly-support.sh` Phase 3 (Phase 2 — implement at midnight). What's missing is a way to:
+
+1. Decouple feature work from the midnight cadence — the household reporters end up waiting ~12h for any automated work to start.
+2. Surface the pipeline to a human reviewer between "Claude has read the spec" and "Claude is writing code", so misinterpretations are caught early instead of producing a wrong PR.
+3. Keep features moving on a board that the operator can monitor on mobile without opening a terminal.
+4. Preserve the existing "human merges" rule and migration safety guards while letting allowlisted reporters approve work via email reply.
+
+The goal: a "vibe-kanban-style" pipeline where dragging a card on a GitHub Projects v2 board triggers Claude-driven implementation, deploys to a beta channel, and waits for explicit human approval before firing production releases. Also: keep cost discipline ([CLAUDE.md → "Infrastructure cost discipline"](../../CLAUDE.md)) — no new paid services. Run on the existing Mac mini, free Vercel, free GitHub, free GitHub Actions.
+
+## Decision
+
+Build a **dark factory** as a fourth Mac-mini agent that extends the same skeleton as `support-agent.sh` (PID locks, atomic state via `state-cli.mjs`, phase-gated rollout, `factory-failure` issue trap). State lives in three already-free layers:
+
+1. **GitHub Projects v2 board** — UI surface. Free, native to issues, mobile-friendly. The Status field's value is the source of truth for where each card sits in the lifecycle.
+2. **Repository labels** (`status:*`, `factory-pause`, `migration-approved`, `factory-failure`, `parity:*`) — what the agent reads. A GitHub Action (`factory-status-mirror.yml`) mirrors Status changes onto labels within seconds of a drag, so the agent (which polls labels) sees Project field changes without itself needing a Project v2 PAT.
+3. **`logs/factory-state.json`** (gitignored, mode 0600) — atomic via the same `state-cli.mjs` pattern as the support agent. Tracks worktree-slot ownership, per-issue retry budgets, and the global pause flag.
+
+### Two human gates
+
+The state machine has two transitions where a human must intervene:
+
+- **Plan Review → In Progress** — plan-approval gate. The factory's `--plan` mode is read-only: it reads the issue, posts a structured plan as an issue comment, then stops. No code is written until the human (or an allowlisted reporter via email) drags the card forward.
+- **In Test → Approved** — merge + ship gate. PR stays open with a Vercel preview URL; merging the PR requires the human (or allowlisted reporter) to authorise.
+
+Both gates are reachable via the kanban for anyone, and via email reply for allowlisted reporters (Jakub + his wife) — see "Household autopilot" in [`docs/features/dark-factory.md`](../features/dark-factory.md).
+
+### Concurrency
+
+Up to **2 parallel worktrees** for `--implement`, slot-locked separately. `--plan`, `--watch`, and `--release` are I/O-bound and share single locks. Plan mode does not take a worktree slot — it does read-only research at `origin/main` HEAD only.
+
+### Phased rollout
+
+The factory rolls out in four phases, each gated on ≥5 clean runs at the previous phase:
+
+| Phase | Behaviour                                                                                    |
+| ----- | -------------------------------------------------------------------------------------------- |
+| A     | Plan-only. `--implement` is a no-op; pure observation of plan quality.                       |
+| B     | Web implementation enabled. Mobile/desktop changes auto-blocked at the post-check.           |
+| C     | Mobile + desktop implementation enabled. Approved still merges + Vercel prod only.           |
+| D     | Approved also dispatches iOS / Android beta + local Mac TestFlight. macOS prod stays manual. |
+
+### Coexistence with existing pipelines
+
+The factory does not replace `support-agent.sh` or `nightly-support.sh`. It integrates with them:
+
+- `support-agent.sh` gains an "auto-Ready for allowlisted reporters" behaviour and an "accept-signal classifier" that maps email replies (`go ahead`, `ship it`, `thanks`) onto card transitions via `state-cli.mjs factory:advance`.
+- `nightly-support.sh` Phase 3 (the existing midnight implementation pass) is deprecated **in stages** — it stays running while Phase A/B prove out the factory, gets disabled at Phase C cutover, and is removed at Phase D.
+
+## Consequences
+
+**Positive**
+
+- Allowlisted reporters reach a Vercel preview without opening GitHub. Email a bug → receive plan email → reply "go ahead" → preview URL email → factory ships beta on approval. The reporter touches email twice (plan approval + done acknowledgement).
+- Plan-vs-diff drift is checkable: the plan comment is a public, version-stable artifact the operator can compare against the resulting PR diff, instead of debugging Claude's reasoning post-hoc.
+- The two human gates concentrate review attention where it matters (intent, ship-readiness) without forcing line-by-line code review on every PR.
+- Worktree slots cap the blast radius of a misbehaving plan — at most two concurrent in-flight implementations at any time.
+- Same failure-trap pattern as support-agent — outages file `factory-failure`-labelled issues so they're visible in the existing nightly-audit sweep.
+
+**Negative**
+
+- The factory burns a Claude session per `--plan` and per `--implement` cycle; budget is bounded by the per-issue retry counter in `factory-state.json`, but a runaway plan-review loop on a poorly-specced issue still costs more than a static template would.
+- The Project v2 board is a third state surface (after labels and `factory-state.json`). The mirror workflow is the only thing that keeps Status and labels in sync — if it ever stops firing, the factory will appear to "ignore" board moves.
+- A second launchd job (after `support-agent`, `nightly-support`, `nightly-audit`) is now load-bearing. Mac-mini downtime delays factory progress; the host is a single point of failure.
+- The `--watch` mode polls open PRs to advance In Review → In Test, which means a CI flake that takes >24h to surface can silently leave a card hanging until the operator notices. The `nightly-audit` extension catches this with a "stuck in In Review" check.
+
+**Neutral**
+
+- The factory shares `claude --dangerously-skip-permissions` and the run-claude.mjs wall-time wrapper with the support agent. Failures look the same in logs and route the same admin email.
+- All new state is in already-gitignored paths (`logs/factory-state.json`, `worktrees/`); the repo proper stays clean.
+- The plan-vs-diff drift check is a quality signal, not a hard gate. A diff that exceeds the plan posts a warning comment and proceeds — the human reviewer at the In Test gate is the final word.
+
+## Alternatives Considered
+
+- **Custom kanban UI in `apps/web`.** Rejected. Projects v2 covers it for free, with mobile apps and email subscriptions out of the box. Building our own would be a multi-week project for negligible UX gain.
+- **vibe-kanban integration.** Rejected. vibe-kanban runs its own state machine and worktree manager; integrating with it would split state across two systems and lose the "GitHub issues are source of truth" property. The factory's "drag-equals-action" pattern delivers the same UX without that split.
+- **Single human gate (only at In Test → Approved).** Rejected. The plan-review gate is the early-stage misinterpretation catcher — without it, a wrong plan produces a wrong PR that the human must then reject in the In Test column, having already burned a worktree slot and a Claude implementation session. Doubling the gates costs negligible operator time (it's the same drag) and saves substantially more on rework.
+- **One worktree slot.** Rejected as too restrictive — small fixes would queue behind larger ones for hours. Three+ slots would push the Mac mini's CPU budget under concurrent E2E test runs. Two is the empirical sweet spot from the `support-agent.sh` + `nightly-support.sh` overlap pattern.
+- **Cross-repo orchestration.** Rejected — Drafto is a single-repo monorepo today, and the factory's worktree model assumes one repo root. If Drafto ever splits, this ADR will need a successor.
+- **Auto-merge before Approved.** Rejected for non-allowlisted reporters. The merge-on-Approved-drag is the human's last word before code lands on `main`. Allowlisted reporters' issues _do_ auto-advance to Approved (their identity-on-file is the implicit sign-off), but the migration gate remains a hard stop in that path too.
+
+## Related
+
+- `docs/features/dark-factory.md` — operator manual (board URL, label glossary, troubleshooting).
+- `docs/operations/factory-runbook.md` — phase progression criteria, kill switches, rollback drills.
+- `docs/dark-factory-proposal.md` — the proposal document this ADR finalises (kept for the lifecycle table and implementation-wave breakdown).
+- `scripts/setup-factory-labels.sh`, `scripts/setup-factory-board.sh` — one-shot bootstrap.
+- `.github/workflows/factory-status-mirror.yml` — Status-field → label bridge.
+- `.github/ISSUE_TEMPLATE/factory-feature.yml` — spec contract enforcement.
+- [ADR-0024](./0024-realtime-support-agent.md) and [ADR-0025](./0025-support-allowlist-from-zoho-sender.md) — the support pipeline this ADR extends, not replaces.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,3 +58,4 @@ Every ADR follows the template in [0000-adr-template.md](./0000-adr-template.md)
 | [0023](./0023-per-request-client-tagging.md)             | Per-Request Client Tagging                     | Accepted           | 2026-04-27 |
 | [0024](./0024-realtime-support-agent.md)                 | Real-Time Support Agent                        | Accepted           | 2026-04-28 |
 | [0025](./0025-support-allowlist-from-zoho-sender.md)     | Support Allowlist Gate from Zoho Sender        | Accepted           | 2026-05-03 |
+| [0026](./0026-dark-factory-pipeline.md)                  | Dark Factory Unattended Development Pipeline   | Accepted           | 2026-05-06 |

--- a/docs/features/dark-factory.md
+++ b/docs/features/dark-factory.md
@@ -1,0 +1,117 @@
+# Dark factory
+
+**Status:** rolling out (Phase A) **Updated:** 2026-05-06
+
+## What it is
+
+A "vibe-kanban-style" pipeline where moving a card on a GitHub Projects v2 board triggers Claude-driven implementation, deploys the result to a beta channel, and waits for explicit human approval before firing production releases. Built on the existing Mac mini, free GitHub, free Vercel — no new paid services. See [ADR-0026](../adr/0026-dark-factory-pipeline.md) for the decision; the original proposal is [`docs/dark-factory-proposal.md`](../dark-factory-proposal.md).
+
+## Current state
+
+**Phase A (Plan-only).** The factory's `--plan` mode is wired up: it watches `status:ready` issues, posts a structured plan as an issue comment, and stops at `status:plan-review`. The `--implement` mode is a no-op at this phase. Promote past A only after ≥5 clean runs without human intervention.
+
+## The board
+
+- **Owner**: `JakubAnderwald`
+- **Title**: `Drafto Factory`
+- **URL**: bootstrap with `scripts/setup-factory-board.sh`, then record the URL here. The script prints it on success.
+
+The board has one custom Status field with eleven values:
+
+| Status      | Who sets it           | Meaning                                                               |
+| ----------- | --------------------- | --------------------------------------------------------------------- |
+| Backlog     | human                 | Filed, not yet specced. Factory ignores.                              |
+| Ready       | human                 | Spec complete; factory may **plan** (read-only).                      |
+| Planning    | factory               | Claude is reading the issue and writing a plan.                       |
+| Plan Review | factory               | Plan posted as a comment; awaiting human approval.                    |
+| In Progress | human / allowlisted   | Plan approved; factory implements per the approved plan.              |
+| In Review   | factory               | PR open; factory monitors CI and review comments.                     |
+| In Test     | factory               | Vercel preview ready; awaiting human approval.                        |
+| Approved    | human / allowlisted   | Authorise prod release. Migration gate enforced.                      |
+| Released    | factory               | PR merged; beta channels dispatched (Phase D).                        |
+| Done        | human / support-agent | Final acceptance; issue closed.                                       |
+| Blocked     | factory               | Spec incomplete, retry budget exhausted, parity violation, hard gate. |
+
+Each Status maps 1:1 to a `status:*` label via `.github/workflows/factory-status-mirror.yml`. The factory agent reads labels, not Project v2 fields.
+
+## Label glossary
+
+The full set is created idempotently by `scripts/setup-factory-labels.sh`. Reference:
+
+| Label                 | Set by               | Meaning                                                          |
+| --------------------- | -------------------- | ---------------------------------------------------------------- |
+| `status:ready`        | mirror workflow      | Spec accepted; factory may plan.                                 |
+| `status:planning`     | factory              | Plan in progress.                                                |
+| `status:plan-review`  | factory              | Awaiting plan approval.                                          |
+| `status:in-progress`  | mirror / factory     | Implementation in progress.                                      |
+| `status:in-review`    | factory              | PR open, CI / review comments active.                            |
+| `status:in-test`      | factory              | Vercel preview ready, awaiting ship approval.                    |
+| `status:approved`     | mirror / factory     | Approved for release; merge + dispatch authorised.               |
+| `status:released`     | factory              | Merged + beta dispatched.                                        |
+| `status:done`         | mirror / support     | Final acceptance.                                                |
+| `status:blocked`      | factory              | Hard stop — see comment on issue.                                |
+| `factory-pause`       | operator             | Global kill switch on this issue (factory ignores).              |
+| `migration-approved`  | operator             | Authorises factory to merge a PR with `supabase/migrations` SQL. |
+| `factory-failure`     | factory failure trap | Filed by `cleanup()` when a factory run errors out.              |
+| `parity:web-only`     | operator             | Skip cross-platform parity check (legitimate web-only work).     |
+| `parity:mobile-only`  | operator             | Skip cross-platform parity check (legitimate mobile-only work).  |
+| `parity:desktop-only` | operator             | Skip cross-platform parity check (legitimate desktop-only work). |
+
+## How to file an issue for the factory
+
+Use the **Factory feature spec** template (`.github/ISSUE_TEMPLATE/factory-feature.yml`). It enforces the spec contract:
+
+1. **What** — one paragraph user-facing description.
+2. **Acceptance criteria** — bulleted, testable.
+3. **Affected platforms** — checkboxes (web / iOS+Android / macOS).
+4. **Schema changes?** — yes/no. If yes, the factory adds `needs-migration-review`.
+5. **UI?** — screenshot / Figma URL if applicable.
+6. **Out of scope** — explicit non-goals.
+
+After filing, drag the card to **Ready** on the board. The mirror workflow applies `status:ready` within seconds; the factory picks it up on its next 5-min tick.
+
+## Kill switches
+
+- **Per-card**: drag the card to **Blocked**, or apply `factory-pause` to the issue. The factory ignores the card on the next tick.
+- **Global**: run `node scripts/lib/state-cli.mjs factory:pause` on the Mac mini. The agent reads the flag every cycle and exits early when set. `factory:resume` to unpause. (Available once Wave 2 lands; until then, unload the launchd plist.)
+- **Emergency stop**: `launchctl unload ~/Library/LaunchAgents/eu.drafto.factory.plist` on the Mac mini, or `kill` the active claude PID under `logs/factory.*.pid`.
+
+## Troubleshooting
+
+### "I dragged a card but the factory didn't pick it up"
+
+1. Check the workflow ran: GitHub → Actions → "Factory Status Mirror". Look for a successful run within the last minute.
+2. If the workflow ran but the issue's labels didn't change: check the run's "Apply label" step output. Common causes: PAT expired (`FACTORY_PROJECT_TOKEN` secret), or the Status value isn't in the workflow's case statement (typo on a Status rename — update both `setup-factory-board.sh` and the workflow case).
+3. If the label IS correct but the factory doesn't act: check `logs/factory-*.log` on the Mac mini. The agent might be paused (`factory-pause` global flag), out of retry budget for that issue, or holding both worktree slots on other issues.
+
+### "The plan comment looks wrong / Claude misread the issue"
+
+This is exactly what the Plan Review gate catches. Don't drag to In Progress. Instead, comment on the issue with the correction (or have the allowlisted reporter reply with rejection in email — the factory will re-plan on its next cycle). If you want the factory to forget and start over, drag the card back to **Ready** and the next tick will replan.
+
+### "PR opened but CI keeps failing"
+
+The factory's `--watch` mode loops `/push`-style: it reads CI failures and review comments, re-invokes Claude to fix, re-pushes. Bounded by `factory.issues[<n>].attempts` in `logs/factory-state.json`. When the budget is exhausted the card moves to **Blocked** with a comment listing the unresolved items. Human must take over from there.
+
+### "Vercel preview never appeared in In Test"
+
+The factory advances In Review → In Test only when (a) CI is green AND (b) the Vercel bot has commented with a preview URL on the PR. If CI is green but Vercel hasn't run, check the Vercel project's GitHub integration is wired up; sometimes the bot misses a push and a force-push to bump the PR head re-triggers it.
+
+### "Allowlisted reporter's email reply didn't move the card"
+
+`support-agent.sh`'s accept-signal classifier requires:
+
+- The reporter's address matches `reporter-email` from the issue body footer (no impersonation via cc/bcc).
+- The card is in one of the two transitionable states (`status:plan-review` → `status:in-progress`, or `status:released` → `status:done`).
+- The reply text reads as accept-intent ("go ahead", "ship it", "thanks", `[ACCEPT]`, `[GO]`).
+
+Check `logs/support/support-agent-*.log` for the per-thread classification line. If the classifier flagged the reply as non-accept-intent (e.g. it mentioned a new direction), the agent treated the reply as a fresh comment and the card stays where it is — drag it manually if needed.
+
+## Related
+
+- [ADR-0026](../adr/0026-dark-factory-pipeline.md) — decision record.
+- [`docs/operations/factory-runbook.md`](../operations/factory-runbook.md) — phase promotion criteria, rollback drills, on-call response.
+- [`docs/dark-factory-proposal.md`](../dark-factory-proposal.md) — original proposal (lifecycle table, household autopilot details, implementation waves).
+- [`scripts/setup-factory-labels.sh`](../../scripts/setup-factory-labels.sh) — label bootstrap.
+- [`scripts/setup-factory-board.sh`](../../scripts/setup-factory-board.sh) — Project v2 board bootstrap.
+- [`.github/workflows/factory-status-mirror.yml`](../../.github/workflows/factory-status-mirror.yml) — Status field → label mirror.
+- [`.github/ISSUE_TEMPLATE/factory-feature.yml`](../../.github/ISSUE_TEMPLATE/factory-feature.yml) — spec contract template.

--- a/docs/features/dark-factory.md
+++ b/docs/features/dark-factory.md
@@ -14,7 +14,9 @@ A "vibe-kanban-style" pipeline where moving a card on a GitHub Projects v2 board
 
 - **Owner**: `JakubAnderwald`
 - **Title**: `Drafto Factory`
-- **URL**: bootstrap with `scripts/setup-factory-board.sh`, then record the URL here. The script prints it on success.
+- **URL**: <https://github.com/users/JakubAnderwald/projects/1>
+
+To re-bootstrap (e.g. after a deletion), run `scripts/setup-factory-board.sh`. It is idempotent and prints the URL on success.
 
 The board has one custom Status field with eleven values:
 

--- a/docs/operations/factory-runbook.md
+++ b/docs/operations/factory-runbook.md
@@ -34,10 +34,12 @@ Run these in order, on a workstation with `gh` authenticated as the project owne
 4. **Create a PAT for the mirror workflow.**
    - GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens.
    - Resource owner: `JakubAnderwald` (your user). Repository access: only `JakubAnderwald/drafto`.
-   - Permissions:
-     - **Repository → Issues**: Read and write.
-     - **Repository → Metadata**: Read-only (auto-set).
-     - **Account → Projects**: Read-only.
+   - Permissions — note the two tabs at the top of the **Permissions** section, **Repositories** and **Account**:
+     - **Repositories** tab:
+       - **Issues**: Read and write.
+       - **Metadata**: Read-only (auto-set).
+     - **Account** tab (Projects v2 are user-owned, not repo-scoped, so the Project permission lives here):
+       - **Projects**: Read-only.
    - Expiration: 90 days (set a calendar reminder to rotate; rotation is in this runbook).
 
 5. **Add the PAT to repo secrets.**

--- a/docs/operations/factory-runbook.md
+++ b/docs/operations/factory-runbook.md
@@ -1,0 +1,145 @@
+# Factory runbook
+
+Operational guide for the dark factory pipeline. For the user-facing description of what the factory does, see [`docs/features/dark-factory.md`](../features/dark-factory.md). For the architectural decision, see [ADR-0026](../adr/0026-dark-factory-pipeline.md).
+
+## Initial setup (one-time)
+
+Run these in order, on a workstation with `gh` authenticated as the project owner.
+
+1. **Bootstrap labels.**
+
+   ```bash
+   scripts/setup-factory-labels.sh
+   ```
+
+   Idempotent. Re-running upserts colour + description on existing labels.
+
+2. **Bootstrap the Project v2 board.**
+
+   ```bash
+   gh auth refresh -s project,read:project   # if you haven't yet
+   scripts/setup-factory-board.sh
+   ```
+
+   Prints the board URL on success — paste it into `docs/features/dark-factory.md` ("The board" section).
+
+3. **Link the repo to the project.**
+
+   ```bash
+   gh project link <number> --owner JakubAnderwald --repo JakubAnderwald/drafto
+   ```
+
+   Without this, issues filed in the repo don't auto-add to the board.
+
+4. **Create a PAT for the mirror workflow.**
+   - GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens.
+   - Resource owner: `JakubAnderwald` (your user). Repository access: only `JakubAnderwald/drafto`.
+   - Permissions:
+     - **Repository → Issues**: Read and write.
+     - **Repository → Metadata**: Read-only (auto-set).
+     - **Account → Projects**: Read-only.
+   - Expiration: 90 days (set a calendar reminder to rotate; rotation is in this runbook).
+
+5. **Add the PAT to repo secrets.**
+   - Repo → Settings → Secrets and variables → Actions → New repository secret.
+   - Name: `FACTORY_PROJECT_TOKEN`.
+   - Value: the PAT from step 4.
+
+6. **Smoke test the mirror.**
+   - File any issue. Add it to the board. Drag the card to **Ready**.
+   - Within ~30 s, the issue should gain `status:ready`. Confirm via Actions tab → "Factory Status Mirror" → most recent run.
+   - If it doesn't, see "Mirror workflow failing" below.
+
+7. **Install the factory launchd job.** (Wave 4 — does not apply at Phase A until the agent code lands.)
+
+## Phase progression criteria
+
+| Promote from → to | Required signals before promotion                                                                                                                                                                                                                                                                                                                                                                   |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| (initial) → A     | Setup steps 1–6 above complete. `factory-status-mirror.yml` mirrors a manual board move within 30 s.                                                                                                                                                                                                                                                                                                |
+| A → B             | ≥5 successful `--plan` runs (Ready → Planning → Plan Review with a usable plan comment). Zero `factory-failure` issues. Operator has read at least 3 plans and judges they were accurate enough to act on. `--implement` no-op confirmed: dragging Plan Review → In Progress in Phase A logs a "phase=A; implementation skipped" comment and leaves the card in In Progress without further action. |
+| B → C             | ≥5 successful end-to-end web-only runs (Ready → Plan Review → In Progress → In Review → In Test → Approved → Released → Done). Zero parity violations. SonarCloud quality gate green on all factory-authored PRs.                                                                                                                                                                                   |
+| C → D             | ≥5 successful runs that include mobile or desktop changes. Operator manually fired beta dispatches (TestFlight, Play internal) per Phase C — confirms the dispatch payloads work before the factory automates them.                                                                                                                                                                                 |
+| D → (steady)      | ≥10 successful Released cards in Phase D. Beta dispatch path validated for both iOS and Android. Mac TestFlight lane runs locally on the Mac mini per the existing release pattern.                                                                                                                                                                                                                 |
+
+Promote by editing the launchd plist's `--phase` argument and reloading:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/eu.drafto.factory.plist
+# edit plist, change --phase A → --phase B (or B → C, etc.)
+launchctl load ~/Library/LaunchAgents/eu.drafto.factory.plist
+```
+
+There is no "auto-promote". The phase change is always a deliberate operator action so a regression at one phase can't silently unlock the next.
+
+## Kill switches
+
+| Severity                     | Action                                                                                                                                                                                                                                 |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| One bad card                 | Drag to **Blocked**, or apply `factory-pause` to the issue. Factory skips it next tick.                                                                                                                                                |
+| Stop all factory work        | `node scripts/lib/state-cli.mjs factory:pause` (Wave 2+). Resume with `factory:resume`.                                                                                                                                                |
+| Stop the launchd job         | `launchctl unload ~/Library/LaunchAgents/eu.drafto.factory.plist`. Reload to resume.                                                                                                                                                   |
+| Active Claude session hangs  | Find the PID in `logs/factory.slot{0,1}.pid` (or `logs/factory.plan.pid`), `kill -TERM <pid>`. The wall-time wrapper (`run-claude.mjs`) caps each invocation at `CLAUDE_CALL_TIMEOUT_SEC` (default 180 s) so this is rare in practice. |
+| Stuck PR with a wrong commit | `gh pr close <n> --delete-branch`. Drag the card back to Ready. Factory will re-plan on the next tick.                                                                                                                                 |
+
+## Rollback drills
+
+The factory's blast radius is bounded by:
+
+1. **Pre-merge.** Worst case, a PR is opened with bad code. Closing the PR (and removing its `factory/issue-<n>` branch) reverts to zero side effects.
+2. **Post-merge but pre-release.** Vercel auto-deploys main → prod on merge. If the factory merged something bad, follow the standard web rollback: `vercel rollback <previous-deployment-id>` from the Vercel dashboard. The web app is back in <60 s.
+3. **Post-merge and post-beta-dispatch (Phase D only).** TestFlight / Play internal builds are pre-authorised and reversible — the next build supersedes the bad one. No store-public users are affected (production app-store submissions stay manual; see CLAUDE.md "Release Authorization").
+4. **Schema migration.** The migration gate refuses to merge a PR with `supabase/migrations/**` files unless `migration-approved` is on the PR. If a bad migration _did_ land, follow [`docs/operations/migrations.md`](./migrations.md) → "Rolling back a migration".
+
+Practice drill (do once per month while the factory is active):
+
+- File a trivial test issue ("test: bump footer copyright year"), drag through to Released.
+- Verify Vercel rollback works for that exact commit before declaring the drill green.
+
+## On-call response — `factory-failure` issue appears
+
+The factory's `cleanup()` trap files a `factory-failure`-labelled GitHub issue when a run errors out. `nightly-audit.sh` will surface these in its 05:00 sweep. When you see one:
+
+1. **Read the issue body.** Sanitised log tail is included (timestamps only — no bundle PII, same regex pattern as `support-agent.sh`).
+2. **Check `logs/factory-*.log` on the Mac mini** for the full context.
+3. **Common causes** (in approximate order of frequency):
+   - Network blip during `gh` call (transient — usually resolves on the next tick).
+   - Worktree slot leaked (a previous run died without releasing its lock). Inspect `logs/factory.slot{0,1}.pid`; if the PID is dead, `rm` the lock.
+   - Disk full under `worktrees/` — clean up via `git worktree prune`.
+   - Claude wall-time cap hit on every retry (the prompt or context bundle is too large). Inspect the bundle in the log; truncate prior PR threads if needed.
+4. **Close the failure issue** once resolved. The trap doesn't auto-close; that's intentional so the issue is visible until acknowledged.
+
+If the same failure mode files >3 issues in 24h, pause the factory globally (`factory:pause`) and open a regular bug to fix the root cause.
+
+## PAT rotation
+
+The `FACTORY_PROJECT_TOKEN` PAT expires every 90 days (per setup step 4). When it expires, the mirror workflow fails — board moves stop translating to labels and the factory queue silently empties.
+
+To rotate:
+
+1. Generate a new fine-grained PAT with the same scopes as setup step 4.
+2. Update the `FACTORY_PROJECT_TOKEN` secret value in repo settings.
+3. Smoke-test by dragging a Backlog card to Ready and back; the workflow should run twice and the labels should toggle.
+4. Set a new 90-day calendar reminder.
+
+The launchd plist on the Mac mini does **not** use this PAT — `gh` on the Mac mini authenticates separately via `gh auth login`. Don't confuse the two.
+
+## Coexistence with `nightly-support.sh` Phase 3
+
+Phase 3 (existing midnight implementation pass) and the factory's `--implement` mode operate on overlapping issue sets. The deprecation schedule is:
+
+| Factory phase | Phase 3 status                                                                                                                                                                                                                                                               |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A             | Phase 3 keeps running. Factory only `--plan`s; no overlap.                                                                                                                                                                                                                   |
+| B             | Phase 3 keeps running. Factory `--implement`s only `status:ready` cards set by humans; Phase 3 still picks up `support`-labelled issues without `status:*`. Operator monitors logs to ensure they don't both pick up the same issue (label set is disjoint by construction). |
+| C             | Phase 3 disabled at cutover. Factory takes over support-issue implementation.                                                                                                                                                                                                |
+| D             | Phase 3 code removed.                                                                                                                                                                                                                                                        |
+
+If both the factory and Phase 3 ever try to implement the same issue (a misconfiguration), the factory takes priority — its worktree-slot lock will block Phase 3's attempt. Both will log; Phase 3's log will say "issue #N already has a factory worktree".
+
+## Related
+
+- [`docs/features/dark-factory.md`](../features/dark-factory.md) — operator manual.
+- [ADR-0026](../adr/0026-dark-factory-pipeline.md) — decision record.
+- [`docs/operations/migrations.md`](./migrations.md) — migration safety + rollback workflow.
+- [`docs/operations/builds-and-releases.md`](./builds-and-releases.md) — release commands, beta lanes.

--- a/docs/operations/factory-runbook.md
+++ b/docs/operations/factory-runbook.md
@@ -32,15 +32,16 @@ Run these in order, on a workstation with `gh` authenticated as the project owne
    Without this, issues filed in the repo don't auto-add to the board.
 
 4. **Create a PAT for the mirror workflow.**
-   - GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens.
-   - Resource owner: `JakubAnderwald` (your user). Repository access: only `JakubAnderwald/drafto`.
-   - Permissions — note the two tabs at the top of the **Permissions** section, **Repositories** and **Account**:
-     - **Repositories** tab:
-       - **Issues**: Read and write.
-       - **Metadata**: Read-only (auto-set).
-     - **Account** tab (Projects v2 are user-owned, not repo-scoped, so the Project permission lives here):
-       - **Projects**: Read-only.
+
+   Use a **classic PAT** rather than a fine-grained one. Projects v2 access via fine-grained PATs is gated on an Account-tab "Projects" permission that is unreliably surfaced for personal accounts (search filters return "No items available"). Classic PATs cover Projects v2 out of the box.
+   - GitHub → Settings → Developer settings → Personal access tokens → **Tokens (classic)** → Generate new token (classic).
+   - Note: name it something like "drafto factory mirror".
+   - Scopes:
+     - `repo` (full) — covers issue label edits on `JakubAnderwald/drafto`.
+     - `project` — Projects v2 read.
    - Expiration: 90 days (set a calendar reminder to rotate; rotation is in this runbook).
+
+   Classic PATs are user-wide rather than repo-scoped, which is a slightly larger blast radius than fine-grained — for a single-user, single-repo project this is an acceptable tradeoff for "always works". If you'd rather use fine-grained, the equivalent is **Repositories → Issues: Read+Write, Metadata: Read-only** plus **Account → Projects: Read-only** — the Account permission only appears in the search if your account context exposes it.
 
 5. **Add the PAT to repo secrets.**
    - Repo → Settings → Secrets and variables → Actions → New repository secret.
@@ -119,7 +120,7 @@ The `FACTORY_PROJECT_TOKEN` PAT expires every 90 days (per setup step 4). When i
 
 To rotate:
 
-1. Generate a new fine-grained PAT with the same scopes as setup step 4.
+1. Generate a new classic PAT with the same scopes as setup step 4 (`repo`, `project`).
 2. Update the `FACTORY_PROJECT_TOKEN` secret value in repo settings.
 3. Smoke-test by dragging a Backlog card to Ready and back; the workflow should run twice and the labels should toggle.
 4. Set a new 90-day calendar reminder.

--- a/scripts/setup-factory-board.sh
+++ b/scripts/setup-factory-board.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# One-shot, idempotent factory Project v2 board bootstrap.
+#
+# Usage: scripts/setup-factory-board.sh [--owner <user-or-org>] [--title <title>]
+#
+# Defaults to JakubAnderwald / "Drafto Factory". Re-running is safe — the
+# script checks for an existing project of the same title before creating one
+# and only adds Status field options that are missing.
+#
+# Requires:
+#   gh auth status with `project` scope. If gh complains "missing scope",
+#   run: gh auth refresh -s project,read:project
+#
+# After this script returns successfully, configure the
+# .github/workflows/factory-status-mirror.yml workflow with a PAT in the
+# FACTORY_PROJECT_TOKEN repository secret (PAT scope: project, repo).
+
+set -euo pipefail
+
+OWNER="JakubAnderwald"
+TITLE="Drafto Factory"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --owner)
+      OWNER="$2"; shift 2 ;;
+    --title)
+      TITLE="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,17p' "$0"; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not found on PATH" >&2
+  exit 1
+fi
+
+# Status options must match the labels created by setup-factory-labels.sh
+# AND the parser in .github/workflows/factory-status-mirror.yml. Keep all
+# three in sync.
+STATUS_OPTIONS=(
+  "Backlog"
+  "Ready"
+  "Planning"
+  "Plan Review"
+  "In Progress"
+  "In Review"
+  "In Test"
+  "Approved"
+  "Released"
+  "Done"
+  "Blocked"
+)
+
+echo "Looking up existing project '$TITLE' under owner '$OWNER'..."
+EXISTING_NUMBER=$(gh project list --owner "$OWNER" --format json --limit 100 \
+  | jq -r --arg title "$TITLE" '.projects[] | select(.title == $title) | .number' \
+  | head -1)
+
+if [[ -n "$EXISTING_NUMBER" ]]; then
+  echo "Project already exists: #$EXISTING_NUMBER"
+  PROJECT_NUMBER="$EXISTING_NUMBER"
+else
+  echo "Creating project '$TITLE'..."
+  PROJECT_NUMBER=$(gh project create --owner "$OWNER" --title "$TITLE" --format json \
+    | jq -r '.number')
+  echo "Created project #$PROJECT_NUMBER"
+fi
+
+PROJECT_URL="https://github.com/users/$OWNER/projects/$PROJECT_NUMBER"
+echo "Project URL: $PROJECT_URL"
+
+# Find the Status single-select field. New projects ship with one named
+# "Status" already; if it's been renamed, we error out instead of guessing.
+echo "Locating Status field..."
+FIELDS_JSON=$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 100)
+STATUS_FIELD=$(echo "$FIELDS_JSON" \
+  | jq -r '.fields[] | select(.name == "Status" and .type == "ProjectV2SingleSelectField")')
+if [[ -z "$STATUS_FIELD" ]]; then
+  echo "ERROR: project $PROJECT_NUMBER has no single-select field named 'Status'." >&2
+  echo "       Rename or recreate the Status field, then re-run this script." >&2
+  exit 1
+fi
+STATUS_FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
+
+EXISTING_OPTIONS=$(echo "$STATUS_FIELD" | jq -r '.options[].name')
+echo "Existing Status options: $(echo "$EXISTING_OPTIONS" | paste -sd, -)"
+
+# Compute the union of existing + desired option names. Order matters in the
+# UI, so we always set the full list (not just additions). This is also
+# idempotent: passing the same set twice is a no-op server-side.
+DESIRED_JSON=$(printf '%s\n' "${STATUS_OPTIONS[@]}" \
+  | jq -R '{name: ., color: "GRAY", description: ""}' \
+  | jq -s '.')
+
+# Colour each option to roughly mirror the labels.
+COLOURED_JSON=$(echo "$DESIRED_JSON" | jq '
+  map(
+    .color = (
+      {
+        "Backlog":     "GRAY",
+        "Ready":       "GREEN",
+        "Planning":    "BLUE",
+        "Plan Review": "PURPLE",
+        "In Progress": "YELLOW",
+        "In Review":   "BLUE",
+        "In Test":     "GREEN",
+        "Approved":    "GREEN",
+        "Released":    "GREEN",
+        "Done":        "GRAY",
+        "Blocked":     "RED"
+      }[.name] // "GRAY"
+    )
+  )')
+
+echo "Updating Status field options (idempotent)..."
+gh api graphql -f query='
+  mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+    updateProjectV2Field(input: {
+      fieldId: $fieldId
+      singleSelectOptions: $options
+    }) {
+      projectV2Field {
+        ... on ProjectV2SingleSelectField {
+          id
+          options { id name }
+        }
+      }
+    }
+  }' \
+  -f fieldId="$STATUS_FIELD_ID" \
+  -F options="$COLOURED_JSON" >/dev/null
+
+echo "Status options now: $(IFS=,; echo "${STATUS_OPTIONS[*]}")"
+echo
+echo "Next steps:"
+echo "  1. Add this repo as a project source: gh project link $PROJECT_NUMBER --owner $OWNER --repo $OWNER/drafto"
+echo "  2. Add to repo secrets:  FACTORY_PROJECT_TOKEN  (PAT with scopes: project, repo)"
+echo "  3. Smoke test: file an issue, drag to Ready, watch factory-status-mirror.yml apply status:ready."

--- a/scripts/setup-factory-board.sh
+++ b/scripts/setup-factory-board.sh
@@ -1,23 +1,28 @@
 #!/bin/bash
 # One-shot, idempotent factory Project v2 board bootstrap.
 #
-# Usage: scripts/setup-factory-board.sh [--owner <user-or-org>] [--title <title>]
+# Usage: scripts/setup-factory-board.sh [--owner <login>] [--title <title>]
 #
-# Defaults to JakubAnderwald / "Drafto Factory". Re-running is safe — the
-# script checks for an existing project of the same title before creating one
-# and only adds Status field options that are missing.
+# Defaults to the authenticated viewer / "Drafto Factory". Re-running is safe
+# — the script checks for an existing project of the same title and only
+# adds Status field options that are missing.
 #
-# Requires:
-#   gh auth status with `project` scope. If gh complains "missing scope",
-#   run: gh auth refresh -s project,read:project
+# Auth requirements:
+#   Uses GraphQL throughout (`gh api graphql`) so the token only needs the
+#   `project` scope (or the fine-grained Projects: read+write equivalent).
+#   The `gh project` CLI subcommands are deliberately avoided because they
+#   additionally require `read:org` / `read:discussion`, which aren't on the
+#   workflow's classic PAT.
 #
-# After this script returns successfully, configure the
-# .github/workflows/factory-status-mirror.yml workflow with a PAT in the
-# FACTORY_PROJECT_TOKEN repository secret (PAT scope: project, repo).
+# Token sources, in order:
+#   1. $GH_TOKEN (set by the caller for one-shot use, e.g.
+#      `GH_TOKEN=ghp_... scripts/setup-factory-board.sh`).
+#   2. Whatever `gh auth status` is currently using.
+# Either must have `project` (read+write) and the ability to call the v4 API.
 
 set -euo pipefail
 
-OWNER="JakubAnderwald"
+OWNER=""
 TITLE="Drafto Factory"
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -26,7 +31,7 @@ while [[ $# -gt 0 ]]; do
     --title)
       TITLE="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,17p' "$0"; exit 0 ;;
+      sed -n '2,21p' "$0"; exit 0 ;;
     *)
       echo "Unknown argument: $1" >&2; exit 2 ;;
   esac
@@ -34,6 +39,10 @@ done
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "ERROR: gh CLI not found on PATH" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq not found on PATH" >&2
   exit 1
 fi
 
@@ -54,88 +63,174 @@ STATUS_OPTIONS=(
   "Blocked"
 )
 
-echo "Looking up existing project '$TITLE' under owner '$OWNER'..."
-EXISTING_NUMBER=$(gh project list --owner "$OWNER" --format json --limit 100 \
-  | jq -r --arg title "$TITLE" '.projects[] | select(.title == $title) | .number' \
-  | head -1)
+# Resolve viewer login + id from the same token we'll use for everything else.
+echo "Resolving authenticated user..."
+VIEWER_JSON=$(gh api graphql -f query='{ viewer { id login } }')
+VIEWER_LOGIN=$(echo "$VIEWER_JSON" | jq -r '.data.viewer.login')
+VIEWER_ID=$(echo "$VIEWER_JSON" | jq -r '.data.viewer.id')
+if [[ -z "$VIEWER_LOGIN" || -z "$VIEWER_ID" ]]; then
+  echo "ERROR: could not resolve viewer (auth missing or token lacks identity scopes)" >&2
+  exit 1
+fi
+echo "Authenticated as $VIEWER_LOGIN"
 
-if [[ -n "$EXISTING_NUMBER" ]]; then
-  echo "Project already exists: #$EXISTING_NUMBER"
-  PROJECT_NUMBER="$EXISTING_NUMBER"
-else
-  echo "Creating project '$TITLE'..."
-  PROJECT_NUMBER=$(gh project create --owner "$OWNER" --title "$TITLE" --format json \
-    | jq -r '.number')
-  echo "Created project #$PROJECT_NUMBER"
+if [[ -z "$OWNER" ]]; then
+  OWNER="$VIEWER_LOGIN"
+fi
+if [[ "$OWNER" != "$VIEWER_LOGIN" ]]; then
+  echo "WARN: --owner $OWNER differs from authenticated viewer $VIEWER_LOGIN — script only manages projects under the authenticated user." >&2
+  echo "       Re-auth as $OWNER (or pass --owner $VIEWER_LOGIN) and re-run." >&2
+  exit 1
 fi
 
-PROJECT_URL="https://github.com/users/$OWNER/projects/$PROJECT_NUMBER"
+echo "Looking up existing project '$TITLE' under viewer..."
+EXISTING_JSON=$(gh api graphql -f query='
+  query($login: String!) {
+    user(login: $login) {
+      projectsV2(first: 100) {
+        nodes { id number title }
+      }
+    }
+  }' -f login="$VIEWER_LOGIN")
+PROJECT_ID=$(echo "$EXISTING_JSON" | jq -r --arg title "$TITLE" \
+  '.data.user.projectsV2.nodes[] | select(.title == $title) | .id' | head -1)
+PROJECT_NUMBER=$(echo "$EXISTING_JSON" | jq -r --arg title "$TITLE" \
+  '.data.user.projectsV2.nodes[] | select(.title == $title) | .number' | head -1)
+
+if [[ -n "$PROJECT_ID" && "$PROJECT_ID" != "null" ]]; then
+  echo "Project already exists: #$PROJECT_NUMBER ($PROJECT_ID)"
+else
+  echo "Creating project '$TITLE'..."
+  CREATE_JSON=$(gh api graphql -f query='
+    mutation($ownerId: ID!, $title: String!) {
+      createProjectV2(input: { ownerId: $ownerId, title: $title }) {
+        projectV2 { id number title }
+      }
+    }' -f ownerId="$VIEWER_ID" -f title="$TITLE")
+  PROJECT_ID=$(echo "$CREATE_JSON" | jq -r '.data.createProjectV2.projectV2.id')
+  PROJECT_NUMBER=$(echo "$CREATE_JSON" | jq -r '.data.createProjectV2.projectV2.number')
+  if [[ -z "$PROJECT_ID" || "$PROJECT_ID" == "null" ]]; then
+    echo "ERROR: createProjectV2 returned no id. Raw response:" >&2
+    echo "$CREATE_JSON" >&2
+    exit 1
+  fi
+  echo "Created project #$PROJECT_NUMBER ($PROJECT_ID)"
+fi
+
+PROJECT_URL="https://github.com/users/$VIEWER_LOGIN/projects/$PROJECT_NUMBER"
 echo "Project URL: $PROJECT_URL"
 
 # Find the Status single-select field. New projects ship with one named
-# "Status" already; if it's been renamed, we error out instead of guessing.
+# "Status"; if it's been renamed, we error out instead of guessing.
 echo "Locating Status field..."
-FIELDS_JSON=$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 100)
-STATUS_FIELD=$(echo "$FIELDS_JSON" \
-  | jq -r '.fields[] | select(.name == "Status" and .type == "ProjectV2SingleSelectField")')
-if [[ -z "$STATUS_FIELD" ]]; then
-  echo "ERROR: project $PROJECT_NUMBER has no single-select field named 'Status'." >&2
-  echo "       Rename or recreate the Status field, then re-run this script." >&2
-  exit 1
-fi
-STATUS_FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
-
-EXISTING_OPTIONS=$(echo "$STATUS_FIELD" | jq -r '.options[].name')
-echo "Existing Status options: $(echo "$EXISTING_OPTIONS" | paste -sd, -)"
-
-# Compute the union of existing + desired option names. Order matters in the
-# UI, so we always set the full list (not just additions). This is also
-# idempotent: passing the same set twice is a no-op server-side.
-DESIRED_JSON=$(printf '%s\n' "${STATUS_OPTIONS[@]}" \
-  | jq -R '{name: ., color: "GRAY", description: ""}' \
-  | jq -s '.')
-
-# Colour each option to roughly mirror the labels.
-COLOURED_JSON=$(echo "$DESIRED_JSON" | jq '
-  map(
-    .color = (
-      {
-        "Backlog":     "GRAY",
-        "Ready":       "GREEN",
-        "Planning":    "BLUE",
-        "Plan Review": "PURPLE",
-        "In Progress": "YELLOW",
-        "In Review":   "BLUE",
-        "In Test":     "GREEN",
-        "Approved":    "GREEN",
-        "Released":    "GREEN",
-        "Done":        "GRAY",
-        "Blocked":     "RED"
-      }[.name] // "GRAY"
-    )
-  )')
-
-echo "Updating Status field options (idempotent)..."
-gh api graphql -f query='
-  mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
-    updateProjectV2Field(input: {
-      fieldId: $fieldId
-      singleSelectOptions: $options
-    }) {
-      projectV2Field {
-        ... on ProjectV2SingleSelectField {
-          id
-          options { id name }
+FIELDS_JSON=$(gh api graphql -f query='
+  query($projectId: ID!) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        fields(first: 50) {
+          nodes {
+            __typename
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              options { id name }
+            }
+          }
         }
       }
     }
-  }' \
-  -f fieldId="$STATUS_FIELD_ID" \
-  -F options="$COLOURED_JSON" >/dev/null
+  }' -f projectId="$PROJECT_ID")
+STATUS_FIELD_ID=$(echo "$FIELDS_JSON" | jq -r '
+  .data.node.fields.nodes[]
+  | select(.__typename == "ProjectV2SingleSelectField" and .name == "Status")
+  | .id' | head -1)
+if [[ -z "$STATUS_FIELD_ID" || "$STATUS_FIELD_ID" == "null" ]]; then
+  echo "ERROR: project $PROJECT_NUMBER has no single-select field named 'Status'." >&2
+  echo "       Rename or recreate the Status field via the project UI, then re-run." >&2
+  exit 1
+fi
+EXISTING_OPTIONS=$(echo "$FIELDS_JSON" | jq -r '
+  .data.node.fields.nodes[]
+  | select(.__typename == "ProjectV2SingleSelectField" and .name == "Status")
+  | .options[].name')
+echo "Existing Status options: $(echo "$EXISTING_OPTIONS" | paste -sd, -)"
+
+# Build the desired option list. Order matters in the UI, so we always set
+# the full list (passing the same set twice is a server-side no-op).
+DESIRED_JSON=$(printf '%s\n' "${STATUS_OPTIONS[@]}" \
+  | jq -R '{name: ., color: "GRAY", description: ""}' \
+  | jq -s '
+    map(
+      .color = (
+        {
+          "Backlog":     "GRAY",
+          "Ready":       "GREEN",
+          "Planning":    "BLUE",
+          "Plan Review": "PURPLE",
+          "In Progress": "YELLOW",
+          "In Review":   "BLUE",
+          "In Test":     "GREEN",
+          "Approved":    "GREEN",
+          "Released":    "GREEN",
+          "Done":        "GRAY",
+          "Blocked":     "RED"
+        }[.name] // "GRAY"
+      )
+    )')
+
+echo "Updating Status field options (idempotent)..."
+# `gh api graphql -f` / `-F` can't bind a list variable, so build the full
+# request body in jq and pipe via `--input -`.
+UPDATE_QUERY='mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+  updateProjectV2Field(input: {
+    fieldId: $fieldId
+    singleSelectOptions: $options
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField { id options { id name } }
+    }
+  }
+}'
+UPDATE_BODY=$(jq -n \
+  --arg query "$UPDATE_QUERY" \
+  --arg fieldId "$STATUS_FIELD_ID" \
+  --argjson options "$DESIRED_JSON" \
+  '{ query: $query, variables: { fieldId: $fieldId, options: $options } }')
+UPDATE_RESP=$(echo "$UPDATE_BODY" | gh api graphql --input -)
+if echo "$UPDATE_RESP" | jq -e '.errors' >/dev/null 2>&1; then
+  echo "ERROR: updateProjectV2Field returned errors:" >&2
+  echo "$UPDATE_RESP" | jq '.errors' >&2
+  exit 1
+fi
 
 echo "Status options now: $(IFS=,; echo "${STATUS_OPTIONS[*]}")"
+
+# Add the drafto repo to the project so issues filed there can be added to
+# the board (and so PRs can be auto-added by board workflows). Idempotent —
+# if the link already exists the mutation just returns the same project.
+REPO_NWO="$VIEWER_LOGIN/drafto"
+echo "Linking $REPO_NWO to project..."
+REPO_ID=$(gh api graphql -f query='
+  query($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) { id }
+  }' -f owner="$VIEWER_LOGIN" -f name="drafto" | jq -r '.data.repository.id')
+if [[ -z "$REPO_ID" || "$REPO_ID" == "null" ]]; then
+  echo "WARN: could not resolve repo id for $REPO_NWO; skipping link step." >&2
+else
+  gh api graphql -f query='
+    mutation($projectId: ID!, $repoId: ID!) {
+      linkProjectV2ToRepository(input: { projectId: $projectId, repositoryId: $repoId }) {
+        repository { nameWithOwner }
+      }
+    }' -f projectId="$PROJECT_ID" -f repoId="$REPO_ID" >/dev/null \
+    && echo "Linked $REPO_NWO to project #$PROJECT_NUMBER" \
+    || echo "WARN: link mutation failed (already linked, or token lacks repo write)."
+fi
+
+echo
+echo "Done."
+echo "Project URL: $PROJECT_URL"
 echo
 echo "Next steps:"
-echo "  1. Add this repo as a project source: gh project link $PROJECT_NUMBER --owner $OWNER --repo $OWNER/drafto"
-echo "  2. Add to repo secrets:  FACTORY_PROJECT_TOKEN  (PAT with scopes: project, repo)"
-echo "  3. Smoke test: file an issue, drag to Ready, watch factory-status-mirror.yml apply status:ready."
+echo "  1. Add to repo secrets:  FACTORY_PROJECT_TOKEN  (classic PAT, scopes: repo, project)."
+echo "  2. Smoke test: file an issue (use Factory feature spec template), add to project, drag to Ready, watch Actions for 'Factory Status Mirror'."

--- a/scripts/setup-factory-labels.sh
+++ b/scripts/setup-factory-labels.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# One-shot, idempotent factory label bootstrap.
+#
+# Usage: scripts/setup-factory-labels.sh [--repo <owner/name>]
+#
+# Defaults to JakubAnderwald/drafto. Re-running is safe: existing labels are
+# updated in place via `gh label create --force` (which upserts colour +
+# description), missing labels are created.
+#
+# These labels back the dark-factory state machine documented in
+# docs/features/dark-factory.md and ADR-0026. The status:* set mirrors the
+# Project v2 Status field (see .github/workflows/factory-status-mirror.yml);
+# parity:* and migration-approved are operator gates; factory-pause and
+# factory-failure are kill-switch / failure-trap signals.
+
+set -euo pipefail
+
+REPO="JakubAnderwald/drafto"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,17p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not found on PATH" >&2
+  exit 1
+fi
+
+# Schema: name|color|description. Colours are deliberately spread along the
+# lifecycle (cool → warm → green) so the board reads at a glance.
+LABELS=(
+  # Lifecycle (mirrored from Project v2 Status). Backlog has no label —
+  # it's the implicit "no status:* set" state.
+  "status:ready|0E8A16|Spec complete; factory may plan."
+  "status:planning|1D76DB|Factory is reading the issue and writing a plan."
+  "status:plan-review|5319E7|Plan posted as a comment; awaiting human approval."
+  "status:in-progress|FBCA04|Plan approved; factory is implementing."
+  "status:in-review|0052CC|PR open; factory monitoring CI and review comments."
+  "status:in-test|006B75|Vercel preview ready; awaiting human approval to ship."
+  "status:approved|0E8A16|Approved for release; factory will merge + dispatch."
+  "status:released|2E7D32|Merged + beta channels dispatched (Phase D)."
+  "status:done|0E8A16|Final acceptance from reporter; issue closed."
+  "status:blocked|B60205|Spec incomplete, retry budget exhausted, or hard gate."
+
+  # Operator gates.
+  "factory-pause|D93F0B|Global kill switch — factory exits early when set."
+  "migration-approved|0052CC|Authorises factory to merge a PR with supabase/migrations changes."
+  "factory-failure|B60205|Filed by the factory failure trap when a run errors out."
+
+  # Parity overrides — set by the operator to disable the cross-platform
+  # parity check for legitimate single-platform work.
+  "parity:web-only|C5DEF5|Skip cross-platform parity check (web-only feature)."
+  "parity:mobile-only|C5DEF5|Skip cross-platform parity check (mobile-only feature)."
+  "parity:desktop-only|C5DEF5|Skip cross-platform parity check (desktop-only feature)."
+)
+
+echo "Bootstrapping factory labels on $REPO ($(date '+%Y-%m-%d %H:%M:%S'))"
+for entry in "${LABELS[@]}"; do
+  IFS='|' read -r name color description <<<"$entry"
+  if gh label create "$name" --repo "$REPO" --color "$color" --description "$description" --force >/dev/null 2>&1; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name" >&2
+    exit 1
+  fi
+done
+echo "Done."


### PR DESCRIPTION
## Summary

Wave 1 of the dark-factory rollout (Phase A scope). No agent code yet — this PR establishes the surface area the Phase-A `--plan` agent will plug into next.

- `docs/adr/0026-dark-factory-pipeline.md` records the decision; `docs/features/dark-factory.md` is the operator manual; `docs/operations/factory-runbook.md` covers phase promotion, kill switches, rollback drills, and PAT rotation.
- `scripts/setup-factory-labels.sh` upserts the 16 `status:*` + `parity:*` + `factory-*` labels (idempotent via `gh label create --force`).
- `scripts/setup-factory-board.sh` provisions the **Drafto Factory** Project v2 board and updates the Status field to the lifecycle's 11 values.
- `.github/workflows/factory-status-mirror.yml` mirrors a Project v2 Status field change onto the linked issue's `status:*` label within seconds of a drag — bridges the board (UI) and the agent's label-driven queue.
- `.github/ISSUE_TEMPLATE/factory-feature.yml` enforces the spec contract (What / Acceptance / Affected platforms / Schema / UI / Out of scope).
- `CLAUDE.md` gets a **Dark Factory** section pointing to the operator manual, runbook, and ADR; calls out both human gates and the kill switches.

## What's *not* in this PR

- The Mac-mini agent (`scripts/factory-agent.sh`, `scripts/factory-plan-prompt.md`, etc.) — Wave 3.
- The factory-state libraries (`scripts/lib/factory-state.mjs`, extending `state-cli.mjs`) — Wave 2.
- The launchd plist on the Mac mini — Wave 4 (operator-side, not version-controlled).

The Wave 1 deliverables can land independently because the mirror workflow + labels + board are inert without the agent reading them.

## Test plan

- [ ] CI green (`pnpm lint`, `pnpm format:check`, `pnpm typecheck`).
- [ ] Operator runs `scripts/setup-factory-labels.sh`; verify all 16 labels appear in repo Settings → Labels.
- [ ] Operator runs `scripts/setup-factory-board.sh`; verify a "Drafto Factory" project appears with Status field options Backlog / Ready / Planning / Plan Review / In Progress / In Review / In Test / Approved / Released / Done / Blocked.
- [ ] Operator creates a fine-grained PAT per `docs/operations/factory-runbook.md` and adds it as `FACTORY_PROJECT_TOKEN` repo secret.
- [ ] Smoke test the mirror: file a test issue, add to project, drag Backlog → Ready; verify `status:ready` appears within ~30 s via Actions tab. Drag Ready → Planning; verify label switches with no leftover `status:ready`.

## Related

- ADR-0026 (this PR), supersedes nothing; complements [ADR-0024](./docs/adr/0024-realtime-support-agent.md) and [ADR-0025](./docs/adr/0025-support-allowlist-from-zoho-sender.md).
- Original proposal: `docs/dark-factory-proposal.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)