### PR TITLE
feat(import): import notes from TickTick CSV export

### DIFF
--- a/apps/web/__tests__/integration/app-menu.test.tsx
+++ b/apps/web/__tests__/integration/app-menu.test.tsx
@@ -19,13 +19,16 @@ vi.mock("@/lib/supabase/client", () => ({
 
 describe("AppMenu", () => {
   const mockOnImportEvernote = vi.fn();
+  const mockOnImportTickTick = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("renders the menu trigger and theme toggle", () => {
-    render(<AppMenu onImportEvernote={mockOnImportEvernote} />);
+    render(
+      <AppMenu onImportEvernote={mockOnImportEvernote} onImportTickTick={mockOnImportTickTick} />,
+    );
 
     expect(screen.getByTestId("app-menu-trigger")).toBeInTheDocument();
     expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
@@ -33,7 +36,9 @@ describe("AppMenu", () => {
 
   it("opens dropdown when trigger is clicked", async () => {
     const user = userEvent.setup();
-    render(<AppMenu onImportEvernote={mockOnImportEvernote} />);
+    render(
+      <AppMenu onImportEvernote={mockOnImportEvernote} onImportTickTick={mockOnImportTickTick} />,
+    );
 
     await user.click(screen.getByTestId("app-menu-trigger"));
 
@@ -43,7 +48,9 @@ describe("AppMenu", () => {
 
   it("calls onImportEvernote when import button is clicked", async () => {
     const user = userEvent.setup();
-    render(<AppMenu onImportEvernote={mockOnImportEvernote} />);
+    render(
+      <AppMenu onImportEvernote={mockOnImportEvernote} onImportTickTick={mockOnImportTickTick} />,
+    );
 
     await user.click(screen.getByTestId("app-menu-trigger"));
     await user.click(screen.getByTestId("import-evernote-button"));
@@ -51,16 +58,36 @@ describe("AppMenu", () => {
     expect(mockOnImportEvernote).toHaveBeenCalled();
   });
 
+  it("calls onImportTickTick when TickTick import button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppMenu onImportEvernote={mockOnImportEvernote} onImportTickTick={mockOnImportTickTick} />,
+    );
+
+    await user.click(screen.getByTestId("app-menu-trigger"));
+    await user.click(screen.getByTestId("import-ticktick-button"));
+
+    expect(mockOnImportTickTick).toHaveBeenCalled();
+  });
+
   it("does not render Admin link when isAdmin is false", async () => {
     const user = userEvent.setup();
-    render(<AppMenu onImportEvernote={mockOnImportEvernote} />);
+    render(
+      <AppMenu onImportEvernote={mockOnImportEvernote} onImportTickTick={mockOnImportTickTick} />,
+    );
     await user.click(screen.getByTestId("app-menu-trigger"));
     expect(screen.queryByTestId("admin-button")).not.toBeInTheDocument();
   });
 
   it("renders Admin link and navigates when isAdmin is true", async () => {
     const user = userEvent.setup();
-    render(<AppMenu onImportEvernote={mockOnImportEvernote} isAdmin />);
+    render(
+      <AppMenu
+        onImportEvernote={mockOnImportEvernote}
+        onImportTickTick={mockOnImportTickTick}
+        isAdmin
+      />,
+    );
     await user.click(screen.getByTestId("app-menu-trigger"));
 
     const adminButton = screen.getByTestId("admin-button");
@@ -80,7 +107,9 @@ describe("AppMenu", () => {
       writable: true,
     });
 
-    render(<AppMenu onImportEvernote={mockOnImportEvernote} />);
+    render(
+      <AppMenu onImportEvernote={mockOnImportEvernote} onImportTickTick={mockOnImportTickTick} />,
+    );
 
     await user.click(screen.getByTestId("app-menu-trigger"));
     await user.click(screen.getByTestId("logout-button"));

--- a/apps/web/__tests__/integration/import-ticktick-dialog.test.tsx
+++ b/apps/web/__tests__/integration/import-ticktick-dialog.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ImportTickTickDialog } from "@/components/import/import-ticktick-dialog";
+
+vi.mock("@/lib/import/ticktick-parser", () => ({
+  parseTickTickCsv: vi.fn(() => [
+    {
+      notebookName: "Work / Inbox",
+      items: [
+        {
+          folderName: "Work",
+          listName: "Inbox",
+          title: "Sample task",
+          content: "body",
+          isCheckList: false,
+          created: "2025-01-01T00:00:00.000Z",
+          updated: "2025-01-01T00:00:00.000Z",
+        },
+      ],
+    },
+  ]),
+}));
+
+vi.mock("@/lib/handle-auth-error", () => ({
+  handleAuthError: vi.fn(() => false),
+}));
+
+describe("ImportTickTickDialog", () => {
+  const mockOnClose = vi.fn();
+  const mockOnComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("renders the dialog with file input and import button", () => {
+    render(<ImportTickTickDialog onClose={mockOnClose} onComplete={mockOnComplete} />);
+
+    expect(screen.getByText("Import from TickTick")).toBeInTheDocument();
+    expect(screen.getByTestId("ticktick-file-input")).toBeInTheDocument();
+    expect(screen.getByTestId("start-ticktick-import-button")).toBeInTheDocument();
+  });
+
+  it("disables import button when no file is selected", () => {
+    render(<ImportTickTickDialog onClose={mockOnClose} onComplete={mockOnComplete} />);
+
+    expect(screen.getByTestId("start-ticktick-import-button")).toBeDisabled();
+  });
+
+  it("calls onClose when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ImportTickTickDialog onClose={mockOnClose} onComplete={mockOnComplete} />);
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it("shows a success status after a successful import", async () => {
+    const user = userEvent.setup();
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          notebookId: "nb-1",
+          notesImported: 1,
+          notesFailed: 0,
+          errors: [],
+        }),
+    });
+
+    render(<ImportTickTickDialog onClose={mockOnClose} onComplete={mockOnComplete} />);
+
+    const file = new File(["List Name,Title\nInbox,Real"], "ticktick-export.csv", {
+      type: "text/csv",
+    });
+    await user.upload(screen.getByTestId("ticktick-file-input"), file);
+    await user.click(screen.getByTestId("start-ticktick-import-button"));
+
+    const status = await screen.findByTestId("ticktick-import-status");
+    expect(status.textContent).toContain("1 notes imported");
+    expect(mockOnComplete).toHaveBeenCalledWith("nb-1");
+  });
+
+  it("shows an error when parsing fails", async () => {
+    const user = userEvent.setup();
+    const { parseTickTickCsv } = await import("@/lib/import/ticktick-parser");
+    (parseTickTickCsv as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error("CSV parsing failed");
+    });
+
+    render(<ImportTickTickDialog onClose={mockOnClose} onComplete={mockOnComplete} />);
+
+    const file = new File(["bad"], "broken.csv", { type: "text/csv" });
+    await user.upload(screen.getByTestId("ticktick-file-input"), file);
+    await user.click(screen.getByTestId("start-ticktick-import-button"));
+
+    const errorEl = await screen.findByTestId("ticktick-import-error");
+    expect(errorEl.textContent).toContain("CSV parsing failed");
+  });
+
+  it("shows an error when no items are found", async () => {
+    const user = userEvent.setup();
+    const { parseTickTickCsv } = await import("@/lib/import/ticktick-parser");
+    (parseTickTickCsv as ReturnType<typeof vi.fn>).mockReturnValueOnce([]);
+
+    render(<ImportTickTickDialog onClose={mockOnClose} onComplete={mockOnComplete} />);
+
+    const file = new File(["empty"], "empty.csv", { type: "text/csv" });
+    await user.upload(screen.getByTestId("ticktick-file-input"), file);
+    await user.click(screen.getByTestId("start-ticktick-import-button"));
+
+    const errorEl = await screen.findByTestId("ticktick-import-error");
+    expect(errorEl.textContent).toContain("No items found");
+  });
+
+  it("reports failures returned by the API", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          notebookId: "nb-1",
+          notesImported: 0,
+          notesFailed: 1,
+          errors: ["Bad row"],
+        }),
+    });
+
+    render(<ImportTickTickDialog onClose={mockOnClose} onComplete={mockOnComplete} />);
+
+    const file = new File(["x"], "ticktick.csv", { type: "text/csv" });
+    await user.upload(screen.getByTestId("ticktick-file-input"), file);
+    await user.click(screen.getByTestId("start-ticktick-import-button"));
+
+    const status = await screen.findByTestId("ticktick-import-status");
+    expect(status.textContent).toContain("0 imported, 1 failed");
+  });
+});

--- a/apps/web/__tests__/unit/ticktick-import-api.test.ts
+++ b/apps/web/__tests__/unit/ticktick-import-api.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { TickTickImportBatchRequest, TickTickItem } from "@/lib/import/ticktick-types";
+
+const mockGetAuthenticatedUser = vi.fn();
+const mockErrorResponse = vi.fn();
+const mockSuccessResponse = vi.fn();
+
+vi.mock("@/lib/api/utils", () => ({
+  getAuthenticatedUser: (...args: unknown[]) => mockGetAuthenticatedUser(...args),
+  getAuthenticatedUserFast: (...args: unknown[]) => mockGetAuthenticatedUser(...args),
+  errorResponse: (...args: unknown[]) => mockErrorResponse(...args),
+  successResponse: (...args: unknown[]) => mockSuccessResponse(...args),
+}));
+
+const notebookSingle = vi.fn();
+const noteInsert = vi.fn();
+
+const mockSupabase = {
+  from: vi.fn((table: string) => {
+    if (table === "notebooks") {
+      return {
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({ single: notebookSingle })),
+        })),
+      };
+    }
+    return { insert: noteInsert };
+  }),
+};
+
+function buildItem(overrides: Partial<TickTickItem> = {}): TickTickItem {
+  return {
+    folderName: "Work",
+    listName: "Inbox",
+    title: "Task",
+    content: "body",
+    isCheckList: false,
+    created: "2025-01-01T00:00:00.000Z",
+    updated: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("POST /api/import/ticktick", () => {
+  let POST: (request: NextRequest) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockErrorResponse.mockImplementation(
+      (msg: string, status: number) => new Response(JSON.stringify({ error: msg }), { status }),
+    );
+    mockSuccessResponse.mockImplementation(
+      (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    );
+
+    mockGetAuthenticatedUser.mockResolvedValue({
+      data: { user: { id: "user-1", email: "test@test.com" }, supabase: mockSupabase },
+      error: null,
+    });
+
+    noteInsert.mockResolvedValue({ error: null });
+
+    vi.resetModules();
+    const mod = await import("@/app/api/import/ticktick/route");
+    POST = mod.POST;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue({
+      data: null,
+      error: new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+    });
+
+    const req = new NextRequest("http://localhost/api/import/ticktick", {
+      method: "POST",
+      body: JSON.stringify({ notebookName: "x", items: [] }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/import/ticktick", {
+      method: "POST",
+      body: "not json",
+    });
+
+    await POST(req);
+    expect(mockErrorResponse).toHaveBeenCalledWith("Invalid JSON body", 400);
+  });
+
+  it("returns 400 for empty items array", async () => {
+    const req = new NextRequest("http://localhost/api/import/ticktick", {
+      method: "POST",
+      body: JSON.stringify({ notebookName: "x", items: [] }),
+    });
+
+    await POST(req);
+    expect(mockErrorResponse).toHaveBeenCalledWith("No items provided", 400);
+  });
+
+  it("returns 400 when batch exceeds limit", async () => {
+    const items = Array.from({ length: 21 }, (_, i) => buildItem({ title: `T${i}` }));
+    const req = new NextRequest("http://localhost/api/import/ticktick", {
+      method: "POST",
+      body: JSON.stringify({ notebookName: "x", items }),
+    });
+
+    await POST(req);
+    expect(mockErrorResponse).toHaveBeenCalledWith("Maximum 20 items per batch", 400);
+  });
+
+  it("creates a notebook on first batch and imports items", async () => {
+    notebookSingle.mockResolvedValueOnce({ data: { id: "nb-1" }, error: null });
+
+    const body: TickTickImportBatchRequest = {
+      notebookName: "TickTick",
+      items: [buildItem({ title: "Task A" }), buildItem({ title: "Task B" })],
+    };
+
+    const req = new NextRequest("http://localhost/api/import/ticktick", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    await POST(req);
+
+    expect(mockSupabase.from).toHaveBeenCalledWith("notebooks");
+    expect(mockSuccessResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ notebookId: "nb-1", notesImported: 2, notesFailed: 0 }),
+      200,
+    );
+  });
+
+  it("reuses an existing notebookId", async () => {
+    const body: TickTickImportBatchRequest = {
+      notebookId: "existing-nb",
+      notebookName: "Ignored",
+      items: [buildItem()],
+    };
+
+    const req = new NextRequest("http://localhost/api/import/ticktick", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    await POST(req);
+
+    expect(mockSuccessResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ notebookId: "existing-nb", notesImported: 1 }),
+      200,
+    );
+    expect(notebookSingle).not.toHaveBeenCalled();
+  });
+
+  it("counts failures without aborting the batch", async () => {
+    notebookSingle.mockResolvedValueOnce({ data: { id: "nb-1" }, error: null });
+    noteInsert
+      .mockResolvedValueOnce({ error: null })
+      .mockResolvedValueOnce({ error: { message: "constraint" } });
+
+    const body: TickTickImportBatchRequest = {
+      notebookName: "Test",
+      items: [buildItem({ title: "Good" }), buildItem({ title: "Bad" })],
+    };
+
+    const req = new NextRequest("http://localhost/api/import/ticktick", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    await POST(req);
+
+    expect(mockSuccessResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notesImported: 1,
+        notesFailed: 1,
+        errors: expect.arrayContaining([expect.stringContaining("Bad")]),
+      }),
+      200,
+    );
+  });
+
+  it("returns 500 when notebook creation fails", async () => {
+    notebookSingle.mockResolvedValueOnce({ data: null, error: { message: "db error" } });
+
+    const body: TickTickImportBatchRequest = {
+      notebookName: "Fail",
+      items: [buildItem()],
+    };
+
+    const req = new NextRequest("http://localhost/api/import/ticktick", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    await POST(req);
+    expect(mockErrorResponse).toHaveBeenCalledWith("Failed to create notebook", 500);
+  });
+
+  it("rejects non-array items", async () => {
+    const req = new NextRequest("http://localhost/api/import/ticktick", {
+      method: "POST",
+      body: JSON.stringify({ notebookName: "x", items: "not-array" }),
+    });
+
+    await POST(req);
+    expect(mockErrorResponse).toHaveBeenCalledWith("No items provided", 400);
+  });
+});

--- a/apps/web/__tests__/unit/ticktick-parser.test.ts
+++ b/apps/web/__tests__/unit/ticktick-parser.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { parseTickTickCsv } from "@/lib/import/ticktick-parser";
+
+describe("parseTickTickCsv", () => {
+  it("parses a basic CSV export with one task", () => {
+    const csv = `"Date: 2025-12-01"\n"Version: 8.0.0"\n\nFolder Name,List Name,Title,Kind,Tags,Content,Is Check list,Created Time,Modified Time\nWork,Inbox,Buy milk,TEXT,,Some content,N,2025-11-01T10:00:00+0000,2025-11-02T11:00:00+0000`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].notebookName).toBe("Work / Inbox");
+    expect(groups[0].items).toHaveLength(1);
+    expect(groups[0].items[0].title).toBe("Buy milk");
+    expect(groups[0].items[0].content).toBe("Some content");
+    expect(groups[0].items[0].isCheckList).toBe(false);
+    expect(groups[0].items[0].folderName).toBe("Work");
+    expect(groups[0].items[0].listName).toBe("Inbox");
+  });
+
+  it("groups items by folder/list combination", () => {
+    const csv = `Folder Name,List Name,Title,Content\n,Inbox,Task A,content A\n,Inbox,Task B,content B\nWork,Projects,Task C,content C`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups).toHaveLength(2);
+    const inbox = groups.find((g) => g.notebookName === "Inbox");
+    const work = groups.find((g) => g.notebookName === "Work / Projects");
+    expect(inbox?.items).toHaveLength(2);
+    expect(work?.items).toHaveLength(1);
+  });
+
+  it("detects checklist items via Kind column", () => {
+    const csv = `Folder Name,List Name,Title,Kind,Content\n,Tasks,My list,CHECKLIST,- [ ] One\n- [x] Two`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items[0].isCheckList).toBe(true);
+  });
+
+  it("detects checklist items via Is Check list column", () => {
+    const csv = `List Name,Title,Is Check list,Content\nInbox,My list,Y,line one\nline two`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups[0].items[0].isCheckList).toBe(true);
+  });
+
+  it("handles quoted fields with commas and newlines", () => {
+    const csv = `List Name,Title,Content\nInbox,"Title, with comma","Multi\nline\ncontent"`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups[0].items[0].title).toBe("Title, with comma");
+    expect(groups[0].items[0].content).toBe("Multi\nline\ncontent");
+  });
+
+  it("handles escaped quotes inside quoted fields", () => {
+    const csv = `List Name,Title,Content\nInbox,"She said ""hi""",body`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups[0].items[0].title).toBe('She said "hi"');
+  });
+
+  it("skips rows without a title", () => {
+    const csv = `List Name,Title,Content\nInbox,,empty title row\nInbox,Real,actual content`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups[0].items).toHaveLength(1);
+    expect(groups[0].items[0].title).toBe("Real");
+  });
+
+  it("uses list name only when folder is empty", () => {
+    const csv = `Folder Name,List Name,Title\n,Quick Notes,Task one`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups[0].notebookName).toBe("Quick Notes");
+  });
+
+  it("falls back to Inbox when list name is missing", () => {
+    const csv = `Folder Name,List Name,Title\n,,Orphan task`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups[0].notebookName).toBe("Inbox");
+  });
+
+  it("strips a UTF-8 BOM at the start of the file", () => {
+    const csv = `﻿List Name,Title\nInbox,My note`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items[0].title).toBe("My note");
+  });
+
+  it("throws on missing required columns", () => {
+    expect(() => parseTickTickCsv("Foo,Bar\nA,B")).toThrow(/header row not found/i);
+  });
+
+  it("throws on empty input", () => {
+    expect(() => parseTickTickCsv("")).toThrow(/empty/i);
+  });
+
+  it("parses timestamps to ISO format", () => {
+    const csv = `List Name,Title,Created Time\nInbox,Task,2025-06-15T08:30:00+0000`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups[0].items[0].created).toBe("2025-06-15T08:30:00.000Z");
+  });
+
+  it("falls back to current time when timestamp is missing", () => {
+    const csv = `List Name,Title\nInbox,Task`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(() => new Date(groups[0].items[0].created)).not.toThrow();
+  });
+
+  it("skips metadata preamble lines before the header", () => {
+    const csv = `"Date: 2025-12-01"\n"Account: user@example.com"\n"Status"\n\nList Name,Title\nInbox,Real task`;
+
+    const groups = parseTickTickCsv(csv);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items[0].title).toBe("Real task");
+  });
+});

--- a/apps/web/__tests__/unit/ticktick-parser.test.ts
+++ b/apps/web/__tests__/unit/ticktick-parser.test.ts
@@ -118,7 +118,7 @@ describe("parseTickTickCsv", () => {
 
     const groups = parseTickTickCsv(csv);
 
-    expect(() => new Date(groups[0].items[0].created)).not.toThrow();
+    expect(Number.isNaN(Date.parse(groups[0].items[0].created))).toBe(false);
   });
 
   it("skips metadata preamble lines before the header", () => {

--- a/apps/web/__tests__/unit/ticktick-to-blocks.test.ts
+++ b/apps/web/__tests__/unit/ticktick-to-blocks.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { ticktickItemToBlocks } from "@/lib/import/ticktick-to-blocks";
+import type { TickTickItem } from "@/lib/import/ticktick-types";
+
+function item(overrides: Partial<TickTickItem>): TickTickItem {
+  return {
+    folderName: "",
+    listName: "Inbox",
+    title: "Untitled",
+    content: "",
+    isCheckList: false,
+    created: "2025-01-01T00:00:00.000Z",
+    updated: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("ticktickItemToBlocks", () => {
+  it("returns an empty paragraph for empty content", () => {
+    const blocks = ticktickItemToBlocks(item({ content: "" }));
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("paragraph");
+    expect(blocks[0].content).toEqual([]);
+  });
+
+  it("converts plain text content via markdown", () => {
+    const blocks = ticktickItemToBlocks(item({ content: "Hello world" }));
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("paragraph");
+  });
+
+  it("preserves markdown headings", () => {
+    const blocks = ticktickItemToBlocks(item({ content: "# Heading 1\nbody" }));
+
+    expect(blocks[0].type).toBe("heading");
+  });
+
+  it("converts checklist content into checkListItem blocks", () => {
+    const blocks = ticktickItemToBlocks(
+      item({
+        isCheckList: true,
+        content: "- [ ] Item 1\n- [x] Item 2",
+      }),
+    );
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("checkListItem");
+    expect(blocks[0].props?.checked).toBe(false);
+    expect(blocks[1].type).toBe("checkListItem");
+    expect(blocks[1].props?.checked).toBe(true);
+  });
+
+  it("treats plain bullet lines as unchecked items in checklist mode", () => {
+    const blocks = ticktickItemToBlocks(
+      item({
+        isCheckList: true,
+        content: "- First\n- Second",
+      }),
+    );
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("checkListItem");
+    expect(blocks[0].props?.checked).toBe(false);
+  });
+
+  it("treats raw lines as unchecked items in checklist mode", () => {
+    const blocks = ticktickItemToBlocks(
+      item({
+        isCheckList: true,
+        content: "Buy milk\nWalk dog",
+      }),
+    );
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("checkListItem");
+    const firstContent = blocks[0].content as Array<{ text: string }>;
+    const secondContent = blocks[1].content as Array<{ text: string }>;
+    expect(firstContent[0].text).toBe("Buy milk");
+    expect(secondContent[0].text).toBe("Walk dog");
+  });
+
+  it("returns a paragraph for whitespace-only content", () => {
+    const blocks = ticktickItemToBlocks(item({ content: "   \n  " }));
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("paragraph");
+  });
+});

--- a/apps/web/src/app/api/import/ticktick/route.ts
+++ b/apps/web/src/app/api/import/ticktick/route.ts
@@ -1,0 +1,91 @@
+import type { NextRequest } from "next/server";
+import { getAuthenticatedUserFast, errorResponse, successResponse } from "@/lib/api/utils";
+import { ticktickItemToBlocks } from "@/lib/import/ticktick-to-blocks";
+import type {
+  TickTickImportBatchRequest,
+  TickTickImportBatchResult,
+  TickTickItem,
+} from "@/lib/import/ticktick-types";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "@/lib/supabase/database.types";
+
+const MAX_BATCH_SIZE = 20;
+
+export async function POST(request: NextRequest) {
+  const { data: auth, error: authError } = await getAuthenticatedUserFast(request);
+  if (authError) return authError;
+
+  const { supabase, user } = auth;
+
+  let body: TickTickImportBatchRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  if (!body.items || !Array.isArray(body.items) || body.items.length === 0) {
+    return errorResponse("No items provided", 400);
+  }
+
+  if (body.items.length > MAX_BATCH_SIZE) {
+    return errorResponse(`Maximum ${MAX_BATCH_SIZE} items per batch`, 400);
+  }
+
+  let notebookId = body.notebookId;
+  if (!notebookId) {
+    const name = (body.notebookName || "TickTick Import").slice(0, 200);
+    const { data: notebook, error: nbError } = await supabase
+      .from("notebooks")
+      .insert({ name, user_id: user.id })
+      .select("id")
+      .single();
+
+    if (nbError || !notebook) {
+      return errorResponse("Failed to create notebook", 500);
+    }
+    notebookId = notebook.id;
+  }
+
+  const result: TickTickImportBatchResult = {
+    notebookId,
+    notesImported: 0,
+    notesFailed: 0,
+    errors: [],
+  };
+
+  for (const item of body.items) {
+    try {
+      await importItem(supabase, user.id, notebookId, item);
+      result.notesImported++;
+    } catch (err) {
+      result.notesFailed++;
+      const message = err instanceof Error ? err.message : "Unknown error";
+      result.errors.push(`"${item.title}": ${message}`);
+    }
+  }
+
+  return successResponse(result, 200);
+}
+
+async function importItem(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  notebookId: string,
+  item: TickTickItem,
+): Promise<void> {
+  const blocks = ticktickItemToBlocks(item);
+
+  const { error: insertError } = await supabase.from("notes").insert({
+    title: item.title.slice(0, 500),
+    content: blocks as unknown as Json[],
+    notebook_id: notebookId,
+    user_id: userId,
+    created_at: item.created,
+    updated_at: item.updated,
+  });
+
+  if (insertError) {
+    throw new Error(`Failed to create note: ${insertError.message}`);
+  }
+}

--- a/apps/web/src/components/import/import-ticktick-dialog.tsx
+++ b/apps/web/src/components/import/import-ticktick-dialog.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { parseTickTickCsv } from "@/lib/import/ticktick-parser";
+import { handleAuthError } from "@/lib/handle-auth-error";
+import type { TickTickGroup, TickTickImportBatchResult } from "@/lib/import/ticktick-types";
+
+interface ImportTickTickDialogProps {
+  onClose: () => void;
+  onComplete: (notebookId: string) => void;
+}
+
+type ImportStatus = "idle" | "parsing" | "importing" | "done" | "error";
+
+const BATCH_SIZE = 20;
+
+export function ImportTickTickDialog({ onClose, onComplete }: ImportTickTickDialogProps) {
+  const [status, setStatus] = useState<ImportStatus>("idle");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [progress, setProgress] = useState({ current: 0, total: 0 });
+  const [errorMessage, setErrorMessage] = useState("");
+  const [importedCount, setImportedCount] = useState(0);
+  const [failedCount, setFailedCount] = useState(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setSelectedFile(file);
+  }, []);
+
+  const handleImport = useCallback(async () => {
+    if (!selectedFile) return;
+
+    setStatus("parsing");
+    setErrorMessage("");
+
+    let groups: TickTickGroup[];
+    try {
+      const text = await selectedFile.text();
+      groups = parseTickTickCsv(text);
+    } catch (err) {
+      setStatus("error");
+      setErrorMessage(err instanceof Error ? err.message : "Failed to parse CSV file");
+      return;
+    }
+
+    const totalItems = groups.reduce((sum, group) => sum + group.items.length, 0);
+    if (totalItems === 0) {
+      setStatus("error");
+      setErrorMessage("No items found in the TickTick export");
+      return;
+    }
+
+    setStatus("importing");
+    setProgress({ current: 0, total: totalItems });
+
+    let lastNotebookId: string | undefined;
+    let totalImported = 0;
+    let totalFailed = 0;
+    const allErrors: string[] = [];
+
+    for (const group of groups) {
+      let notebookId: string | undefined;
+      const batches = chunk(group.items, BATCH_SIZE);
+
+      for (const batch of batches) {
+        try {
+          const res = await fetch("/api/import/ticktick", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              notebookName: notebookId ? undefined : group.notebookName,
+              notebookId,
+              items: batch,
+            }),
+          });
+
+          if (handleAuthError(res)) return;
+
+          if (!res.ok) {
+            const errBody = await res.json().catch(() => null);
+            totalFailed += batch.length;
+            allErrors.push(errBody?.error || `Batch failed: ${res.status}`);
+            continue;
+          }
+
+          const result: TickTickImportBatchResult = await res.json();
+          notebookId = result.notebookId;
+          lastNotebookId = result.notebookId;
+          totalImported += result.notesImported;
+          totalFailed += result.notesFailed;
+          allErrors.push(...result.errors);
+        } catch (err) {
+          totalFailed += batch.length;
+          allErrors.push(err instanceof Error ? err.message : "Network error");
+        }
+
+        setProgress((prev) => ({ ...prev, current: prev.current + batch.length }));
+      }
+    }
+
+    setImportedCount(totalImported);
+    setFailedCount(totalFailed);
+    setStatus("done");
+
+    if (allErrors.length > 0) {
+      setErrorMessage(`Completed with errors:\n${allErrors.join("\n")}`);
+    }
+
+    if (lastNotebookId) {
+      onComplete(lastNotebookId);
+    }
+  }, [selectedFile, onComplete]);
+
+  const statusText = (() => {
+    switch (status) {
+      case "parsing":
+        return "Parsing file...";
+      case "importing":
+        return `Importing item ${Math.min(progress.current + 1, progress.total)} of ${progress.total}...`;
+      case "done":
+        return failedCount > 0
+          ? `Done: ${importedCount} imported, ${failedCount} failed`
+          : `Done: ${importedCount} notes imported`;
+      case "error":
+        return "Import failed";
+      default:
+        return null;
+    }
+  })();
+
+  const isProcessing = status === "parsing" || status === "importing";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      data-testid="import-ticktick-dialog"
+    >
+      <div className="bg-bg mx-4 w-full max-w-md rounded-xl p-6 shadow-lg">
+        <h2 className="text-fg mb-4 text-lg font-semibold">Import from TickTick</h2>
+
+        <div className="space-y-4">
+          <p className="text-fg-muted text-sm">
+            Export your TickTick data as CSV (Settings → Backup) and upload the file below. Each
+            TickTick list becomes a Drafto notebook, and each task or note becomes a note.
+            Checklists are preserved as checkable items.
+          </p>
+
+          <div>
+            <label className="text-fg-muted mb-1 block text-sm font-medium">CSV file</label>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,text/csv"
+              onChange={handleFileChange}
+              disabled={isProcessing}
+              className="text-fg file:bg-bg-muted file:text-fg file:border-border text-sm file:mr-3 file:cursor-pointer file:rounded-md file:border file:px-3 file:py-1.5 file:text-sm"
+              data-testid="ticktick-file-input"
+            />
+          </div>
+
+          {statusText && (
+            <div className="flex items-center gap-2" data-testid="ticktick-import-status">
+              {isProcessing && (
+                <svg
+                  className="text-primary-500 h-4 w-4 animate-spin"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+              )}
+              <span className="text-fg-muted text-sm">{statusText}</span>
+              {status === "done" && failedCount > 0 && (
+                <Badge variant="warning">{failedCount} failed</Badge>
+              )}
+              {status === "done" && failedCount === 0 && <Badge variant="success">Complete</Badge>}
+            </div>
+          )}
+
+          {errorMessage && (
+            <p
+              className="text-error text-sm whitespace-pre-line"
+              data-testid="ticktick-import-error"
+            >
+              {errorMessage}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-6 flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={isProcessing}>
+            {status === "done" ? "Close" : "Cancel"}
+          </Button>
+          {status !== "done" && (
+            <Button
+              onClick={handleImport}
+              loading={isProcessing}
+              disabled={!selectedFile || isProcessing}
+              data-testid="start-ticktick-import-button"
+            >
+              Import
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}

--- a/apps/web/src/components/layout/app-menu.tsx
+++ b/apps/web/src/components/layout/app-menu.tsx
@@ -13,6 +13,7 @@ import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 interface AppMenuProps {
   onImportEvernote: () => void;
+  onImportTickTick: () => void;
   isAdmin?: boolean;
 }
 
@@ -35,7 +36,7 @@ function EllipsisIcon() {
   );
 }
 
-export function AppMenu({ onImportEvernote, isAdmin = false }: AppMenuProps) {
+export function AppMenu({ onImportEvernote, onImportTickTick, isAdmin = false }: AppMenuProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
@@ -74,6 +75,15 @@ export function AppMenu({ onImportEvernote, isAdmin = false }: AppMenuProps) {
           data-testid="import-evernote-button"
         >
           Import from Evernote
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => {
+            setOpen(false);
+            onImportTickTick();
+          }}
+          data-testid="import-ticktick-button"
+        >
+          Import from TickTick
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => {

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -10,6 +10,7 @@ import { IconButton } from "@/components/ui/icon-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AppMenu } from "@/components/layout/app-menu";
 import { ImportEvernoteDialog } from "@/components/import/import-evernote-dialog";
+import { ImportTickTickDialog } from "@/components/import/import-ticktick-dialog";
 import { SearchOverlay } from "@/components/search/search-overlay";
 import { usePaneCollapse } from "@/hooks/use-pane-collapse";
 
@@ -212,6 +213,7 @@ export function AppShell({
   const [viewingTrash, setViewingTrash] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showImportDialog, setShowImportDialog] = useState(false);
+  const [showTickTickImportDialog, setShowTickTickImportDialog] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const { notebooksCollapsed, notesCollapsed, togglePane } = usePaneCollapse();
   const [lastNoteUpdate, setLastNoteUpdate] = useState<{
@@ -464,7 +466,11 @@ export function AppShell({
           initialNotebooks={initialNotebooks}
         />
         <div className="flex items-center justify-end p-2">
-          <AppMenu onImportEvernote={() => setShowImportDialog(true)} isAdmin={isAdmin} />
+          <AppMenu
+            onImportEvernote={() => setShowImportDialog(true)}
+            onImportTickTick={() => setShowTickTickImportDialog(true)}
+            isAdmin={isAdmin}
+          />
         </div>
       </aside>
 
@@ -609,6 +615,19 @@ export function AppShell({
           onClose={() => setShowImportDialog(false)}
           onComplete={(notebookId) => {
             setShowImportDialog(false);
+            setRefreshTrigger((prev) => prev + 1);
+            setSelectedNotebookId(notebookId);
+            setSelectedNoteId(null);
+            setViewingTrash(false);
+          }}
+        />
+      )}
+
+      {showTickTickImportDialog && (
+        <ImportTickTickDialog
+          onClose={() => setShowTickTickImportDialog(false)}
+          onComplete={(notebookId) => {
+            setShowTickTickImportDialog(false);
             setRefreshTrigger((prev) => prev + 1);
             setSelectedNotebookId(notebookId);
             setSelectedNoteId(null);

--- a/apps/web/src/lib/import/ticktick-parser.ts
+++ b/apps/web/src/lib/import/ticktick-parser.ts
@@ -1,0 +1,157 @@
+import type { TickTickGroup, TickTickItem } from "@/lib/import/ticktick-types";
+
+const REQUIRED_COLUMNS = ["List Name", "Title"] as const;
+
+export function parseTickTickCsv(csv: string): TickTickGroup[] {
+  const rows = parseCsvRows(csv);
+  if (rows.length === 0) {
+    throw new Error("Invalid TickTick export: file is empty");
+  }
+
+  const headerIndex = rows.findIndex(isHeaderRow);
+  if (headerIndex === -1) {
+    throw new Error("Invalid TickTick export: header row not found");
+  }
+
+  const header = rows[headerIndex];
+  const columnIndex = new Map<string, number>();
+  header.forEach((name, idx) => columnIndex.set(name.trim(), idx));
+
+  for (const required of REQUIRED_COLUMNS) {
+    if (!columnIndex.has(required)) {
+      throw new Error(`Invalid TickTick export: missing "${required}" column`);
+    }
+  }
+
+  const dataRows = rows.slice(headerIndex + 1).filter((row) => row.some((cell) => cell !== ""));
+  const groups = new Map<string, TickTickGroup>();
+
+  for (const row of dataRows) {
+    const item = rowToItem(row, columnIndex);
+    if (!item) continue;
+    const key = item.folderName ? `${item.folderName} / ${item.listName}` : item.listName;
+    const notebookName = key || "TickTick Import";
+    const group = groups.get(notebookName);
+    if (group) {
+      group.items.push(item);
+    } else {
+      groups.set(notebookName, { notebookName, items: [item] });
+    }
+  }
+
+  return Array.from(groups.values());
+}
+
+function isHeaderRow(row: string[]): boolean {
+  return row.includes("List Name") && row.includes("Title");
+}
+
+function rowToItem(row: string[], columnIndex: Map<string, number>): TickTickItem | null {
+  const get = (name: string): string => {
+    const idx = columnIndex.get(name);
+    if (idx === undefined) return "";
+    return row[idx]?.trim() ?? "";
+  };
+
+  const title = get("Title");
+  if (!title) return null;
+
+  const isCheckList =
+    parseBoolean(get("Is Check list")) || get("Kind").toUpperCase() === "CHECKLIST";
+  const createdRaw = get("Created Time");
+  const updatedRaw = get("Modified Time") || createdRaw;
+  const created = parseTickTickDate(createdRaw);
+  const updated = parseTickTickDate(updatedRaw) || created;
+
+  return {
+    folderName: get("Folder Name"),
+    listName: get("List Name") || "Inbox",
+    title,
+    content: get("Content"),
+    isCheckList,
+    created,
+    updated,
+  };
+}
+
+function parseBoolean(value: string): boolean {
+  const v = value.trim().toUpperCase();
+  return v === "Y" || v === "YES" || v === "TRUE" || v === "1";
+}
+
+function parseTickTickDate(value: string): string {
+  if (!value) return new Date().toISOString();
+  const trimmed = value.trim();
+  const direct = new Date(trimmed);
+  if (!Number.isNaN(direct.getTime())) return direct.toISOString();
+  const normalised = trimmed.replace(" ", "T");
+  const fallback = new Date(normalised);
+  if (!Number.isNaN(fallback.getTime())) return fallback.toISOString();
+  return new Date().toISOString();
+}
+
+function parseCsvRows(input: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let i = 0;
+  let inQuotes = false;
+  const text = input.replace(/^﻿/, "");
+
+  while (i < text.length) {
+    const ch = text[i];
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i++;
+        continue;
+      }
+      field += ch;
+      i++;
+      continue;
+    }
+
+    if (ch === '"') {
+      inQuotes = true;
+      i++;
+      continue;
+    }
+
+    if (ch === ",") {
+      row.push(field);
+      field = "";
+      i++;
+      continue;
+    }
+
+    if (ch === "\r") {
+      i++;
+      continue;
+    }
+
+    if (ch === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+      i++;
+      continue;
+    }
+
+    field += ch;
+    i++;
+  }
+
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  return rows;
+}

--- a/apps/web/src/lib/import/ticktick-parser.ts
+++ b/apps/web/src/lib/import/ticktick-parser.ts
@@ -58,10 +58,9 @@ function rowToItem(row: string[], columnIndex: Map<string, number>): TickTickIte
 
   const isCheckList =
     parseBoolean(get("Is Check list")) || get("Kind").toUpperCase() === "CHECKLIST";
-  const createdRaw = get("Created Time");
-  const updatedRaw = get("Modified Time") || createdRaw;
-  const created = parseTickTickDate(createdRaw);
-  const updated = parseTickTickDate(updatedRaw) || created;
+  const created = parseTickTickDate(get("Created Time"));
+  const modifiedRaw = get("Modified Time");
+  const updated = modifiedRaw ? parseTickTickDate(modifiedRaw) : created;
 
   return {
     folderName: get("Folder Name"),

--- a/apps/web/src/lib/import/ticktick-to-blocks.ts
+++ b/apps/web/src/lib/import/ticktick-to-blocks.ts
@@ -1,0 +1,62 @@
+import type { BlockNoteBlock } from "@drafto/shared";
+import { markdownToBlockNote } from "@drafto/shared";
+import type { TickTickItem } from "@/lib/import/ticktick-types";
+
+export function ticktickItemToBlocks(item: TickTickItem): BlockNoteBlock[] {
+  if (!item.content.trim()) {
+    return [emptyParagraph()];
+  }
+
+  if (item.isCheckList) {
+    return checklistBlocks(item.content);
+  }
+
+  return markdownToBlockNote(item.content);
+}
+
+function checklistBlocks(content: string): BlockNoteBlock[] {
+  const lines = content.split(/\r?\n/);
+  const blocks: BlockNoteBlock[] = [];
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    const markdownMatch = line.match(/^-\s+\[([ xX])\]\s+(.*)/);
+    if (markdownMatch) {
+      blocks.push(checkBlock(markdownMatch[1].toLowerCase() === "x", markdownMatch[2].trim()));
+      continue;
+    }
+
+    const ticktickMatch = line.match(/^([-*])\s+(.*)/);
+    if (ticktickMatch) {
+      blocks.push(checkBlock(false, ticktickMatch[2].trim()));
+      continue;
+    }
+
+    blocks.push(checkBlock(false, line));
+  }
+
+  if (blocks.length === 0) {
+    return [emptyParagraph()];
+  }
+
+  return blocks;
+}
+
+function checkBlock(checked: boolean, text: string): BlockNoteBlock {
+  return {
+    type: "checkListItem",
+    props: { checked },
+    content: [{ type: "text", text, styles: {} }],
+    children: [],
+  };
+}
+
+function emptyParagraph(): BlockNoteBlock {
+  return {
+    type: "paragraph",
+    content: [],
+    children: [],
+  };
+}

--- a/apps/web/src/lib/import/ticktick-types.ts
+++ b/apps/web/src/lib/import/ticktick-types.ts
@@ -1,0 +1,27 @@
+export interface TickTickItem {
+  folderName: string;
+  listName: string;
+  title: string;
+  content: string;
+  isCheckList: boolean;
+  created: string;
+  updated: string;
+}
+
+export interface TickTickGroup {
+  notebookName: string;
+  items: TickTickItem[];
+}
+
+export interface TickTickImportBatchRequest {
+  notebookName: string;
+  notebookId?: string;
+  items: TickTickItem[];
+}
+
+export interface TickTickImportBatchResult {
+  notebookId: string;
+  notesImported: number;
+  notesFailed: number;
+  errors: string[];
+}


### PR DESCRIPTION
## Summary

- Adds a one-shot TickTick CSV importer to the web app (reachable from the app menu → "Import from TickTick")
- Each TickTick list (folder + list name) becomes a Drafto notebook; each row becomes a note
- Checklist items are preserved as checkable BlockNote blocks; non-checklist content goes through the existing markdown converter
- New API route `POST /api/import/ticktick` mirrors the Evernote pattern: client-side parse, batched server calls (20 items/batch), partial-failure tolerant

## Scope

- Web only for v1 (issue called out web-first; `parity:web-only` label applied)
- Format: CSV (TickTick's standard backup format via Settings → Backup)
- Out of scope per the issue: attachments, recurring tasks, two-way sync

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm format:check` passes
- [x] `pnpm --filter=@drafto/web test` — 754 tests pass (incl. new parser, block converter, API route, and dialog tests)
- [x] `pnpm --filter=@drafto/shared test` — 237 tests pass
- [ ] Manual smoke test on Vercel preview: upload a TickTick CSV export, confirm notebooks + notes appear with checklists intact

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TickTick import functionality to import notebooks and notes from TickTick CSV exports.
  * New import dialog with file selection and batch processing.
  * Progress tracking with success/failure counts and detailed error reporting.

* **Tests**
  * Comprehensive test coverage for TickTick import workflows and data parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JakubAnderwald/drafto/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->