### PR TITLE
fix(support-agent): persist Zoho thread ID in state for --comment-sync (#422)

### DIFF
--- a/docs/adr/0025-support-allowlist-from-zoho-sender.md
+++ b/docs/adr/0025-support-allowlist-from-zoho-sender.md
@@ -70,6 +70,18 @@ The existing `SUPPORT_ALLOWLIST` env variable (sourced by both `support-agent.sh
 - **Strengthen the prompt's "MUST end with footer" instruction.** Prompts are best-effort. Even if hardened to ~100% inclusion, the spoof window remains.
 - **Add a label-based gate.** Apply a `reporter-allowlisted` label to the issue at filing time. Equivalent to the chosen approach in expressiveness but loses the `reporterEmail` value (useful for triage logs and future audits) and adds a label-management code path. The state-file approach carries the address, not just a boolean.
 
+## Update — issue #422 (2026-05-23)
+
+The decision above retained the issue-body footer as the source of truth for `zoho-thread-id` routing in `--comment-sync` (point 3, "Keep the footer in the issue body, but only for `zoho-thread-id`"). That footer field turned out to be unreliable for singleton-first-contact tickets: it is initialised with `zoho-thread-id: null` and the LLM does not always patch it once the auto-reply gives Zoho a real `ackThreadId`. Result: progress comments stopped reaching the customer's inbox (confirmed for issues #360 and #409).
+
+The fix moves the `zoho-thread-id` source of truth off the LLM-written footer and onto state, matching the pattern this ADR established for `reporterEmail`:
+
+- `record-filed-issue` now takes an optional third positional `<zoho-thread-id>`. When the inbound Zoho bundle carries a real threadId (reply to an existing thread), bash passes it through; for singletons (empty inbound threadId) bash re-reads the GitHub issue body footer immediately after Claude's filing action and mirrors the patched `ackThreadId` into state via the new `set-issue-field` allowlisted setter.
+- `--comment-sync` now reads `state.issues[<n>].zohoThreadId` via the new `get-issue-zoho-thread-id` subcommand. The footer is no longer parsed at sync time.
+- The footer remains in the issue body as human-readable provenance but is no longer load-bearing for any code path.
+
+Pre-fix open issues need a one-off `state-cli set-issue-field <n> zohoThreadId <id>` to route through state. The allowlist gate from this ADR's main decision is untouched.
+
 ## Related
 
 - `scripts/lib/state-cli.mjs` — `record-filed-issue` and `get-reporter-email` subcommands.

--- a/docs/adr/0025-support-allowlist-from-zoho-sender.md
+++ b/docs/adr/0025-support-allowlist-from-zoho-sender.md
@@ -84,10 +84,11 @@ Pre-fix open issues need a one-off `state-cli set-issue-field <n> zohoThreadId <
 
 ## Related
 
-- `scripts/lib/state-cli.mjs` — `record-filed-issue` and `get-reporter-email` subcommands.
-- `scripts/lib/state.mjs` — `issues.<n>.reporterEmail` schema field.
-- `scripts/support-agent.sh` — `filed-issue` action handler invokes `record-filed-issue` after Claude exits.
-- `scripts/nightly-support.sh` — gate replaced with `get-reporter-email` lookup + comma-bounded match against `$SUPPORT_ALLOWLIST`.
-- `scripts/lib/parse-issue-footer.mjs` — `evaluateAllowlist` removed; `parseIssueFooter` retained for `zoho-thread-id` routing in comment-sync.
-- `scripts/support-agent-prompt.md` — step 8 narrative updated; the footer block remains in the issue body but the `reporter-allowlisted` claim is informational.
-- [`docs/adr/0024-realtime-support-agent.md`](./0024-realtime-support-agent.md) — narrows section "State storage" point 2; the footer-as-allowlist-gate aspect is replaced by this ADR. The footer itself remains for `zoho-thread-id` routing.
+- `scripts/lib/state-cli.mjs` — `record-filed-issue` (now optional 3rd positional `<zoho-thread-id>`), `get-reporter-email`, `get-issue-zoho-thread-id` and the allowlisted `set-issue-field` subcommands (the last three added by issue #422).
+- `scripts/lib/state.mjs` — `issues.<n>.reporterEmail`, `issues.<n>.zohoThreadId`, plus `threads.<zohoThreadId>.linkedIssue` + `.fromAddress` mirror fields.
+- `scripts/support-agent.sh` — `filed-issue` action handler invokes `record-filed-issue` with the inbound threadId (when present) and, for singletons, re-reads the patched footer post-filing and calls `set-issue-field zohoThreadId`. `--comment-sync` reads `state.issues[<n>].zohoThreadId` via `get-issue-zoho-thread-id` (not the footer).
+- `scripts/nightly-support.sh` — gate uses `get-reporter-email` lookup + comma-bounded match against `$SUPPORT_ALLOWLIST` (unchanged by #422).
+- `scripts/lib/parse-issue-footer.mjs` — `evaluateAllowlist` removed; `parseIssueFooter` retained, used only by `support-agent.sh`'s singleton post-filing footer re-read. No longer called at sync time.
+- `scripts/support-agent-prompt.md` — step 8 narrative updated for the allowlist move; step 11 notes that bash re-reads the patched footer immediately after filing and mirrors `<ackThreadId>` into state.
+- Pre-fix issues whose linkage was never recorded can be patched manually via `node scripts/lib/state-cli.mjs set-issue-field <n> zohoThreadId <id>`. The footer is now human-readable provenance only — no code path reads it at sync time.
+- [`docs/adr/0024-realtime-support-agent.md`](./0024-realtime-support-agent.md) — narrows section "State storage" point 2; the footer-as-allowlist-gate aspect is replaced by this ADR's main decision, and the footer-as-comment-sync-routing aspect is replaced by the issue #422 update above.

--- a/scripts/__tests__/state-cli-get-issue-zoho-thread-id.test.mjs
+++ b/scripts/__tests__/state-cli-get-issue-zoho-thread-id.test.mjs
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(HERE, "..", "lib", "state-cli.mjs");
+
+function run(args, { stateFile } = {}) {
+  const allArgs = stateFile ? [...args, "--state-file", stateFile] : args;
+  return spawnSync("node", [CLI, ...allArgs], { encoding: "utf8" });
+}
+
+async function withTempState(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "state-cli-test-"));
+  const file = path.join(dir, "state.json");
+  try {
+    await fn(file);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("state-cli get-issue-zoho-thread-id (issue #422)", () => {
+  it("returns bare string with no trailing newline after a 3-arg record-filed-issue", async () => {
+    await withTempState(async (file) => {
+      const w = run(["record-filed-issue", "700", "customer@example.com", "abc123"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const r = run(["get-issue-zoho-thread-id", "700"], { stateFile: file });
+      assert.equal(r.status, 0, r.stderr);
+      assert.equal(r.stdout, "abc123");
+    });
+  });
+
+  it("returns empty string for an unknown issue", async () => {
+    await withTempState(async (file) => {
+      const r = run(["get-issue-zoho-thread-id", "999"], { stateFile: file });
+      assert.equal(r.status, 0, r.stderr);
+      assert.equal(r.stdout, "");
+    });
+  });
+
+  it("returns empty string for a brand-new state file (ENOENT path)", async () => {
+    await withTempState(async (file) => {
+      const r = run(["get-issue-zoho-thread-id", "1"], { stateFile: file });
+      assert.equal(r.status, 0, r.stderr);
+      assert.equal(r.stdout, "");
+    });
+  });
+
+  it("returns empty string for an issue with reporterEmail but no zohoThreadId", async () => {
+    await withTempState(async (file) => {
+      const w = run(["record-filed-issue", "701", "customer@example.com"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const r = run(["get-issue-zoho-thread-id", "701"], { stateFile: file });
+      assert.equal(r.status, 0, r.stderr);
+      assert.equal(r.stdout, "");
+    });
+  });
+
+  it("rejects missing issue number", async () => {
+    await withTempState(async (file) => {
+      const r = run(["get-issue-zoho-thread-id"], { stateFile: file });
+      assert.notEqual(r.status, 0);
+      assert.match(r.stderr, /issue-number/i);
+    });
+  });
+});

--- a/scripts/__tests__/state-cli-reporter-email.test.mjs
+++ b/scripts/__tests__/state-cli-reporter-email.test.mjs
@@ -99,3 +99,91 @@ describe("state-cli record-filed-issue / get-reporter-email (ADR-0025)", () => {
     });
   });
 });
+
+describe("state-cli record-filed-issue 3-arg form (issue #422)", () => {
+  it("persists zohoThreadId on the issue and mirrors onto the thread entry", async () => {
+    await withTempState(async (file) => {
+      const w = run(["record-filed-issue", "500", "customer@example.com", "1234567890"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.issues["500"].reporterEmail, "customer@example.com");
+      assert.equal(raw.issues["500"].zohoThreadId, "1234567890");
+      assert.equal(raw.threads["1234567890"].linkedIssue, "500");
+      assert.equal(raw.threads["1234567890"].fromAddress, "customer@example.com");
+    });
+  });
+
+  it("treats an explicit empty 3rd arg as no-linkage (singleton path)", async () => {
+    await withTempState(async (file) => {
+      const w = run(["record-filed-issue", "501", "customer@example.com", ""], { stateFile: file });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.issues["501"].reporterEmail, "customer@example.com");
+      assert.equal(raw.issues["501"].zohoThreadId, undefined);
+      assert.equal(Object.keys(raw.threads ?? {}).length, 0);
+    });
+  });
+
+  it("treats the literal string 'null' as no-linkage", async () => {
+    await withTempState(async (file) => {
+      const w = run(["record-filed-issue", "502", "customer@example.com", "null"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.issues["502"].zohoThreadId, undefined);
+      assert.equal(Object.keys(raw.threads ?? {}).length, 0);
+    });
+  });
+
+  it("2-arg form (backward compat) still works; zohoThreadId stays absent", async () => {
+    await withTempState(async (file) => {
+      const w = run(["record-filed-issue", "503", "customer@example.com"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.issues["503"].reporterEmail, "customer@example.com");
+      assert.equal(raw.issues["503"].zohoThreadId, undefined);
+    });
+  });
+
+  it("preserves pre-existing thread fields when mirroring linkage", async () => {
+    await withTempState(async (file) => {
+      // Seed a thread entry the way policy.mjs would.
+      await fs.writeFile(
+        file,
+        JSON.stringify({
+          threads: {
+            1234567890: {
+              autoReplies: ["2026-05-20T10:00:00.000Z"],
+              lastAdminNotificationAt: "2026-05-20T11:00:00.000Z",
+            },
+          },
+        }),
+      );
+      const w = run(["record-filed-issue", "504", "customer@example.com", "1234567890"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.deepEqual(raw.threads["1234567890"].autoReplies, ["2026-05-20T10:00:00.000Z"]);
+      assert.equal(raw.threads["1234567890"].lastAdminNotificationAt, "2026-05-20T11:00:00.000Z");
+      assert.equal(raw.threads["1234567890"].linkedIssue, "504");
+      assert.equal(raw.threads["1234567890"].fromAddress, "customer@example.com");
+    });
+  });
+
+  it("normalises the email when mirroring onto the thread entry", async () => {
+    await withTempState(async (file) => {
+      const w = run(["record-filed-issue", "505", "  Customer@Example.COM  ", "999"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.threads["999"].fromAddress, "customer@example.com");
+    });
+  });
+});

--- a/scripts/__tests__/state-cli-set-issue-field.test.mjs
+++ b/scripts/__tests__/state-cli-set-issue-field.test.mjs
@@ -76,7 +76,7 @@ describe("state-cli set-issue-field (issue #422)", () => {
     });
   });
 
-  it("writes reporterEmail lower-cased + trimmed and does NOT touch threads", async () => {
+  it("writes reporterEmail lower-cased + trimmed and does NOT touch threads when no linkage exists", async () => {
     await withTempState(async (file) => {
       const w = run(["set-issue-field", "603", "reporterEmail", "  Customer@Example.COM  "], {
         stateFile: file,
@@ -85,6 +85,26 @@ describe("state-cli set-issue-field (issue #422)", () => {
       const raw = JSON.parse(await fs.readFile(file, "utf8"));
       assert.equal(raw.issues["603"].reporterEmail, "customer@example.com");
       assert.equal(Object.keys(raw.threads ?? {}).length, 0);
+    });
+  });
+
+  it("updates threads[<id>].fromAddress when reporterEmail changes on a linked issue", async () => {
+    await withTempState(async (file) => {
+      // Seed a fully-linked record (record-filed-issue 3-arg form mirrors
+      // fromAddress onto the thread side at filing time).
+      const seed = run(["record-filed-issue", "606", "old@example.com", "thread-606"], {
+        stateFile: file,
+      });
+      assert.equal(seed.status, 0, seed.stderr);
+      // Now override the email — the threads mirror should follow.
+      const w = run(["set-issue-field", "606", "reporterEmail", "  New@Example.COM  "], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.issues["606"].reporterEmail, "new@example.com");
+      assert.equal(raw.threads["thread-606"].fromAddress, "new@example.com");
+      assert.equal(raw.threads["thread-606"].linkedIssue, "606");
     });
   });
 

--- a/scripts/__tests__/state-cli-set-issue-field.test.mjs
+++ b/scripts/__tests__/state-cli-set-issue-field.test.mjs
@@ -1,0 +1,123 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(HERE, "..", "lib", "state-cli.mjs");
+
+function run(args, { stateFile } = {}) {
+  const allArgs = stateFile ? [...args, "--state-file", stateFile] : args;
+  return spawnSync("node", [CLI, ...allArgs], { encoding: "utf8" });
+}
+
+async function withTempState(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "state-cli-test-"));
+  const file = path.join(dir, "state.json");
+  try {
+    await fn(file);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("state-cli set-issue-field (issue #422)", () => {
+  it("rejects fields not in the allowlist", async () => {
+    await withTempState(async (file) => {
+      const r = run(["set-issue-field", "600", "lastKnownState", "foo"], {
+        stateFile: file,
+      });
+      assert.notEqual(r.status, 0);
+      assert.match(r.stderr, /allowlist/i);
+    });
+  });
+
+  it("rejects empty / whitespace-only values", async () => {
+    await withTempState(async (file) => {
+      const r = run(["set-issue-field", "600", "zohoThreadId", "   "], {
+        stateFile: file,
+      });
+      assert.notEqual(r.status, 0);
+      assert.match(r.stderr, /empty/i);
+    });
+  });
+
+  it("writes zohoThreadId and mirrors onto the thread entry", async () => {
+    await withTempState(async (file) => {
+      // Seed reporterEmail so the mirror can pick it up for fromAddress.
+      const seed = run(["record-filed-issue", "601", "customer@example.com"], {
+        stateFile: file,
+      });
+      assert.equal(seed.status, 0, seed.stderr);
+      const w = run(["set-issue-field", "601", "zohoThreadId", "7777"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.issues["601"].zohoThreadId, "7777");
+      assert.equal(raw.threads["7777"].linkedIssue, "601");
+      assert.equal(raw.threads["7777"].fromAddress, "customer@example.com");
+    });
+  });
+
+  it("writes zohoThreadId without a prior reporterEmail (no fromAddress mirror)", async () => {
+    await withTempState(async (file) => {
+      const w = run(["set-issue-field", "602", "zohoThreadId", "8888"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.issues["602"].zohoThreadId, "8888");
+      assert.equal(raw.threads["8888"].linkedIssue, "602");
+      assert.equal(raw.threads["8888"].fromAddress, undefined);
+    });
+  });
+
+  it("writes reporterEmail lower-cased + trimmed and does NOT touch threads", async () => {
+    await withTempState(async (file) => {
+      const w = run(["set-issue-field", "603", "reporterEmail", "  Customer@Example.COM  "], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.issues["603"].reporterEmail, "customer@example.com");
+      assert.equal(Object.keys(raw.threads ?? {}).length, 0);
+    });
+  });
+
+  it("preserves other fields on the same issue", async () => {
+    await withTempState(async (file) => {
+      // Seed a cursor + email, then overwrite just the zohoThreadId.
+      const c = run(["set-issue-cursor", "604", "2026-05-23T10:00:00.000Z"], {
+        stateFile: file,
+      });
+      assert.equal(c.status, 0, c.stderr);
+      const e = run(["record-filed-issue", "604", "customer@example.com"], {
+        stateFile: file,
+      });
+      assert.equal(e.status, 0, e.stderr);
+      const w = run(["set-issue-field", "604", "zohoThreadId", "9999"], {
+        stateFile: file,
+      });
+      assert.equal(w.status, 0, w.stderr);
+      const raw = JSON.parse(await fs.readFile(file, "utf8"));
+      assert.equal(raw.issues["604"].zohoThreadId, "9999");
+      assert.equal(raw.issues["604"].reporterEmail, "customer@example.com");
+      assert.equal(raw.issues["604"].lastGithubCommentSyncAt, "2026-05-23T10:00:00.000Z");
+    });
+  });
+
+  it("rejects missing args", async () => {
+    await withTempState(async (file) => {
+      const r1 = run(["set-issue-field", "605"], { stateFile: file });
+      assert.notEqual(r1.status, 0);
+      const r2 = run(["set-issue-field", "605", "zohoThreadId"], {
+        stateFile: file,
+      });
+      assert.notEqual(r2.status, 0);
+    });
+  });
+});

--- a/scripts/lib/state-cli.mjs
+++ b/scripts/lib/state-cli.mjs
@@ -24,7 +24,7 @@
 //                                    after handling (or bootstrapping) a
 //                                    transition. <state-reason> may be
 //                                    empty/"null" to record an explicit null.
-//   record-filed-issue <issue> <sender-email>
+//   record-filed-issue <issue> <sender-email> [<zoho-thread-id>]
 //                                    Persist state.issues[<issue>].reporterEmail
 //                                    = sender-email (lower-cased, trimmed). Called
 //                                    by support-agent.sh after Claude reports
@@ -32,10 +32,31 @@
 //                                    is the authoritative sender (captured before
 //                                    the LLM ran) — nightly-support.sh reads it to
 //                                    gate auto-implementation. See ADR-0025.
+//
+//                                    Optional 3rd positional <zoho-thread-id> also
+//                                    writes state.issues[<issue>].zohoThreadId and
+//                                    mirrors onto state.threads[<id>] (linkedIssue
+//                                    + fromAddress). Empty/"null" 3rd arg is
+//                                    treated as "no linkage yet" and skips the
+//                                    thread-side write. Read back by `--comment-sync`
+//                                    via get-issue-zoho-thread-id. See issue #422.
 //   get-reporter-email <issue>      Print state.issues[<issue>].reporterEmail (or
 //                                    empty string if absent / unknown). Exit 0
 //                                    regardless — callers branch on the printed
 //                                    value. Used by nightly-support.sh's gate.
+//   get-issue-zoho-thread-id <issue>
+//                                    Print state.issues[<issue>].zohoThreadId (or
+//                                    empty string if absent / unknown). Exit 0
+//                                    regardless — used by --comment-sync to decide
+//                                    routing. See issue #422.
+//   set-issue-field <issue> <field> <value>
+//                                    Allowlisted setter for support-side issue
+//                                    fields. <field> ∈ {zohoThreadId, reporterEmail,
+//                                    lastGithubCommentSyncAt}. Empty/whitespace
+//                                    values are rejected. Writes to zohoThreadId
+//                                    also mirror onto state.threads[<value>]
+//                                    (linkedIssue + fromAddress when the issue has
+//                                    a reporterEmail). See issue #422.
 //
 // Dark-factory subcommands (all prefixed with `factory:`). These mutate
 // logs/factory-state.json (separate file from support-state.json) via
@@ -199,19 +220,37 @@ async function main(argv) {
     case "record-filed-issue": {
       const issueNumber = positional[0];
       const senderEmail = positional[1];
+      const zohoThreadIdRaw = positional[2];
       if (!issueNumber || !senderEmail) {
-        throw new Error("record-filed-issue requires <issue-number> <sender-email>");
+        throw new Error(
+          "record-filed-issue requires <issue-number> <sender-email> [<zoho-thread-id>]",
+        );
       }
       const normalised = String(senderEmail).trim().toLowerCase();
       if (!normalised) {
         throw new Error("record-filed-issue: sender-email is empty after trim");
       }
+      // Empty string or the literal "null" (case-insensitive) → singleton path:
+      // no Zoho linkage yet, persist email only. support-agent.sh re-reads the
+      // patched footer post-filing and calls set-issue-field to fill it in.
+      const zohoThreadIdTrimmed = zohoThreadIdRaw == null ? "" : String(zohoThreadIdRaw).trim();
+      const zohoThreadId =
+        zohoThreadIdTrimmed === "" || zohoThreadIdTrimmed.toLowerCase() === "null"
+          ? null
+          : zohoThreadIdTrimmed;
       const state = await loadState(file);
       state.issues ??= {};
       state.issues[issueNumber] ??= {};
       state.issues[issueNumber].reporterEmail = normalised;
+      if (zohoThreadId != null) {
+        state.issues[issueNumber].zohoThreadId = zohoThreadId;
+        state.threads ??= {};
+        state.threads[zohoThreadId] ??= {};
+        state.threads[zohoThreadId].linkedIssue = String(issueNumber);
+        state.threads[zohoThreadId].fromAddress = normalised;
+      }
       await saveState(state, file);
-      return { ok: true, issueNumber, reporterEmail: normalised };
+      return { ok: true, issueNumber, reporterEmail: normalised, zohoThreadId };
     }
     case "get-reporter-email": {
       const issueNumber = positional[0];
@@ -224,6 +263,53 @@ async function main(argv) {
       // can `REPORTER_EMAIL=$(node ... get-reporter-email "$N")` directly.
       process.stdout.write(email);
       return null;
+    }
+    case "get-issue-zoho-thread-id": {
+      const issueNumber = positional[0];
+      if (!issueNumber) {
+        throw new Error("get-issue-zoho-thread-id requires <issue-number>");
+      }
+      const state = await loadState(file);
+      const id = state.issues?.[issueNumber]?.zohoThreadId ?? "";
+      // Bare value, no JSON, no trailing newline — bash callers capture directly.
+      process.stdout.write(id);
+      return null;
+    }
+    case "set-issue-field": {
+      // Allowlist guards against typos clobbering structured fields like
+      // lastKnownState (a nested object) or lastIssueStateSync (an audit
+      // timestamp set by --state-sync). Keep this set narrow; widen only when
+      // there is a real operator need.
+      const ALLOWED = new Set(["zohoThreadId", "reporterEmail", "lastGithubCommentSyncAt"]);
+      const issueNumber = positional[0];
+      const field = positional[1];
+      const value = positional[2];
+      if (!issueNumber || !field || value == null) {
+        throw new Error("set-issue-field requires <issue-number> <field> <value>");
+      }
+      if (!ALLOWED.has(field)) {
+        throw new Error(
+          `set-issue-field: field '${field}' not in allowlist (${[...ALLOWED].join(", ")})`,
+        );
+      }
+      let normalised = String(value).trim();
+      if (!normalised) {
+        throw new Error("set-issue-field: value is empty after trim");
+      }
+      if (field === "reporterEmail") normalised = normalised.toLowerCase();
+      const state = await loadState(file);
+      state.issues ??= {};
+      state.issues[issueNumber] ??= {};
+      state.issues[issueNumber][field] = normalised;
+      if (field === "zohoThreadId") {
+        state.threads ??= {};
+        state.threads[normalised] ??= {};
+        state.threads[normalised].linkedIssue = String(issueNumber);
+        const email = state.issues[issueNumber].reporterEmail;
+        if (email) state.threads[normalised].fromAddress = email;
+      }
+      await saveState(state, file);
+      return { ok: true, issueNumber, field, value: normalised };
     }
     case "factory:pause": {
       const reason = positional[0] ?? null;
@@ -344,8 +430,10 @@ async function main(argv) {
           "bump-counters <track-key> <sender>|" +
           "set-issue-cursor <issue-number> <cursor-iso>|" +
           "set-issue-state <issue-number> <state> [<state-reason>]|" +
-          "record-filed-issue <issue-number> <sender-email>|" +
+          "record-filed-issue <issue-number> <sender-email> [<zoho-thread-id>]|" +
           "get-reporter-email <issue-number>|" +
+          "get-issue-zoho-thread-id <issue-number>|" +
+          "set-issue-field <issue-number> <field> <value>|" +
           "factory:pause [<reason>]|" +
           "factory:resume|" +
           "factory:status|" +

--- a/scripts/lib/state-cli.mjs
+++ b/scripts/lib/state-cli.mjs
@@ -307,6 +307,16 @@ async function main(argv) {
         state.threads[normalised].linkedIssue = String(issueNumber);
         const email = state.issues[issueNumber].reporterEmail;
         if (email) state.threads[normalised].fromAddress = email;
+      } else if (field === "reporterEmail") {
+        // Keep state.threads[<id>].fromAddress in sync with the new
+        // reporterEmail; the threads side is documented as a joinless mirror
+        // and operators should not have to remember to update both.
+        const existingThreadId = state.issues[issueNumber].zohoThreadId;
+        if (existingThreadId) {
+          state.threads ??= {};
+          state.threads[existingThreadId] ??= {};
+          state.threads[existingThreadId].fromAddress = normalised;
+        }
       }
       await saveState(state, file);
       return { ok: true, issueNumber, field, value: normalised };

--- a/scripts/lib/state.mjs
+++ b/scripts/lib/state.mjs
@@ -13,6 +13,15 @@
 //                                                    // successful filed-issue. nightly-support.sh
 //                                                    // reads this to gate auto-implementation
 //                                                    // — see ADR-0025.
+//         zohoThreadId:            string,           // canonical link to the Zoho thread the
+//                                                    // customer reads. Written by
+//                                                    // record-filed-issue (3rd positional) or by
+//                                                    // set-issue-field (singleton post-filing
+//                                                    // backfill in support-agent.sh). Read by
+//                                                    // --comment-sync to route progress
+//                                                    // updates. Replaces the unreliable
+//                                                    // issue-body footer source — see issue
+//                                                    // #422.
 //         lastGithubCommentSyncAt: ISO-8601,        // cursor for comment-sync
 //         lastIssueStateSync:      ISO-8601,        // cursor for state-sync
 //         lastKnownState: {
@@ -24,7 +33,15 @@
 //     threads: {
 //       "<zohoThreadId>": {
 //         autoReplies:              [ISO-8601, ...],   // last 24h, for ≤3 cap
-//         lastAdminNotificationAt:  ISO-8601 | null     // for 24h cooldown
+//         lastAdminNotificationAt:  ISO-8601 | null,   // for 24h cooldown
+//         linkedIssue:              string,            // GH issue number — mirror of
+//                                                       // issues[<n>].zohoThreadId for joinless
+//                                                       // lookup. Written alongside zohoThreadId
+//                                                       // by record-filed-issue / set-issue-field
+//                                                       // (issue #422).
+//         fromAddress:              string             // lower-cased customer email — mirror of
+//                                                       // reporterEmail for joinless lookup
+//                                                       // (issue #422).
 //       }
 //     },
 //     senders: {

--- a/scripts/support-agent-prompt.md
+++ b/scripts/support-agent-prompt.md
@@ -313,6 +313,13 @@ it as new mail or file a duplicate issue. Instead:
        (the footer already has the real id). Skip if `ackThreadId` came
        back null too (rare; log and continue — comment-sync just won't
        work for this issue, but filing succeeded).
+     - **Important (issue #422):** the bash runner re-reads this patched
+       footer immediately after the `filed-issue` action returns and
+       mirrors `<ackThreadId>` into `logs/support-state.json` so
+       `--comment-sync` can route progress updates. If you skip this
+       patch (or write `null`), comment-sync will log a WARNING and
+       progress updates won't reach the customer until an operator runs
+       `state-cli set-issue-field <n> zohoThreadId <id>` manually.
    - `move-to-folder <threadId> Drafto/Support/Resolved` (skip when the
      original `threadId` is null — folder moves require a thread id).
    - **No admin notification** for allowlisted senders.

--- a/scripts/support-agent.sh
+++ b/scripts/support-agent.sh
@@ -335,11 +335,17 @@ if [[ "$COMMENT_SYNC" -eq 1 ]]; then
     ISSUE_NUMBER=$(echo "$ISSUE_ENTRY" | jq -r '.number')
     ISSUE_BODY=$(echo "$ISSUE_ENTRY" | jq -r '.body // ""')
 
-    # Find the linked Zoho thread via the issue body's agent footer. If the
-    # issue lacks the footer (e.g. an older Apps-Script-era issue) we have
-    # no way to reach the customer — skip silently. This is correct: those
-    # threads are decommissioned in Phase H anyway.
-    THREAD_ID=$(printf '%s' "$ISSUE_BODY" | node "$SCRIPT_DIR/lib/parse-issue-footer.mjs" --field zoho-thread-id 2>>"$LOG_FILE" || echo "")
+    # Find the linked Zoho thread via state.issues[<n>].zohoThreadId. This is
+    # written by record-filed-issue at filing time (and by set-issue-field for
+    # singletons whose ackThreadId only exists after Claude's auto-reply has
+    # gone out). Before issue #422 this came from the issue body's agent
+    # footer, but that field was unreliable for singleton-first-contact
+    # tickets (initialised with `null` and not always patched), so state.json
+    # is now the source of truth. Issues with no linkage (older Apps-Script-
+    # era, or pre-fix singletons that need a one-off `set-issue-field`) are
+    # skipped silently — same behaviour as before.
+    THREAD_ID=$(node "$SCRIPT_DIR/lib/state-cli.mjs" get-issue-zoho-thread-id "$ISSUE_NUMBER" \
+      --state-file "$STATE_FILE" 2>>"$LOG_FILE" || echo "")
     if [[ -z "$THREAD_ID" ]]; then
       continue
     fi
@@ -985,16 +991,37 @@ for THREAD_INDEX in $(seq 0 $((PENDING_COUNT - 1))); do
       # customer in-thread, applied the Drafto/Support/Issue/<n> label, and
       # moved the thread to Drafto/Support/Resolved.
       #
-      # Persist the inbound sender against the issue number (ADR-0025). The
-      # bash runner extracted SENDER from the Zoho bundle BEFORE invoking
-      # Claude — that's the authoritative source for the allowlist gate.
-      # nightly-support.sh reads this at gate time instead of parsing an
-      # LLM-written footer in the issue body.
+      # Persist the inbound sender against the issue number (ADR-0025) and —
+      # when Zoho gave us a real threadId on the inbound side — the linkage
+      # too (issue #422). Both are extracted from the Zoho bundle BEFORE
+      # invoking Claude, so they are the authoritative source. The empty-arg
+      # form (third positional `""`) is the singleton path: state-cli persists
+      # the email only, and the post-filing footer re-read below mirrors the
+      # ackThreadId Claude has just written.
       ISSUE_NUM=$(echo "$SUMMARY_LINE" | sed -E 's/.*issue=([^ ]+).*/\1/')
       if [[ -n "$ISSUE_NUM" && "$ISSUE_NUM" != "-" && -n "$SENDER" ]]; then
-        if ! node "$SCRIPT_DIR/lib/state-cli.mjs" record-filed-issue "$ISSUE_NUM" "$SENDER" \
+        if ! node "$SCRIPT_DIR/lib/state-cli.mjs" record-filed-issue "$ISSUE_NUM" "$SENDER" "${THREAD_ID:-}" \
             --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1; then
           log "WARNING: state-cli record-filed-issue failed for issue $ISSUE_NUM ($TRACK_ID)"
+        fi
+        # Singleton path (issue #422): the inbound message had no Zoho
+        # threadId, so record-filed-issue couldn't persist the linkage. Claude
+        # has now sent the auto-reply and patched the GitHub issue body
+        # footer with the ackThreadId. Re-read the footer once and mirror the
+        # value into state.json so --comment-sync can route progress updates
+        # back to the customer's thread. Costs one extra `gh issue view` per
+        # singleton filed-issue action (~1/day typical).
+        if [[ -z "${THREAD_ID:-}" ]]; then
+          ACK_TID=$(gh issue view "$ISSUE_NUM" --json body --jq .body 2>>"$LOG_FILE" \
+            | node "$SCRIPT_DIR/lib/parse-issue-footer.mjs" --field zoho-thread-id 2>>"$LOG_FILE" || echo "")
+          if [[ -n "$ACK_TID" && "$ACK_TID" != "null" ]]; then
+            if ! node "$SCRIPT_DIR/lib/state-cli.mjs" set-issue-field "$ISSUE_NUM" zohoThreadId "$ACK_TID" \
+                --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1; then
+              log "WARNING: set-issue-field zohoThreadId failed for issue $ISSUE_NUM"
+            fi
+          else
+            log "WARNING: singleton issue $ISSUE_NUM has no zoho-thread-id in footer after filing — comment-sync will skip until an operator runs set-issue-field"
+          fi
         fi
       else
         log "WARNING: filed-issue but cannot record sender (issue=$ISSUE_NUM sender=${SENDER:-<empty>})"


### PR DESCRIPTION
## Summary

Closes #422. `--comment-sync` was silently dropping bot-authored Phase G progress comments for singleton-first-contact tickets (confirmed for #360 and #409) because the issue-body footer's `zoho-thread-id` was initialised with `null` and the LLM didn't always patch it once Zoho assigned a real `ackThreadId`. This PR moves the source of truth onto `state.issues[<n>].zohoThreadId`, written authoritatively by `support-agent.sh` at filing time (and re-read from the patched footer for singletons).

- `record-filed-issue` accepts an optional 3rd positional `<zoho-thread-id>` and mirrors onto `state.threads[<id>]` (`linkedIssue` + `fromAddress`).
- New `get-issue-zoho-thread-id` (read) and `set-issue-field` (allowlisted: `zohoThreadId`, `reporterEmail`, `lastGithubCommentSyncAt`).
- `support-agent.sh` filing path passes the threadId through; for singletons (empty inbound) it re-reads the patched footer post-filing via `gh issue view` and mirrors `ackThreadId` into state. `--comment-sync` now reads from state, not the footer.
- Footer remains in the issue body as provenance only — ADR-0025 updated.

## Backfill not included

Per the planning conversation, the backfill is out of scope. Any currently-open pre-fix issue whose footer Claude failed to patch can be patched manually:

```bash
node scripts/lib/state-cli.mjs set-issue-field <issue> zohoThreadId <id>
```

Known footer-null open issues from tonight's logs: #360, #408, #409 — though most are already closed.

## Test plan

- [x] `node --test scripts/__tests__/state-cli-{reporter-email,set-issue-field,get-issue-zoho-thread-id}.test.mjs` → 26/26 pass
- [x] Adjacent script test suites (`state-cli.test.mjs`, `state-cli-factory.test.mjs`, `parse-issue-footer.test.mjs`, `policy.test.mjs`) → 76/76 pass, no regression
- [x] Smoke procedure (Case A reply-to-existing, Case B singleton + set-issue-field, allowlist guard, empty-3rd-arg) → all pass against a temp state file
- [x] `pnpm lint` (0 errors), `pnpm typecheck` (clean), `pnpm format:check` (clean), `bash -n scripts/support-agent.sh`
- [ ] Next live `--comment-sync` tick on the Mac mini will exercise the read path against real state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unreliable Zoho thread ID sourcing for comment synchronization. Thread IDs now persist in state using a more reliable approach, ensuring customer inbox routing works consistently for all issue types.

* **Documentation**
  * Updated architectural decision record and schema documentation to clarify the improved Zoho thread ID handling mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JakubAnderwald/drafto/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->