### PR TITLE
docs(dark-factory): drop retired mirror-workflow refs

### DIFF
--- a/docs/features/dark-factory.md
+++ b/docs/features/dark-factory.md
@@ -34,7 +34,7 @@ The board has one custom Status field with eleven values:
 | Done        | human / support-agent | Final acceptance; issue closed.                                       |
 | Blocked     | factory               | Spec incomplete, retry budget exhausted, parity violation, hard gate. |
 
-Each Status maps 1:1 to a `status:*` label via `.github/workflows/factory-status-mirror.yml`. The factory agent reads labels, not Project v2 fields.
+The factory agent reads the Status field directly via the GitHub GraphQL API on each 5-min tick. It also writes a matching `status:*` label as a transition side-effect (for filtering on the Issues list); the labels are observability, not the agent's queue.
 
 ## Label glossary
 
@@ -42,15 +42,15 @@ The full set is created idempotently by `scripts/setup-factory-labels.sh`. Refer
 
 | Label                 | Set by               | Meaning                                                          |
 | --------------------- | -------------------- | ---------------------------------------------------------------- |
-| `status:ready`        | mirror workflow      | Spec accepted; factory may plan.                                 |
+| `status:ready`        | human (via board)    | Spec accepted; factory may plan.                                 |
 | `status:planning`     | factory              | Plan in progress.                                                |
 | `status:plan-review`  | factory              | Awaiting plan approval.                                          |
-| `status:in-progress`  | mirror / factory     | Implementation in progress.                                      |
+| `status:in-progress`  | human / factory      | Implementation in progress.                                      |
 | `status:in-review`    | factory              | PR open, CI / review comments active.                            |
 | `status:in-test`      | factory              | Vercel preview ready, awaiting ship approval.                    |
-| `status:approved`     | mirror / factory     | Approved for release; merge + dispatch authorised.               |
+| `status:approved`     | human / factory      | Approved for release; merge + dispatch authorised.               |
 | `status:released`     | factory              | Merged + beta dispatched.                                        |
-| `status:done`         | mirror / support     | Final acceptance.                                                |
+| `status:done`         | human / support      | Final acceptance.                                                |
 | `status:blocked`      | factory              | Hard stop — see comment on issue.                                |
 | `factory-pause`       | operator             | Global kill switch on this issue (factory ignores).              |
 | `migration-approved`  | operator             | Authorises factory to merge a PR with `supabase/migrations` SQL. |
@@ -70,7 +70,7 @@ Use the **Factory feature spec** template (`.github/ISSUE_TEMPLATE/factory-featu
 5. **UI?** — screenshot / Figma URL if applicable.
 6. **Out of scope** — explicit non-goals.
 
-After filing, drag the card to **Ready** on the board. The mirror workflow applies `status:ready` within seconds; the factory picks it up on its next 5-min tick.
+After filing, drag the card to **Ready** on the board. The factory picks it up on its next 5-min tick — it queries the board's Status field directly, then applies the `status:ready` label as a side-effect for filtering on the Issues list.
 
 ## Kill switches
 
@@ -82,9 +82,9 @@ After filing, drag the card to **Ready** on the board. The mirror workflow appli
 
 ### "I dragged a card but the factory didn't pick it up"
 
-1. Check the workflow ran: GitHub → Actions → "Factory Status Mirror". Look for a successful run within the last minute.
-2. If the workflow ran but the issue's labels didn't change: check the run's "Apply label" step output. Common causes: PAT expired (`FACTORY_PROJECT_TOKEN` secret), or the Status value isn't in the workflow's case statement (typo on a Status rename — update both `setup-factory-board.sh` and the workflow case).
-3. If the label IS correct but the factory doesn't act: check `logs/factory-*.log` on the Mac mini. The agent might be paused (`factory-pause` global flag), out of retry budget for that issue, or holding both worktree slots on other issues.
+1. The factory polls every 5 minutes; wait one tick. Confirm the launchd job is alive on the Mac mini: `launchctl list | grep eu.drafto.factory`. PID column `-` with exit `0` is normal between ticks; a non-zero exit means the last tick failed — check `logs/launchd-factory-stderr.log`.
+2. Check the agent saw the card on its latest tick: `logs/launchd-factory-stdout.log` (or `logs/factory-plan-*.log`) should mention the board fetch. A `factory-project find-project failed` warning means the `gh` token on the Mac mini is missing the `project` scope — run `gh auth refresh -s project`.
+3. If the tick ran and the card was in scope but ignored: check the issue for a `factory-pause` label, or `logs/factory-state.json` for a global `paused: true` flag, or the issue's retry budget under `issues[<n>].attempts`.
 
 ### "The plan comment looks wrong / Claude misread the issue"
 
@@ -115,5 +115,4 @@ Check `logs/support/support-agent-*.log` for the per-thread classification line.
 - [`docs/dark-factory-proposal.md`](../dark-factory-proposal.md) — original proposal (lifecycle table, household autopilot details, implementation waves).
 - [`scripts/setup-factory-labels.sh`](../../scripts/setup-factory-labels.sh) — label bootstrap.
 - [`scripts/setup-factory-board.sh`](../../scripts/setup-factory-board.sh) — Project v2 board bootstrap.
-- [`.github/workflows/factory-status-mirror.yml`](../../.github/workflows/factory-status-mirror.yml) — Status field → label mirror.
 - [`.github/ISSUE_TEMPLATE/factory-feature.yml`](../../.github/ISSUE_TEMPLATE/factory-feature.yml) — spec contract template.

--- a/docs/operations/factory-runbook.md
+++ b/docs/operations/factory-runbook.md
@@ -31,46 +31,51 @@ Run these in order, on a workstation with `gh` authenticated as the project owne
 
    Without this, issues filed in the repo don't auto-add to the board.
 
-4. **Create a PAT for the mirror workflow.**
+4. **Grant `gh` the `project` scope on the Mac mini.**
 
-   Use a **classic PAT** rather than a fine-grained one. Projects v2 access via fine-grained PATs is gated on an Account-tab "Projects" permission that is unreliably surfaced for personal accounts (search filters return "No items available"). Classic PATs cover Projects v2 out of the box.
-   - GitHub → Settings → Developer settings → Personal access tokens → **Tokens (classic)** → Generate new token (classic).
-   - Note: name it something like "drafto factory mirror".
-   - Scopes:
-     - `repo` (full) — covers issue label edits on `JakubAnderwald/drafto`.
-     - `project` — Projects v2 read.
-   - Expiration: 90 days (set a calendar reminder to rotate; rotation is in this runbook).
+   The agent reads and writes the Project v2 board directly via the GitHub GraphQL API — there is no Action mirror. Refresh the existing token on the Mac mini to add Projects v2 read+write:
 
-   Classic PATs are user-wide rather than repo-scoped, which is a slightly larger blast radius than fine-grained — for a single-user, single-repo project this is an acceptable tradeoff for "always works". If you'd rather use fine-grained, the equivalent is **Repositories → Issues: Read+Write, Metadata: Read-only** plus **Account → Projects: Read-only** — the Account permission only appears in the search if your account context exposes it.
+   ```bash
+   gh auth refresh -s project
+   ```
 
-5. **Add the PAT to repo secrets.**
-   - Repo → Settings → Secrets and variables → Actions → New repository secret.
-   - Name: `FACTORY_PROJECT_TOKEN`.
-   - Value: the PAT from step 4.
+   Verify with `gh auth status` — the listed scopes should include `project`. Without it the agent's first board read fails on every tick with a `factory-project find-project failed` warning.
 
-6. **Smoke test the mirror.**
-   - File any issue. Add it to the board. Drag the card to **Ready**.
-   - Within ~30 s, the issue should gain `status:ready`. Confirm via Actions tab → "Factory Status Mirror" → most recent run.
-   - If it doesn't, see "Mirror workflow failing" below.
+5. **Install the factory launchd job.**
 
-7. **Install the factory launchd job.** (Wave 4 — does not apply at Phase A until the agent code lands.)
+   On the Mac mini, drop a plist at `~/Library/LaunchAgents/eu.drafto.factory.plist` modelled on `eu.drafto.support-agent.plist` with:
+   - `Label = eu.drafto.factory`
+   - `ProgramArguments = [/bin/bash, /Users/jakub/code/drafto/scripts/factory-agent-loop.sh]`
+   - `StartInterval = 300` (5 min)
+   - `EnvironmentVariables.FACTORY_PHASE = A`
+   - Stdout/stderr paths under `logs/launchd-factory-*.log`
+
+   Then load and smoke-test:
+
+   ```bash
+   launchctl load -w ~/Library/LaunchAgents/eu.drafto.factory.plist
+   launchctl kickstart -k "gui/$(id -u)/eu.drafto.factory"
+   tail -f /Users/jakub/code/drafto/logs/launchd-factory-stdout.log
+   ```
+
+   The first tick should log `=== factory-agent --plan run started (phase=A …) ===` followed by `=== factory-agent --plan completed in <N>s ===`. Subsequent ticks fire every 5 min.
 
 ## Phase progression criteria
 
 | Promote from → to | Required signals before promotion                                                                                                                                                                                                                                                                                                                                                                   |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| (initial) → A     | Setup steps 1–6 above complete. `factory-status-mirror.yml` mirrors a manual board move within 30 s.                                                                                                                                                                                                                                                                                                |
+| (initial) → A     | Setup steps 1–5 above complete. `launchctl list \| grep eu.drafto.factory` shows the job registered, and a manual `launchctl kickstart` logs a clean `--plan` tick (board fetched, no `factory-failure` issue filed).                                                                                                                                                                               |
 | A → B             | ≥5 successful `--plan` runs (Ready → Planning → Plan Review with a usable plan comment). Zero `factory-failure` issues. Operator has read at least 3 plans and judges they were accurate enough to act on. `--implement` no-op confirmed: dragging Plan Review → In Progress in Phase A logs a "phase=A; implementation skipped" comment and leaves the card in In Progress without further action. |
 | B → C             | ≥5 successful end-to-end web-only runs (Ready → Plan Review → In Progress → In Review → In Test → Approved → Released → Done). Zero parity violations. SonarCloud quality gate green on all factory-authored PRs.                                                                                                                                                                                   |
 | C → D             | ≥5 successful runs that include mobile or desktop changes. Operator manually fired beta dispatches (TestFlight, Play internal) per Phase C — confirms the dispatch payloads work before the factory automates them.                                                                                                                                                                                 |
 | D → (steady)      | ≥10 successful Released cards in Phase D. Beta dispatch path validated for both iOS and Android. Mac TestFlight lane runs locally on the Mac mini per the existing release pattern.                                                                                                                                                                                                                 |
 
-Promote by editing the launchd plist's `--phase` argument and reloading:
+Promote by editing the `FACTORY_PHASE` env var in the launchd plist and reloading:
 
 ```bash
 launchctl unload ~/Library/LaunchAgents/eu.drafto.factory.plist
-# edit plist, change --phase A → --phase B (or B → C, etc.)
-launchctl load ~/Library/LaunchAgents/eu.drafto.factory.plist
+# edit plist: EnvironmentVariables → FACTORY_PHASE: A → B (or B → C, etc.)
+launchctl load -w ~/Library/LaunchAgents/eu.drafto.factory.plist
 ```
 
 There is no "auto-promote". The phase change is always a deliberate operator action so a regression at one phase can't silently unlock the next.
@@ -113,19 +118,6 @@ The factory's `cleanup()` trap files a `factory-failure`-labelled GitHub issue w
 4. **Close the failure issue** once resolved. The trap doesn't auto-close; that's intentional so the issue is visible until acknowledged.
 
 If the same failure mode files >3 issues in 24h, pause the factory globally (`factory:pause`) and open a regular bug to fix the root cause.
-
-## PAT rotation
-
-The `FACTORY_PROJECT_TOKEN` PAT expires every 90 days (per setup step 4). When it expires, the mirror workflow fails — board moves stop translating to labels and the factory queue silently empties.
-
-To rotate:
-
-1. Generate a new classic PAT with the same scopes as setup step 4 (`repo`, `project`).
-2. Update the `FACTORY_PROJECT_TOKEN` secret value in repo settings.
-3. Smoke-test by dragging a Backlog card to Ready and back; the workflow should run twice and the labels should toggle.
-4. Set a new 90-day calendar reminder.
-
-The launchd plist on the Mac mini does **not** use this PAT — `gh` on the Mac mini authenticates separately via `gh auth login`. Don't confuse the two.
 
 ## Coexistence with `nightly-support.sh` Phase 3
 

--- a/scripts/setup-factory-board.sh
+++ b/scripts/setup-factory-board.sh
@@ -47,8 +47,8 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # Status options must match the labels created by setup-factory-labels.sh
-# AND the parser in .github/workflows/factory-status-mirror.yml. Keep all
-# three in sync.
+# AND the status-name → label mapping in scripts/lib/factory-project.mjs.
+# Keep all three in sync.
 STATUS_OPTIONS=(
   "Backlog"
   "Ready"
@@ -232,5 +232,5 @@ echo "Done."
 echo "Project URL: $PROJECT_URL"
 echo
 echo "Next steps:"
-echo "  1. Add to repo secrets:  FACTORY_PROJECT_TOKEN  (classic PAT, scopes: repo, project)."
-echo "  2. Smoke test: file an issue (use Factory feature spec template), add to project, drag to Ready, watch Actions for 'Factory Status Mirror'."
+echo "  1. On the Mac mini, ensure 'gh auth status' lists the 'project' scope (run 'gh auth refresh -s project' if not)."
+echo "  2. Install the factory launchd job per docs/operations/factory-runbook.md, then smoke-test by filing an issue (Factory feature spec template), dragging the card to Ready, and tailing logs/launchd-factory-stdout.log."

--- a/scripts/setup-factory-labels.sh
+++ b/scripts/setup-factory-labels.sh
@@ -9,7 +9,7 @@
 #
 # These labels back the dark-factory state machine documented in
 # docs/features/dark-factory.md and ADR-0026. The status:* set mirrors the
-# Project v2 Status field (see .github/workflows/factory-status-mirror.yml);
+# Project v2 Status field (the agent writes them as transition side-effects);
 # parity:* and migration-approved are operator gates; factory-pause and
 # factory-failure are kill-switch / failure-trap signals.
 


### PR DESCRIPTION
## Summary

- The Path-A pivot retired `.github/workflows/factory-status-mirror.yml` and replaced it with direct Project v2 GraphQL reads/writes from `scripts/lib/factory-project.mjs`. Wave 4 (launchd install) shipped today on the Mac mini.
- Operator docs + bootstrap scripts still referenced the old workflow (PAT setup, `FACTORY_PROJECT_TOKEN` secret, "Factory Status Mirror" Actions run), which would actively misdirect anyone re-bootstrapping the factory or debugging a stuck card.
- This PR drops those refs and replaces them with the actual install + debug procedure that matches what's live.

## Changes

- **`docs/operations/factory-runbook.md`** — removed PAT setup steps 4–6 and the PAT rotation section. Added step 4 (`gh auth refresh -s project` on the Mac mini) and step 5 (launchd plist + smoke test). Fixed the phase-promotion command to edit `FACTORY_PHASE` env var instead of a (non-existent) `--phase` CLI arg on the plist.
- **`docs/features/dark-factory.md`** — rewrote the Status→label sentence (agent writes labels as a transition side-effect, not via an Action), updated the "Set by" column in the label glossary (no more "mirror workflow"), and rewrote the "card not picked up" troubleshooting bullet to point at the launchd job + project-scope check instead of the Actions run history. Dropped the workflow link from the Related section.
- **`scripts/setup-factory-board.sh`** — updated the inline comment about Status options and the final "Next steps" output (no more "Add `FACTORY_PROJECT_TOKEN` to repo secrets"; instead, refresh `gh` auth + install launchd job).
- **`scripts/setup-factory-labels.sh`** — one-line comment cleanup.

## Out of scope

- **ADR-0026** intentionally untouched — ADRs are append-only per `CLAUDE.md`, and the original decision is still a valid historical record. The proposal (`docs/dark-factory-proposal.md`) already documents the Path-A pivot at the top.
- The factory `--implement` `#null` warnings (issue #414) — separate bug, separate fix.

## Test plan

- [x] `grep -rn "factory-status-mirror\|FACTORY_PROJECT_TOKEN\|mirror workflow" docs/ scripts/ .github/ CLAUDE.md` returns nothing in the cleanup scope (ADR-0026 + proposal are intentional historical references).
- [x] Runbook step 4 (`gh auth refresh -s project`) verified working — used it for the Wave 4 install earlier today.
- [x] Runbook step 5 (launchd install) matches the actual plist now running on the Mac mini.
- [x] Worktree's `git diff --stat`: 4 files, +41/-50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)