### PR TITLE
fix(web): move collapsed-pane expand handles into per-pane rails

### DIFF
--- a/apps/web/__tests__/integration/app-shell.test.tsx
+++ b/apps/web/__tests__/integration/app-shell.test.tsx
@@ -1407,7 +1407,7 @@ describe("AppShell", () => {
       expect(screen.getByLabelText("Collapse note list")).toBeInTheDocument();
     });
 
-    it("does not render the editor expand toolbar when both panes are expanded", async () => {
+    it("does not render expand rails when both panes are expanded", async () => {
       await act(async () => {
         render(<AppShell />);
       });
@@ -1416,7 +1416,8 @@ describe("AppShell", () => {
         expect(screen.getByText("Notebooks")).toBeInTheDocument();
       });
 
-      expect(screen.queryByTestId("editor-expand-toolbar")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("notebooks-rail")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("notes-rail")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Show notebook list")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Show note list")).not.toBeInTheDocument();
     });
@@ -1465,7 +1466,7 @@ describe("AppShell", () => {
       expect(screen.getByLabelText("Show note list")).toBeInTheDocument();
     });
 
-    it("expanding from the editor toolbar restores the pane", async () => {
+    it("expanding from the rail restores the pane", async () => {
       const user = userEvent.setup();
 
       await act(async () => {
@@ -1488,6 +1489,7 @@ describe("AppShell", () => {
       });
       expect(notebooksPane.className).not.toContain("lg:hidden");
       expect(screen.queryByLabelText("Show notebook list")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("notebooks-rail")).not.toBeInTheDocument();
     });
 
     it("each pane collapses independently", async () => {
@@ -1518,9 +1520,69 @@ describe("AppShell", () => {
       expect(notebooksPane.className).toContain("lg:hidden");
       expect(notesPane.className).toContain("lg:hidden");
 
-      // Toolbar should now offer both expand handles
+      // Each collapsed pane should be replaced by its own rail
+      expect(screen.getByTestId("notebooks-rail")).toBeInTheDocument();
+      expect(screen.getByTestId("notes-rail")).toBeInTheDocument();
       expect(screen.getByLabelText("Show notebook list")).toBeInTheDocument();
       expect(screen.getByLabelText("Show note list")).toBeInTheDocument();
+    });
+
+    it("collapsing notebooks renders a rail before the notes pane, not inside the editor", async () => {
+      const user = userEvent.setup();
+
+      const { container } = await act(async () => {
+        return render(<AppShell />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Notebooks")).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        await user.click(screen.getByLabelText("Collapse notebook list"));
+      });
+
+      const rail = screen.getByTestId("notebooks-rail");
+      const notesPane = screen.getByTestId("notes-pane");
+      const main = container.querySelector("main");
+
+      // The rail sits between the notebooks pane and the notes pane so the user
+      // can clearly see which column the expand handle belongs to.
+      expect(
+        rail.compareDocumentPosition(notesPane) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(main?.contains(rail)).toBe(false);
+      expect(notesPane.contains(rail)).toBe(false);
+
+      const expandBtn = screen.getByLabelText("Show notebook list");
+      expect(rail.contains(expandBtn)).toBe(true);
+    });
+
+    it("collapsing notes renders a rail between the notebooks pane and the editor", async () => {
+      const user = userEvent.setup();
+
+      const { container } = await act(async () => {
+        return render(<AppShell />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Notebooks")).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        await user.click(screen.getByLabelText("Collapse note list"));
+      });
+
+      const rail = screen.getByTestId("notes-rail");
+      const aside = container.querySelector("aside");
+      const main = container.querySelector("main");
+
+      expect(aside?.compareDocumentPosition(rail) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      expect(rail.compareDocumentPosition(main!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      expect(main?.contains(rail)).toBe(false);
+
+      const expandBtn = screen.getByLabelText("Show note list");
+      expect(rail.contains(expandBtn)).toBe(true);
     });
 
     it("persists collapse state across remounts via localStorage", async () => {

--- a/apps/web/__tests__/integration/app-shell.test.tsx
+++ b/apps/web/__tests__/integration/app-shell.test.tsx
@@ -1545,13 +1545,14 @@ describe("AppShell", () => {
       const rail = screen.getByTestId("notebooks-rail");
       const notesPane = screen.getByTestId("notes-pane");
       const main = container.querySelector("main");
+      if (!main) throw new Error("main element should be present");
 
       // The rail sits between the notebooks pane and the notes pane so the user
       // can clearly see which column the expand handle belongs to.
       expect(
         rail.compareDocumentPosition(notesPane) & Node.DOCUMENT_POSITION_FOLLOWING,
       ).toBeTruthy();
-      expect(main?.contains(rail)).toBe(false);
+      expect(main.contains(rail)).toBe(false);
       expect(notesPane.contains(rail)).toBe(false);
 
       const expandBtn = screen.getByLabelText("Show notebook list");
@@ -1576,10 +1577,11 @@ describe("AppShell", () => {
       const rail = screen.getByTestId("notes-rail");
       const aside = container.querySelector("aside");
       const main = container.querySelector("main");
+      if (!aside || !main) throw new Error("aside and main should both be present");
 
-      expect(aside?.compareDocumentPosition(rail) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-      expect(rail.compareDocumentPosition(main!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-      expect(main?.contains(rail)).toBe(false);
+      expect(aside.compareDocumentPosition(rail) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      expect(rail.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      expect(main.contains(rail)).toBe(false);
 
       const expandBtn = screen.getByLabelText("Show note list");
       expect(rail.contains(expandBtn)).toBe(true);

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -468,6 +468,24 @@ export function AppShell({
         </div>
       </aside>
 
+      {/* Notebooks expand rail — replaces the notebooks pane when collapsed on desktop.
+          Sits in the column position the notebooks pane occupied, so users can tell
+          which pane the expand handle controls. */}
+      {notebooksCollapsed && (
+        <div
+          data-testid="notebooks-rail"
+          className="bg-sidebar-bg border-border hidden w-11 shrink-0 flex-col items-center border-r p-2 lg:flex"
+        >
+          <IconButton
+            size="sm"
+            onClick={() => togglePane("notebooks")}
+            aria-label="Show notebook list"
+          >
+            <PanelExpandIcon />
+          </IconButton>
+        </div>
+      )}
+
       {/* Middle panel — note list or trash
           Mobile: full-width panel, shown only in notes view
           Tablet/Desktop: fixed 300px width (unless collapsed on desktop) */}
@@ -540,6 +558,20 @@ export function AppShell({
         )}
       </section>
 
+      {/* Notes expand rail — replaces the notes pane when collapsed on desktop.
+          Sits between the notebooks pane (or its rail) and the editor, in the
+          column position the notes pane occupied. */}
+      {notesCollapsed && (
+        <div
+          data-testid="notes-rail"
+          className="bg-bg border-border hidden w-11 shrink-0 flex-col items-center border-r p-2 lg:flex"
+        >
+          <IconButton size="sm" onClick={() => togglePane("notes")} aria-label="Show note list">
+            <PanelExpandIcon />
+          </IconButton>
+        </div>
+      )}
+
       {/* Main panel — editor
           Mobile: full-width panel, shown only in editor view
           Tablet/Desktop: fills remaining space */}
@@ -555,29 +587,6 @@ export function AppShell({
               <ChevronLeftIcon />
             </IconButton>
             <span className="text-fg ml-1 text-sm font-semibold">Back</span>
-          </div>
-        )}
-
-        {/* Desktop: expand handles for collapsed panes */}
-        {(notebooksCollapsed || notesCollapsed) && (
-          <div
-            className="bg-bg-subtle hidden items-center gap-1 p-2 lg:flex"
-            data-testid="editor-expand-toolbar"
-          >
-            {notebooksCollapsed && (
-              <IconButton
-                size="sm"
-                onClick={() => togglePane("notebooks")}
-                aria-label="Show notebook list"
-              >
-                <PanelExpandIcon />
-              </IconButton>
-            )}
-            {notesCollapsed && (
-              <IconButton size="sm" onClick={() => togglePane("notes")} aria-label="Show note list">
-                <PanelExpandIcon />
-              </IconButton>
-            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

When the notebook (left) pane was collapsed on the web app, the expand button (`»`) ended up inside the editor's top toolbar — directly adjacent to the notes pane's collapse button (`«`). The two buttons looked like a single button group, so users couldn't tell which pane each chevron controlled (reported in #360).

This change moves each expand handle into its own thin rail that occupies the column position of the pane it replaces:

- **Notebooks rail** — `bg-sidebar-bg`, sits at the far left where the notebooks pane was, with a right border separating it from the notes pane.
- **Notes rail** — `bg-bg`, sits between the notebooks pane (or its rail) and the editor, with a right border separating it from the editor.

The expand handles are no longer rendered inside `<main>`, so the editor's chrome stays clean and each handle is visually anchored to the column whose pane it controls.

Closes #360

## Test plan

- [x] `pnpm --filter @drafto/web test` — 711/711 pass, including new regression tests:
  - `does not render expand rails when both panes are expanded`
  - `expanding from the rail restores the pane`
  - `collapsing notebooks renders a rail before the notes pane, not inside the editor`
  - `collapsing notes renders a rail between the notebooks pane and the editor`
- [x] `pnpm --filter=@drafto/shared test` — 237/237 pass
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [ ] Manual sanity in browser: collapse notebooks → expand handle now sits in its own left-edge rail, clearly separate from the notes-collapse button (matches issue's "Expected" behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned the desktop layout for collapsed panes: when notebooks or notes are collapsed, dedicated side rails appear next to their columns, replacing the previous editor-area toolbar controls for expanding panes.
* **Tests**
  * Updated integration tests to verify rail-based expand/collapse behavior, presence/placement of rails when panes are collapsed, and correct restore behavior when expanding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JakubAnderwald/drafto/pull/404)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->