### PR TITLE
fix(nightly-support): use POSIX tr for lowercase, not bash-4 ${VAR,,}

### DIFF
--- a/scripts/nightly-support.sh
+++ b/scripts/nightly-support.sh
@@ -240,9 +240,11 @@ for IDX in $(seq 0 $((SUPPORT_COUNT - 1))); do
       # has commas at both ends so the pattern `*,<email>,*` matches at any
       # position. state-cli stores reporterEmail already lower-cased; we lower
       # the allowlist here too so user-edited support-env.sh casing doesn't
-      # leak through.
-      SUPPORT_ALLOWLIST_LC="${SUPPORT_ALLOWLIST,,}"
-      REPORTER_EMAIL_LC="${REPORTER_EMAIL,,}"
+      # leak through. Use `tr` (POSIX) instead of `${VAR,,}` (bash 4+) so the
+      # script keeps working under macOS's stock /bin/bash 3.2 — launchd
+      # invokes that interpreter on the Mac mini.
+      SUPPORT_ALLOWLIST_LC=$(printf '%s' "$SUPPORT_ALLOWLIST" | tr '[:upper:]' '[:lower:]')
+      REPORTER_EMAIL_LC=$(printf '%s' "$REPORTER_EMAIL" | tr '[:upper:]' '[:lower:]')
       if [[ ",${SUPPORT_ALLOWLIST_LC}," != *",${REPORTER_EMAIL_LC},"* ]]; then
         GATE_REASON="not-allowlisted"
       fi


### PR DESCRIPTION
## Summary

- Replace `${SUPPORT_ALLOWLIST,,}` / `${REPORTER_EMAIL,,}` (bash 4+) in `scripts/nightly-support.sh` with `tr '[:upper:]' '[:lower:]'` so the script keeps working under macOS stock `/bin/bash` 3.2.
- Comment expanded to record the constraint so the next contributor doesn't reintroduce the bash-4 syntax.

## Why

`~/Library/LaunchAgents/eu.drafto.nightly-support.plist` invokes `/bin/bash`, which on the Mac mini is Apple's stock **bash 3.2.57**. The lower-case parameter expansion `${VAR,,}` is a bash 4.0+ feature and errors with `bad substitution`. With the script's `set -euo pipefail`, the failed assignment kills the whole nightly run.

The bug was latent since #371 — Phase F's sender gate only reaches the lower-case lines when a queued `support`-labelled issue has `reporterEmail` recorded in `logs/support-state.json` AND no `support-allowlisted` override. On 2026-05-23 that finally happened (issue #409, reporter `joanna@anderwald.info`), the script died inside one second, and the `cleanup` trap filed #416. The nightly audit at 05:00 then filed #417 because the log ended on an `ERROR` line.

Confirmation in `logs/launchd-stderr.log`:

```
/Users/jakub/code/drafto/scripts/nightly-support.sh: line 244:
  ${SUPPORT_ALLOWLIST,,}: bad substitution
```

## Test plan

- [x] `/bin/bash --version` confirms 3.2.57 on this host
- [x] `/bin/bash -n scripts/nightly-support.sh` — syntax OK
- [x] Live gate dry-run with `/bin/bash` 3.2: synthetic off-list email → `not-allowlisted`; #409 (`joanna@anderwald.info`, in allowlist) → `gate=passed`; no `bad substitution`
- [ ] After merge: manual `/bin/bash scripts/nightly-support.sh` run on the Mac mini to process the queued items that were skipped tonight
- [ ] Tomorrow's launchd run at 00:03 produces no new `nightly-failure` issue

Closes #416
Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)