### PR TITLE
fix(dark-factory): don't early-exit --plan when Ready queue is empty

### DIFF
--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -553,11 +553,10 @@ if [[ "$MODE_PLAN" -eq 1 ]]; then
   fi
   log "--plan: $READY_COUNT Ready item(s) on the board"
 
-  if [[ "$READY_COUNT" -eq 0 ]]; then
-    log "=== factory-agent --plan completed in $(( $(date +%s) - START_TIME ))s ==="
-    exit 0
-  fi
-
+  # PROMPT_TEXT is needed by BOTH the Ready loop and the Plan Review replan
+  # sweep below. Load it once up front so the replan sweep still runs even
+  # when there are zero Ready cards (an early-exit here would skip replans
+  # entirely on a board that has only Plan Review work).
   PROMPT_TEXT=""
   if [[ "$DRY_RUN" -eq 0 ]]; then PROMPT_TEXT=$(cat "$PROMPT_FILE"); fi
 


### PR DESCRIPTION
## Summary

PR #426 added a Plan Review replan sweep after the Ready loop, but missed that the original `--plan` flow has a `READY_COUNT == 0 → exit 0` short-circuit at line 556 (now line 556 post-merge). That short-circuit fires before the new replan sweep, so a board with only Plan Review work never reaches it. Operator comments on Plan Review cards never trigger the in-place replan.

Confirmed live: the 15:09 tick on the Mac mini logged `--plan: 0 Ready item(s) on the board` and exited in 2 s, never running the new Plan Review sweep code.

## Fix

- Drop the early exit. The Ready for-loop iterates 0 times naturally when `READY_COUNT == 0`, then falls through to the replan sweep.
- Hoist `PROMPT_TEXT` load to before the Ready loop so it's also available when only the replan sweep has work to do.

## Test plan

- [x] `bash -n scripts/factory-agent.sh` passes
- [x] `pnpm format:check` clean
- [x] `node --test scripts/__tests__/factory-bundle.test.mjs` — 27/27 pass
- [ ] Post-merge: next factory tick should log `--plan replan sweep: N Plan Review item(s)` and pick up #423's unacked logo-image comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)