### PR TITLE
fix(dark-factory): rescue orphaned "Planning" cards in --plan sweep

### DIFF
--- a/docs/features/dark-factory.md
+++ b/docs/features/dark-factory.md
@@ -86,6 +86,10 @@ After filing, drag the card to **Ready** on the board. The factory picks it up o
 2. Check the agent saw the card on its latest tick: `logs/launchd-factory-stdout.log` (or `logs/factory-plan-*.log`) should mention the board fetch. A `factory-project find-project failed` warning means the `gh` token on the Mac mini is missing the `project` scope — run `gh auth refresh -s project`.
 3. If the tick ran and the card was in scope but ignored: check the issue for a `factory-pause` label, or `logs/factory-state.json` for a global `paused: true` flag, or the issue's retry budget under `issues[<n>].attempts`.
 
+### "A card is stuck in Planning"
+
+`Planning` is a transient, factory-owned status — a card should only sit there for the seconds a planner runs. If one is parked there across ticks, an earlier `--plan` tick died between moving the card to Planning and its follow-up transition (e.g. a launchd SIGTERM during the board write, which stranded #418, or a claude timeout). You don't need to do anything: the **rescue sweep** at the top of every `--plan` tick re-floats orphaned Planning cards automatically — if the plan comment was already posted it goes back to **Plan Review**, otherwise it returns to **Ready** to be re-planned (bounded by the `attempts` budget, so a card that keeps dying ends up **Blocked**). To recover immediately instead of waiting for the next tick, drag the card to **Plan Review** (plan comment present) or **Ready** (no plan comment) by hand.
+
 ### "The plan comment looks wrong / Claude misread the issue"
 
 This is exactly what the Plan Review gate catches. Don't drag to In Progress. Two paths:

--- a/scripts/__tests__/factory-agent-plan-rescue.test.mjs
+++ b/scripts/__tests__/factory-agent-plan-rescue.test.mjs
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Regression test for the orphaned-"Planning" rescue sweep.
+//
+// Background (issue #418): a --plan tick was killed by SIGTERM while writing
+// the board status back from Planning → Plan Review after a successful replan.
+// The card was stranded in Planning forever: the Ready sweep only scans Ready
+// items and the replan sweep only scans Plan Review items, so nothing ever
+// re-floated it. The rescue sweep at the top of --plan fixes this class of
+// orphan. These assertions lock in the behaviour and — critically — its
+// ordering relative to the Ready sweep.
+
+const scriptPath = resolve(dirname(fileURLToPath(import.meta.url)), "..", "factory-agent.sh");
+const script = readFileSync(scriptPath, "utf8");
+
+function runBash(snippet) {
+  const result = spawnSync("bash", ["-c", snippet], { encoding: "utf8" });
+  assert.equal(result.status, 0, `bash exited non-zero: ${result.stderr}`);
+  return result.stdout.trim().split("\n").filter(Boolean);
+}
+
+describe("factory-agent --plan orphaned-Planning rescue sweep", () => {
+  it("the script is syntactically valid bash", () => {
+    const result = spawnSync("bash", ["-n", scriptPath], { encoding: "utf8" });
+    assert.equal(result.status, 0, `bash -n failed: ${result.stderr}`);
+  });
+
+  it("queries the Planning queue for orphans", () => {
+    assert.match(
+      script,
+      /query-status-items\s+\\\n\s*--status Planning/,
+      "expected a rescue query against the Planning status",
+    );
+  });
+
+  it("runs the rescue sweep BEFORE the Ready sweep parks new cards in Planning", () => {
+    // This ordering is the whole correctness argument: because the per-mode
+    // plan lock guarantees no concurrent planner, any card in Planning at the
+    // TOP of the tick is a genuine orphan. If the rescue ran after the Ready
+    // sweep it could grab a card this very tick just moved into Planning.
+    const rescueIdx = script.indexOf("rescue sweep:");
+    const readyQueryIdx = script.indexOf("Pull the Ready queue from the board");
+    assert.ok(rescueIdx > 0, "expected a rescue sweep log line");
+    assert.ok(readyQueryIdx > 0, "expected the Ready queue fetch");
+    assert.ok(rescueIdx < readyQueryIdx, "rescue sweep must precede the Ready queue fetch");
+  });
+
+  it("uses a C-style for-loop (the #414 BSD-seq-safe form)", () => {
+    assert.match(
+      script,
+      /for\s*\(\(IDX=0;\s*IDX<RESCUE_COUNT;\s*IDX\+\+\)\)/,
+      "expected C-style for-loop over RESCUE_COUNT",
+    );
+  });
+
+  it("routes orphans by whether a plan comment exists", () => {
+    // Isolate the rescue block (top of --plan, ends at the Ready queue fetch).
+    const start = script.indexOf("Orphaned-Planning rescue sweep");
+    const end = script.indexOf("Pull the Ready queue from the board");
+    assert.ok(start > 0 && end > start, "could not isolate the rescue block");
+    const block = script.slice(start, end);
+
+    // Decision is gated on the existing plan-marker helper.
+    assert.match(block, /issue_already_planned "\$COMMENTS_JSON"/);
+    // plan comment present → Plan Review.
+    assert.match(block, /transition_status "\$ITEM_ID" "\$ISSUE_NUM" "Plan Review"/);
+    // no plan comment → Ready (re-plan from scratch).
+    assert.match(block, /transition_status "\$ITEM_ID" "\$ISSUE_NUM" "Ready"/);
+    // exhausted retry budget → Blocked (bounds a persistently-dying card).
+    assert.match(block, /transition_status "\$ITEM_ID" "\$ISSUE_NUM" "Blocked"/);
+    // honours the per-card kill switch.
+    assert.match(block, /factory-pause/);
+  });
+
+  it("C-style loop does not iterate when RESCUE_COUNT is 0", () => {
+    const lines = runBash(
+      'RESCUE_COUNT=0; for ((IDX=0; IDX<RESCUE_COUNT; IDX++)); do echo "$IDX"; done',
+    );
+    assert.deepEqual(lines, [], "rescue loop must be a no-op on an empty Planning queue");
+  });
+
+  it("non-numeric count is coerced to 0 before the loop", () => {
+    // Mirrors the guard in the script: a malformed jq result must not let the
+    // loop run with a garbage bound.
+    const lines = runBash(
+      'RESCUE_COUNT="oops"; if ! [[ "$RESCUE_COUNT" =~ ^[0-9]+$ ]]; then RESCUE_COUNT=0; fi; ' +
+        'for ((IDX=0; IDX<RESCUE_COUNT; IDX++)); do echo "$IDX"; done; echo "count=$RESCUE_COUNT"',
+    );
+    assert.deepEqual(lines, ["count=0"]);
+  });
+});

--- a/scripts/__tests__/factory-agent-plan-rescue.test.mjs
+++ b/scripts/__tests__/factory-agent-plan-rescue.test.mjs
@@ -73,6 +73,10 @@ describe("factory-agent --plan orphaned-Planning rescue sweep", () => {
     assert.match(block, /transition_status "\$ITEM_ID" "\$ISSUE_NUM" "Ready"/);
     // exhausted retry budget → Blocked (bounds a persistently-dying card).
     assert.match(block, /transition_status "\$ITEM_ID" "\$ISSUE_NUM" "Blocked"/);
+    // the exhaustion notice is idempotency-guarded so a stuck → Blocked
+    // transition can't make every subsequent tick re-post the same comment.
+    assert.match(block, /jq -e/);
+    assert.match(block, /test\("<!-- drafto-factory-retry-exhausted -->"\)/);
     // honours the per-card kill switch.
     assert.match(block, /factory-pause/);
   });

--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -540,6 +540,91 @@ if [[ "$MODE_PLAN" -eq 1 ]]; then
     exit 1
   fi
 
+  # ── Orphaned-Planning rescue sweep ──────────────────────────────────────────
+  # "Planning" is a transient, factory-owned status: both the Ready sweep and
+  # the replan sweep below park a card there only for the span of a single
+  # claude invocation, then move it on (→ Plan Review, or → Blocked). Every
+  # --plan tick holds the per-mode lock (logs/factory-plan.lock), so no other
+  # planner can be mid-flight when this tick begins — which means ANY card
+  # already sitting in Planning right now is an orphan a previous tick left
+  # behind after dying between "→ Planning" and its follow-up move. That
+  # happens when the tick is killed mid-transition (a launchd SIGTERM during
+  # the set-status write stranded #418 this way), or when a claude call times
+  # out / errors and the card is left parked at Planning. Planning is in
+  # neither the Ready queue nor the Plan Review queue, so nothing else would
+  # ever pick these up — we rescue them here, BEFORE the Ready sweep parks any
+  # fresh card in Planning, which guarantees we only ever touch real orphans.
+  #
+  #   • plan comment present → the plan was produced; only the Planning →
+  #     Plan Review hop is missing. Re-emit it. The replan sweep later in THIS
+  #     same tick then handles any operator feedback already waiting on it.
+  #   • no plan comment      → the planner never posted. Send the card back to
+  #     Ready so this tick's Ready sweep re-plans from scratch, bumping the
+  #     attempts counter (claude timeouts don't, so this is what bounds a
+  #     persistently-dying card) so it ends up Blocked rather than looping.
+  if RESCUE_JSON=$(node "$SCRIPT_DIR/lib/factory-project.mjs" query-status-items \
+      --status Planning 2>>"$LOG_FILE"); then
+    RESCUE_COUNT=$(echo "$RESCUE_JSON" | jq 'length' 2>/dev/null || echo "0")
+    if ! [[ "$RESCUE_COUNT" =~ ^[0-9]+$ ]]; then RESCUE_COUNT=0; fi
+    if [[ "$RESCUE_COUNT" -gt 0 ]]; then
+      log "--plan rescue sweep: $RESCUE_COUNT orphaned Planning item(s) on the board"
+    fi
+    for ((IDX=0; IDX<RESCUE_COUNT; IDX++)); do
+      ITEM=$(echo "$RESCUE_JSON" | jq ".[${IDX}]")
+      ITEM_ID=$(echo "$ITEM" | jq -r '.itemId')
+      ISSUE_NUM=$(echo "$ITEM" | jq -r '.issueNumber')
+      ITEM_LABELS=$(echo "$ITEM" | jq -r '.labels // [] | join(",")')
+
+      if [[ ",$ITEM_LABELS," == *",factory-pause,"* ]]; then
+        log "Issue #$ISSUE_NUM: skipping rescue (factory-pause label set)"
+        continue
+      fi
+
+      if ! COMMENTS_JSON=$(fetch_issue_comments "$ISSUE_NUM"); then
+        log "WARNING: fetch_issue_comments failed for #$ISSUE_NUM (rescue sweep); skipping"
+        continue
+      fi
+
+      if issue_already_planned "$COMMENTS_JSON"; then
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+          log "DRY-RUN: would rescue orphaned #$ISSUE_NUM (plan comment present) → Plan Review"
+          continue
+        fi
+        log "Issue #$ISSUE_NUM: orphaned in Planning with a plan comment → restoring to Plan Review"
+        transition_status "$ITEM_ID" "$ISSUE_NUM" "Plan Review" || true
+        node "$SCRIPT_DIR/lib/state-cli.mjs" factory:reset-attempts "$ISSUE_NUM" \
+          --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+        continue
+      fi
+
+      if [[ "$DRY_RUN" -eq 1 ]]; then
+        log "DRY-RUN: would rescue orphaned #$ISSUE_NUM (no plan comment) → Ready"
+        continue
+      fi
+      ATTEMPTS=$(node "$SCRIPT_DIR/lib/state-cli.mjs" factory:bump-attempts "$ISSUE_NUM" \
+        --state-file "$STATE_FILE" 2>>"$LOG_FILE" | jq -r '.attempts // 0' || echo "0")
+      if [[ "$ATTEMPTS" -ge 5 ]]; then
+        log "Issue #$ISSUE_NUM: orphaned in Planning, no plan comment, retry budget exhausted ($ATTEMPTS) → Blocked"
+        gh issue comment "$ISSUE_NUM" --repo JakubAnderwald/drafto \
+          --body "🏭 **Planning stalled ($ATTEMPTS attempts).**
+
+The factory kept starting to plan this issue but never managed to post a plan — \
+claude timed out or the tick was killed mid-flight each time. Investigate via \
+\`logs/factory/factory-agent-plan-*.log\` on the Mac mini, then run \
+\`node scripts/lib/state-cli.mjs factory:reset-attempts $ISSUE_NUM\` and drag the \
+card back to **Ready**.
+
+<!-- drafto-factory-retry-exhausted -->" >>"$LOG_FILE" 2>&1 || true
+        transition_status "$ITEM_ID" "$ISSUE_NUM" "Blocked" || true
+      else
+        log "Issue #$ISSUE_NUM: orphaned in Planning with no plan comment → returning to Ready for a fresh plan"
+        transition_status "$ITEM_ID" "$ISSUE_NUM" "Ready" || true
+      fi
+    done
+  else
+    log "WARNING: query-status-items Planning failed (transient?); skipping rescue sweep this tick"
+  fi
+
   # Pull the Ready queue from the board. Transient lookup → skip this tick.
   if ! READY_JSON=$(node "$SCRIPT_DIR/lib/factory-project.mjs" query-status-items \
       --status Ready 2>>"$LOG_FILE"); then
@@ -653,7 +738,8 @@ See \`docs/features/dark-factory.md\` for the spec contract.
     if [[ $EXIT_CODE -eq 124 ]]; then
       log "WARNING: claude timed out (>${CLAUDE_CALL_TIMEOUT_SEC}s) for #$ISSUE_NUM --plan — skipping; next tick retries"
       rm -f "$CLAUDE_OUTPUT_FILE"
-      # Leave card at Planning so next tick picks it up.
+      # Leave card at Planning; the next tick's rescue sweep (top of --plan)
+      # returns it to Ready — it has no plan comment yet — so planning restarts.
       continue
     elif [[ $EXIT_CODE -ne 0 ]]; then
       log "ERROR: claude exited non-zero ($EXIT_CODE) for #$ISSUE_NUM --plan"

--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -605,8 +605,15 @@ if [[ "$MODE_PLAN" -eq 1 ]]; then
         --state-file "$STATE_FILE" 2>>"$LOG_FILE" | jq -r '.attempts // 0' || echo "0")
       if [[ "$ATTEMPTS" -ge 5 ]]; then
         log "Issue #$ISSUE_NUM: orphaned in Planning, no plan comment, retry budget exhausted ($ATTEMPTS) → Blocked"
-        gh issue comment "$ISSUE_NUM" --repo JakubAnderwald/drafto \
-          --body "🏭 **Planning stalled ($ATTEMPTS attempts).**
+        # Idempotent: post the exhaustion notice at most once. If a prior tick
+        # already posted it but the → Blocked transition then failed (leaving
+        # the card in Planning with attempts still ≥5), this guard stops every
+        # subsequent rescue tick re-posting the same comment. Same marker-based
+        # check the issue_already_* helpers use.
+        if ! echo "$COMMENTS_JSON" | jq -e \
+            'any(.[]; .body | test("<!-- drafto-factory-retry-exhausted -->"))' >/dev/null 2>&1; then
+          gh issue comment "$ISSUE_NUM" --repo JakubAnderwald/drafto \
+            --body "🏭 **Planning stalled ($ATTEMPTS attempts).**
 
 The factory kept starting to plan this issue but never managed to post a plan — \
 claude timed out or the tick was killed mid-flight each time. Investigate via \
@@ -615,6 +622,7 @@ claude timed out or the tick was killed mid-flight each time. Investigate via \
 card back to **Ready**.
 
 <!-- drafto-factory-retry-exhausted -->" >>"$LOG_FILE" 2>&1 || true
+        fi
         transition_status "$ITEM_ID" "$ISSUE_NUM" "Blocked" || true
       else
         log "Issue #$ISSUE_NUM: orphaned in Planning with no plan comment → returning to Ready for a fresh plan"


### PR DESCRIPTION
## Why

A `--plan` tick that dies between moving a card to **Planning** and its follow-up transition strands the card forever: the Ready sweep only scans **Ready** and the replan sweep only scans **Plan Review**, so nothing ever re-floats a card sitting in **Planning**.

This is how **#418** got stuck — on 2026-05-23 a launchd SIGTERM killed a `--plan` tick mid `set-status` while it was restoring #418 from Planning → Plan Review after a successful in-place replan. The replan itself succeeded (plan comment edited + ack marker stamped); only the final board-status write was lost, leaving the card orphaned in Planning with no recovery path.

## What

Adds an **orphaned-Planning rescue sweep** at the top of `--plan`, before the Ready sweep parks any fresh card in Planning. Because every `--plan` tick holds the per-mode lock, any card already in Planning when the tick starts is provably a previous-tick orphan:

- **plan comment present** → restore to **Plan Review** (resets attempts). The replan sweep later in the same tick then handles any operator feedback already waiting on the card. _(This auto-rescues #418.)_
- **no plan comment** → return to **Ready** for a fresh plan, bumping the attempts counter. Claude timeouts don't bump attempts, so this is the only thing that bounds a card that keeps dying → **Blocked** at the budget.

Also corrects the now-accurate first-plan-timeout comment that claimed "next tick picks it up" — it didn't, until this sweep existed.

## Tests

New `scripts/__tests__/factory-agent-plan-rescue.test.mjs` (7 cases): Planning-queue query, **ordering before the Ready sweep** (the correctness invariant), routing by plan-comment presence, C-style loop (the #414 BSD-seq-safe form), and the count guards. All 310 `scripts/__tests__` tests pass; `bash -n` and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic recovery mechanism for cards stuck in **Planning** status. Cards are now automatically transitioned based on plan marker presence.

* **Documentation**
  * Added troubleshooting guide explaining **Planning** status behavior, common causes of cards getting stranded, and manual recovery steps.

* **Tests**
  * Added regression test suite validating the automatic rescue sweep functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JakubAnderwald/drafto/pull/430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->