### PR TITLE
fix(factory-mirror): trigger name is projects_v2_item (plural)

### DIFF
--- a/.github/workflows/factory-status-mirror.yml
+++ b/.github/workflows/factory-status-mirror.yml
@@ -18,7 +18,10 @@ name: Factory Status Mirror
 #   See docs/operations/factory-runbook.md → "Initial setup".
 
 on:
-  project_v2_item:
+  # Note: trigger name is `projects_v2_item` (plural), matching the webhook
+  # event and the `github.event.projects_v2_item.*` payload key. The singular
+  # form does not match any GitHub event and silently never fires.
+  projects_v2_item:
     types: [edited, reopened, restored]
 
 concurrency:


### PR DESCRIPTION
## Summary

One-line fix to the dark-factory mirror workflow's trigger name. GitHub's real event is `projects_v2_item` (plural — with the trailing "s"); my PR #386 used the singular `project_v2_item`, which silently never matches. Result: no `projects_v2_item` events ever fired against the workflow, only the push-discovery runs from when the file itself changed.

The data references inside the workflow (`github.event.projects_v2_item.*`) were already correct — the singular spelling was only in the `on:` clause.

## Test plan

After merge:

- [ ] Open https://github.com/users/JakubAnderwald/projects/1, drag issue #387 from Ready → Planning (or any column change).
- [ ] Within ~30 s, https://github.com/JakubAnderwald/drafto/actions should show a new "Factory Status Mirror" run with `event: projects_v2_item`, conclusion: `success`.
- [ ] Issue #387 should gain `status:planning` and lose `status:ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)