### PR TITLE
docs(workflow): require local /code-review before /push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ Common CI failure patterns:
 - Pre-commit hooks run lint-staged (ESLint + Prettier)
 - **Never commit or push directly to `main`** unless the user explicitly requests it. All work goes through feature branches and PRs.
 - **All pushes must use the `/push` command** — this ensures commits are pushed, CI/CD checks are polled until green, review comments are addressed, and failures are fixed automatically
+- **Before `/push`, run `/code-review` on the pending diff** for any non-trivial change (anything beyond typos, comment edits, or pure renames). Fix or explicitly explain its findings before opening the PR — this catches the same class of issues CodeRabbit catches (mirror-invariant violations, stale doc references, missed edge cases), locally, and saves the post-PR round-trip
 
 ## Release Authorization
 


### PR DESCRIPTION
## Summary

Adds a single Git Conventions bullet in `CLAUDE.md`: run `/code-review` on the pending diff before `/push` for non-trivial changes.

The two findings CodeRabbit caught on #424 — a stale ADR "Related" section and a missing mirror-invariant update on `set-issue-field reporterEmail` — are exactly the class of issues the `code-review` skill is designed for. Moving the pass earlier compresses the feedback loop from a post-PR round-trip to a local pre-commit step and avoids the swap-and-retry I just had to do on #424.

Scoped to non-trivial changes only (excludes typos, comment edits, pure renames) so it doesn't add overhead to micro-PRs.

## Test plan

- [x] Diff is a one-line addition to the existing "Git Conventions" section
- [x] No code changes; no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)