### PR TITLE
feat(support-agent): support-allowlisted label override for sender gate

### DIFF
--- a/docs/features/support-agent.md
+++ b/docs/features/support-agent.md
@@ -99,6 +99,7 @@ The `zoho-thread-id` field is load-bearing — comment-sync uses it to route Git
 1. At filing time, `support-agent.sh` extracts the inbound `fromAddress` from the Zoho bundle (captured BEFORE Claude runs) and persists it to `state.issues[<n>].reporterEmail` via `state-cli.mjs record-filed-issue`.
 2. At gate time, `nightly-support.sh` calls `state-cli.mjs get-reporter-email <n>` and compares the result (case-insensitive, comma-bounded) against `$SUPPORT_ALLOWLIST` from `~/drafto-secrets/support-env.sh`.
 3. Two reject reasons surface: `unknown-sender` (no state entry — legacy / manually-filed / runner failure) and `not-allowlisted`. Either one labels the issue `needs-triage` and posts a comment.
+4. **Manual override**: applying the `support-allowlisted` label (repo collaborators only — GitHub-authenticated, not LLM-mediated) short-circuits the gate. The next nightly run treats the issue as allowlisted regardless of the state entry, and the issue is kept in the queue even if `needs-triage` is also present. Use this for legacy issues filed before sender persistence existed (ADR-0025 "Negative" point) or one-off backfills where the operator can't easily edit `logs/support-state.json` on the Mac mini.
 
 This eliminates the spoof window where a forged `<!-- drafto-support-agent v1 ... reporter-allowlisted: true -->` block in a customer's email body could slip through if the LLM copied it verbatim into the issue body. See [ADR-0025](../adr/0025-support-allowlist-from-zoho-sender.md) for the full rationale.
 

--- a/scripts/nightly-support.sh
+++ b/scripts/nightly-support.sh
@@ -126,9 +126,14 @@ DEPENDABOT_PRS=$(echo "$DEPENDABOT_PRS" | \
 DEPENDABOT_COUNT=$(echo "$DEPENDABOT_PRS" | jq 'length') || DEPENDABOT_COUNT=0
 # Skip support issues already triaged (Phase F gate added needs-triage on a
 # prior run). Dependabot uses the same pattern with needs-review.
+# Exception: if a human triager applied `support-allowlisted` (manual override
+# of the ADR-0025 sender gate, e.g. for legacy issues filed before sender
+# persistence existed), keep the issue in the queue even with needs-triage so
+# the next nightly run picks it up. The Phase F gate below also short-circuits
+# on this label.
 SUPPORT_ISSUES_ALL_COUNT=$(echo "$SUPPORT_ISSUES" | jq -e 'length' 2>/dev/null) || { log "ERROR: Failed to fetch support issues"; SUPPORT_ISSUES_ALL_COUNT=0; }
 SUPPORT_ISSUES=$(echo "$SUPPORT_ISSUES" | \
-  jq '[.[] | select(.labels | map(.name) | index("needs-triage") | not)]') || SUPPORT_ISSUES="[]"
+  jq '[.[] | select((.labels | map(.name) | index("needs-triage") | not) or (.labels | map(.name) | index("support-allowlisted")))]') || SUPPORT_ISSUES="[]"
 SUPPORT_COUNT=$(echo "$SUPPORT_ISSUES" | jq 'length') || SUPPORT_COUNT=0
 SUPPORT_TRIAGED_COUNT=$(( SUPPORT_ISSUES_ALL_COUNT - SUPPORT_COUNT ))
 
@@ -209,25 +214,38 @@ for IDX in $(seq 0 $((SUPPORT_COUNT - 1))); do
   # an LLM-written issue-body footer, eliminates the spoof window where a
   # crafted email could trick the LLM into copying a forged
   # `reporter-allowlisted: true` block into the issue body.
-  REPORTER_EMAIL=$(node "$SCRIPT_DIR/lib/state-cli.mjs" get-reporter-email "$ISSUE_NUMBER" \
-    2>/dev/null || true)
+  #
+  # Manual override: a `support-allowlisted` label, applied by a human
+  # triager (only repo collaborators can add labels — GitHub-authenticated,
+  # not LLM-mediated), short-circuits the gate. This handles legacy issues
+  # filed before sender persistence existed (ADR-0025 "Negative" point) and
+  # any one-off backfill the operator wants to run from outside the Mac mini
+  # without touching state.json directly.
+  HAS_OVERRIDE=$(echo "$ISSUE_ENTRY" | jq -r '.labels // [] | map(.name) | index("support-allowlisted") | tostring')
   GATE_REASON=""
-  if [[ -z "$REPORTER_EMAIL" ]]; then
-    # No state entry. Either a legacy issue filed before ADR-0025, an issue
-    # filed manually outside the agent, or the agent ran but the runner
-    # failed to persist (logged at filing time). Fall through to triage —
-    # human can backfill state if appropriate.
-    GATE_REASON="unknown-sender"
+  REPORTER_EMAIL=""
+  if [[ "$HAS_OVERRIDE" != "null" ]]; then
+    log "Issue #$ISSUE_NUMBER: support-allowlisted label present; bypassing sender gate"
   else
-    # Comma-bounded glob match against the lower-cased CSV. `,X,Y,Z,` always
-    # has commas at both ends so the pattern `*,<email>,*` matches at any
-    # position. state-cli stores reporterEmail already lower-cased; we lower
-    # the allowlist here too so user-edited support-env.sh casing doesn't
-    # leak through.
-    SUPPORT_ALLOWLIST_LC="${SUPPORT_ALLOWLIST,,}"
-    REPORTER_EMAIL_LC="${REPORTER_EMAIL,,}"
-    if [[ ",${SUPPORT_ALLOWLIST_LC}," != *",${REPORTER_EMAIL_LC},"* ]]; then
-      GATE_REASON="not-allowlisted"
+    REPORTER_EMAIL=$(node "$SCRIPT_DIR/lib/state-cli.mjs" get-reporter-email "$ISSUE_NUMBER" \
+      2>/dev/null || true)
+    if [[ -z "$REPORTER_EMAIL" ]]; then
+      # No state entry. Either a legacy issue filed before ADR-0025, an issue
+      # filed manually outside the agent, or the agent ran but the runner
+      # failed to persist (logged at filing time). Fall through to triage —
+      # human can backfill state or apply `support-allowlisted` to bypass.
+      GATE_REASON="unknown-sender"
+    else
+      # Comma-bounded glob match against the lower-cased CSV. `,X,Y,Z,` always
+      # has commas at both ends so the pattern `*,<email>,*` matches at any
+      # position. state-cli stores reporterEmail already lower-cased; we lower
+      # the allowlist here too so user-edited support-env.sh casing doesn't
+      # leak through.
+      SUPPORT_ALLOWLIST_LC="${SUPPORT_ALLOWLIST,,}"
+      REPORTER_EMAIL_LC="${REPORTER_EMAIL,,}"
+      if [[ ",${SUPPORT_ALLOWLIST_LC}," != *",${REPORTER_EMAIL_LC},"* ]]; then
+        GATE_REASON="not-allowlisted"
+      fi
     fi
   fi
   if [[ -n "$GATE_REASON" ]]; then


### PR DESCRIPTION
## Summary

- Adds a `support-allowlisted` label that short-circuits ADR-0025's state-based sender gate in `scripts/nightly-support.sh`.
- Issue selection filter now keeps issues with `support-allowlisted` even when `needs-triage` is also present, so the next nightly run picks them up.
- Trust model unchanged: only repo collaborators can apply labels (GitHub-auth, not LLM-mediated).

## Why

Issue #360 was rejected with `reason: unknown-sender` — it was filed on 2026-04-29 (before #371's sender-based gate was merged on 2026-05-04), so `state.issues["360"].reporterEmail` was never populated on the Mac mini. ADR-0025 already flagged this case under "Negative":

> Legacy issues filed before this change have no state entry and now hit the gate with `reason: unknown-sender`. Issue #361 specifically requires a one-off backfill … on the Mac mini before its next nightly run picks it up.

The label-override gives operators a way to do that backfill from anywhere with `gh` access, without touching `logs/support-state.json` directly.

## Test plan

- [ ] Apply `support-allowlisted` to issue #360, remove `needs-triage`, and confirm the next nightly run processes it (gate log: "support-allowlisted label present; bypassing sender gate").
- [x] Bash syntax check passes (`bash -n scripts/nightly-support.sh`).
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm format:check` all pass.
- [x] `node --test scripts/__tests__/state-cli-reporter-email.test.mjs scripts/__tests__/parse-issue-footer.test.mjs scripts/__tests__/policy.test.mjs` — 49/49 pass.
- [x] jq filter exercised against synthetic label sets (issues with `needs-triage` only are skipped; with `support-allowlisted` are kept; with both are kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual override for the support allowlist gate: collaborators can now apply the `support-allowlisted` GitHub label to bypass sender allowlist checks and ensure issues remain queued for processing.

* **Documentation**
  * Updated documentation to describe the new GitHub label override capability and clarify the spoofing-resistant email validation mechanism used in sender allowlist checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->