### PR TITLE
feat(web): add close button to admin user-approval page

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -17,5 +17,9 @@ NEXT_PUBLIC_POSTHOG_KEY=phc_your-posthog-key
 # E2E_TEST_EMAIL=test@example.com
 # E2E_TEST_PASSWORD=your-test-password
 
+# E2E admin user (must be an approved admin user; required only for admin E2E specs)
+# E2E_ADMIN_EMAIL=admin@example.com
+# E2E_ADMIN_PASSWORD=your-admin-password
+
 # Set to "true" to skip env validation (useful in CI without secrets)
 # SKIP_ENV_VALIDATION=true

--- a/apps/web/__tests__/integration/admin-close-button.test.tsx
+++ b/apps/web/__tests__/integration/admin-close-button.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AdminCloseButton } from "@/app/(app)/admin/admin-close-button";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+describe("AdminCloseButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a close button with an accessible name", () => {
+    render(<AdminCloseButton />);
+
+    expect(screen.getByRole("button", { name: "Close admin" })).toBeInTheDocument();
+  });
+
+  it("navigates to the app home via client-side routing when clicked", async () => {
+    const user = userEvent.setup();
+    render(<AdminCloseButton />);
+
+    await user.click(screen.getByRole("button", { name: "Close admin" }));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith("/");
+  });
+});

--- a/apps/web/e2e/admin.spec.ts
+++ b/apps/web/e2e/admin.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Admin user-approval close-button E2E.
+ *
+ * Requires an authenticated admin storage state, provisioned by the
+ * "authenticate as admin" setup in `auth.setup.ts` from E2E_ADMIN_EMAIL /
+ * E2E_ADMIN_PASSWORD. When those secrets are absent the admin Playwright
+ * project is not registered (see `playwright.config.ts`), so these specs do
+ * not run; the describe-level skip is a belt-and-suspenders guard.
+ */
+const hasAdminCreds = !!process.env.E2E_ADMIN_EMAIL && !!process.env.E2E_ADMIN_PASSWORD;
+
+test.describe("admin user-approval close button", () => {
+  test.skip(!hasAdminCreds, "Admin E2E requires E2E_ADMIN_EMAIL/E2E_ADMIN_PASSWORD");
+
+  test("admin sees the close button on /admin", async ({ page }) => {
+    await page.goto("/admin");
+
+    await expect(page.getByRole("button", { name: "Close admin" })).toBeVisible();
+  });
+
+  test("clicking close navigates to / without a full reload", async ({ page }) => {
+    await page.goto("/admin");
+
+    // A full page reload fires a top-level "load" event; SPA navigation does
+    // not. Attach the listener before the click and assert it never fires.
+    let loadCount = 0;
+    page.on("load", () => {
+      loadCount += 1;
+    });
+
+    await page.getByRole("button", { name: "Close admin" }).click();
+
+    await expect(page).toHaveURL("/");
+    expect(loadCount).toBe(0);
+  });
+});

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -27,3 +27,30 @@ setup("authenticate", async ({ page }) => {
   // Save signed-in state to file
   await page.context().storageState({ path: "e2e/.auth/user.json" });
 });
+
+/**
+ * Authenticate as an admin E2E user and save storage state.
+ *
+ * Optional — skipped cleanly when the admin credentials are absent. Requires:
+ *   E2E_ADMIN_EMAIL    — email of an approved admin test user
+ *   E2E_ADMIN_PASSWORD — password for that user
+ */
+setup("authenticate as admin", async ({ page }) => {
+  const email = process.env.E2E_ADMIN_EMAIL;
+  const password = process.env.E2E_ADMIN_PASSWORD;
+
+  setup.skip(!email || !password, "E2E_ADMIN_EMAIL/E2E_ADMIN_PASSWORD not set");
+  if (!email || !password) return; // unreachable after skip; narrows types
+
+  await page.goto("/login");
+
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Log in" }).click();
+
+  // Wait until we're redirected away from the login page
+  await expect(page).not.toHaveURL(/\/login/);
+
+  // Save signed-in admin state to file
+  await page.context().storageState({ path: "e2e/.auth/admin.json" });
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// Admin specs require a logged-in admin storage state. Only register the admin
+// project when its credentials are provisioned — otherwise binding a missing
+// storage-state file would error, so we skip the project (and the spec) cleanly.
+const hasAdminCreds = !!process.env.E2E_ADMIN_EMAIL && !!process.env.E2E_ADMIN_PASSWORD;
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -26,7 +31,7 @@ export default defineConfig({
         storageState: "e2e/.auth/user.json",
       },
       dependencies: ["setup"],
-      testIgnore: [/auth\.setup\.ts/, /responsive\.spec\.ts/],
+      testIgnore: [/auth\.setup\.ts/, /responsive\.spec\.ts/, /admin\.spec\.ts/],
     },
 
     // Mobile — only runs responsive tests (desktop tests assume three-panel layout)
@@ -59,6 +64,22 @@ export default defineConfig({
       dependencies: ["setup"],
       testMatch: /responsive\.spec\.ts/,
     },
+
+    // Admin — runs admin specs with an authenticated admin storage state.
+    // Only registered when admin credentials are provisioned (see above).
+    ...(hasAdminCreds
+      ? [
+          {
+            name: "chromium-admin",
+            use: {
+              ...devices["Desktop Chrome"],
+              storageState: "e2e/.auth/admin.json",
+            },
+            dependencies: ["setup"],
+            testMatch: /admin\.spec\.ts/,
+          },
+        ]
+      : []),
   ],
   webServer: {
     command: process.env.CI ? "pnpm start" : "pnpm dev",

--- a/apps/web/src/app/(app)/admin/admin-close-button.tsx
+++ b/apps/web/src/app/(app)/admin/admin-close-button.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { IconButton } from "@/components/ui/icon-button";
+
+function CloseIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-5 w-5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+}
+
+/**
+ * Small close button for the admin user-approval page. Navigates back to the
+ * app home via client-side routing (`router.push`), so the panel closes
+ * immediately without a full page reload. `push("/")` is used rather than
+ * `router.back()` because the history stack can be empty on direct loads.
+ */
+export function AdminCloseButton() {
+  const router = useRouter();
+
+  return (
+    <IconButton size="sm" aria-label="Close admin" onClick={() => router.push("/")}>
+      <CloseIcon />
+    </IconButton>
+  );
+}

--- a/apps/web/src/app/(app)/admin/page.tsx
+++ b/apps/web/src/app/(app)/admin/page.tsx
@@ -3,6 +3,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { redirect } from "next/navigation";
 import { AdminUserList, type PendingUser } from "@/app/(app)/admin/admin-user-list";
 import { AdminFlashMessage } from "@/app/(app)/admin/admin-flash-message";
+import { AdminCloseButton } from "@/app/(app)/admin/admin-close-button";
 
 interface AdminPageProps {
   searchParams: Promise<{ approved?: string; error?: string }>;
@@ -55,7 +56,10 @@ export default async function AdminPage({ searchParams }: AdminPageProps) {
     <div className="mx-auto max-w-2xl p-8">
       <div className="mb-6 flex items-baseline justify-between">
         <h1 className="text-fg text-2xl font-bold">Admin — User Approval</h1>
-        <span className="text-fg-muted text-sm">{pendingUsers.length} pending</span>
+        <div className="flex items-center gap-3">
+          <span className="text-fg-muted text-sm">{pendingUsers.length} pending</span>
+          <AdminCloseButton />
+        </div>
       </div>
       <AdminFlashMessage approved={params.approved} error={params.error} />
       <AdminUserList initialUsers={pendingUsers} />


### PR DESCRIPTION
<!-- drafto-factory-pr -->

Closes #418

## Summary

Adds a small close (X) `IconButton` to the **Admin — User Approval** page header (`/admin`), next to the "N pending" count. Clicking it calls `router.push("/")` — Next.js client-side navigation — so the panel closes immediately with no full page reload, per the acceptance criteria. Implements the [approved plan](https://github.com/JakubAnderwald/drafto/issues/418#issuecomment-4524779242).

A naming note flagged by the plan: the spec calls this a "panel" but it's the full `/admin` route, not a modal. There is no in-place toggle to flip, so the closest match to "close without reload" is client-side navigation back to the app home.

## Parity report

Spec checked **web only**; mobile/desktop have no admin UI surface, so no parity work is needed.

- web — `apps/web/src/app/(app)/admin/admin-close-button.tsx` (new) + wired into `apps/web/src/app/(app)/admin/page.tsx` ✅
- mobile — not affected (no admin UI) — n/a
- desktop — not affected (no admin UI) — n/a

## Test plan

- [x] `pnpm --filter @drafto/web test` — 756 passed (includes new `admin-close-button.test.tsx`)
- [x] `pnpm --filter @drafto/web typecheck` — passed
- [x] `pnpm --filter @drafto/web lint` — 0 errors
- [x] `pnpm format:check` — passed
- [ ] `pnpm --filter @drafto/web exec playwright test e2e/admin.spec.ts` — gated on `E2E_ADMIN_EMAIL`/`E2E_ADMIN_PASSWORD`; skips cleanly without them (see below)

## Drift vs. approved plan

Implementation matches the plan's "Files to touch" exactly — all 7 listed files, nothing outside them.

One implementation refinement within the plan's intent: the plan's stated requirement that the admin E2E "skip cleanly when env vars are absent" cannot be met by binding `storageState: admin.json` at the project level (a missing file would error at context creation, not skip). So the admin Playwright project (`chromium-admin`) is registered **conditionally** on `E2E_ADMIN_EMAIL`/`E2E_ADMIN_PASSWORD` being present, `admin.spec.ts` is excluded from the default `chromium` project, and the admin auth setup uses `setup.skip(...)`. Net effect: when admin secrets are absent (current CI), the admin spec never runs and nothing errors; when they're set, it runs against an authenticated admin browser. CI will need `E2E_ADMIN_EMAIL`/`E2E_ADMIN_PASSWORD` secrets added before the admin E2E executes there.

🤖 Generated by the dark factory ([approved plan](https://github.com/JakubAnderwald/drafto/issues/418#issuecomment-4524779242))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a close button to the admin page for quick navigation back to the home screen.

* **Tests**
  * Added integration and end-to-end test coverage for the admin close button functionality to ensure proper navigation behavior.

* **Chores**
  * Updated environment variable configuration examples to support admin credential setup for E2E testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JakubAnderwald/drafto/pull/432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->