### PR TITLE
fix(dark-factory): stop --implement noise on empty In Progress column

### DIFF
--- a/scripts/__tests__/factory-agent-implement.test.mjs
+++ b/scripts/__tests__/factory-agent-implement.test.mjs
@@ -1,0 +1,48 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+// Regression test for issue #414. The `--implement` block in
+// scripts/factory-agent.sh used `for IDX in $(seq 0 $((INPROG_COUNT - 1)))`
+// which, when INPROG_COUNT=0, becomes `seq 0 -1`. BSD seq (macOS) auto-flips
+// to a descending sequence and prints "0\n-1", so the loop ran twice with
+// bogus indices and called fetch_issue_comments with the literal string
+// "null". This locks in the C-style for-loop form that handles count=0
+// correctly across platforms.
+
+function runBash(snippet) {
+  const result = spawnSync("bash", ["-c", snippet], { encoding: "utf8" });
+  assert.equal(result.status, 0, `bash exited non-zero: ${result.stderr}`);
+  return result.stdout.trim().split("\n").filter(Boolean);
+}
+
+describe("factory-agent --implement loop construct", () => {
+  it("C-style for-loop does not iterate when count is 0", () => {
+    const lines = runBash('COUNT=0; for ((IDX=0; IDX<COUNT; IDX++)); do echo "$IDX"; done');
+    assert.deepEqual(lines, [], "loop must not run when COUNT=0");
+  });
+
+  it("C-style for-loop iterates the expected number of times", () => {
+    const lines = runBash('COUNT=3; for ((IDX=0; IDX<COUNT; IDX++)); do echo "$IDX"; done');
+    assert.deepEqual(lines, ["0", "1", "2"]);
+  });
+
+  it("documents the BSD-seq gotcha that the old form hit", () => {
+    // This is the exact pattern that caused #414. We don't assert "must
+    // print 2 lines" because GNU seq (Linux CI) would print zero — the
+    // bug only manifests on BSD seq. We assert the safer claim: the old
+    // form is not guaranteed to be empty across platforms, while the new
+    // form is. So we just verify the new form's emptiness above and
+    // record this case for future readers.
+    const platform = process.platform;
+    const lines = runBash('COUNT=0; for IDX in $(seq 0 $((COUNT - 1))); do echo "$IDX"; done');
+    if (platform === "darwin") {
+      assert.deepEqual(
+        lines,
+        ["0", "-1"],
+        "BSD seq on darwin prints 0 and -1 for `seq 0 -1` — this is what caused #414",
+      );
+    }
+    // On linux GNU seq, lines === []; no assertion needed.
+  });
+});

--- a/scripts/__tests__/factory-agent-implement.test.mjs
+++ b/scripts/__tests__/factory-agent-implement.test.mjs
@@ -1,6 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 // Regression test for issue #414. The `--implement` block in
 // scripts/factory-agent.sh used `for IDX in $(seq 0 $((INPROG_COUNT - 1)))`
@@ -10,6 +13,8 @@ import { spawnSync } from "node:child_process";
 // "null". This locks in the C-style for-loop form that handles count=0
 // correctly across platforms.
 
+const scriptPath = resolve(dirname(fileURLToPath(import.meta.url)), "..", "factory-agent.sh");
+
 function runBash(snippet) {
   const result = spawnSync("bash", ["-c", snippet], { encoding: "utf8" });
   assert.equal(result.status, 0, `bash exited non-zero: ${result.stderr}`);
@@ -17,6 +22,33 @@ function runBash(snippet) {
 }
 
 describe("factory-agent --implement loop construct", () => {
+  it("factory-agent.sh uses C-style loops and guards the zero-count case", () => {
+    const script = readFileSync(scriptPath, "utf8");
+    // --implement: C-style loop + early-return guard for empty In Progress
+    assert.match(
+      script,
+      /for\s*\(\(IDX=0;\s*IDX<INPROG_COUNT;\s*IDX\+\+\)\)/,
+      "expected C-style for-loop over INPROG_COUNT",
+    );
+    assert.match(
+      script,
+      /if\s+\[\[\s*"\$INPROG_COUNT"\s+-eq\s+0\s*\]\]/,
+      "expected zero-count guard before the --implement loop",
+    );
+    // --plan: same C-style form (sibling loop fixed in the same change)
+    assert.match(
+      script,
+      /for\s*\(\(IDX=0;\s*IDX<READY_COUNT;\s*IDX\+\+\)\)/,
+      "expected C-style for-loop over READY_COUNT",
+    );
+    // The BSD-seq form that caused #414 must not reappear.
+    assert.doesNotMatch(
+      script,
+      /for\s+IDX\s+in\s+\$\(seq\s+0\s+\$\(\((INPROG|READY)_COUNT\s*-\s*1\)\)\)/,
+      "seq-based loop form must not be reintroduced",
+    );
+  });
+
   it("C-style for-loop does not iterate when count is 0", () => {
     const lines = runBash('COUNT=0; for ((IDX=0; IDX<COUNT; IDX++)); do echo "$IDX"; done');
     assert.deepEqual(lines, [], "loop must not run when COUNT=0");

--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -491,7 +491,7 @@ if [[ "$MODE_PLAN" -eq 1 ]]; then
   PROMPT_TEXT=""
   if [[ "$DRY_RUN" -eq 0 ]]; then PROMPT_TEXT=$(cat "$PROMPT_FILE"); fi
 
-  for IDX in $(seq 0 $((READY_COUNT - 1))); do
+  for ((IDX=0; IDX<READY_COUNT; IDX++)); do
     ITEM=$(echo "$READY_JSON" | jq ".[${IDX}]")
     ITEM_ID=$(echo "$ITEM" | jq -r '.itemId')
     ISSUE_NUM=$(echo "$ITEM" | jq -r '.issueNumber')
@@ -673,7 +673,12 @@ if [[ "$MODE_IMPLEMENT" -eq 1 ]]; then
   fi
   log "--implement (Phase A): $INPROG_COUNT In Progress item(s)"
 
-  for IDX in $(seq 0 $((INPROG_COUNT - 1))); do
+  if [[ "$INPROG_COUNT" -eq 0 ]]; then
+    log "=== factory-agent --implement (Phase A stub) completed in $(( $(date +%s) - START_TIME ))s ==="
+    exit 0
+  fi
+
+  for ((IDX=0; IDX<INPROG_COUNT; IDX++)); do
     ITEM=$(echo "$INPROG_JSON" | jq ".[${IDX}]")
     ISSUE_NUM=$(echo "$ITEM" | jq -r '.issueNumber')
     ITEM_LABELS=$(echo "$ITEM" | jq -r '.labels // [] | join(",")')


### PR DESCRIPTION
## Summary

- `scripts/factory-agent.sh --implement` was emitting two `WARNING: fetch_issue_comments failed for #null` lines and two `jq: Cannot index string with string "id"` errors per 5-minute launchd tick whenever the kanban board had zero "In Progress" cards. Root cause is the BSD-`seq` gotcha: `seq 0 -1` (from `INPROG_COUNT - 1` when count is 0) auto-flips to a descending sequence on macOS and prints `0\n-1`, so the loop ran twice with bogus indices and fetched comments for issue number "null".
- Adds an early-return guard mirroring the existing `--plan` block, and switches both `seq`-based loops in the script to C-style `for ((IDX=0; IDX<COUNT; IDX++))` so the zero-count case is structurally safe regardless of seq flavor.
- Adds a small node-test regression that locks in the new loop form and documents the old BSD-seq behavior for future readers.

Closes #414

## Test plan

- [x] `node --test scripts/__tests__/factory-agent-implement.test.mjs` — all 3 cases pass on darwin
- [x] `node --test scripts/__tests__/*.test.mjs` — full scripts suite (278 tests) still green
- [x] `bash -n scripts/factory-agent.sh` — syntax-clean
- [x] `pnpm format:check`, `pnpm lint`, `pnpm typecheck` — all green (warnings unchanged from main)
- [ ] After merge, tail `~/Library/Logs/eu.drafto.factory/launchd-factory-stderr.log` on the Mac mini for one tick (~5 min) and confirm no `#null` / `jq` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge-case handling for zero-item iterations in the factory agent script.

* **Tests**
  * Added regression test suite to verify correct behavior of iteration logic, including zero-item edge cases and platform-specific scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JakubAnderwald/drafto/pull/419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->