### PR TITLE
feat(dark-factory): in-test iteration loop — comment to request a revision

### DIFF
--- a/docs/dark-factory-proposal.md
+++ b/docs/dark-factory-proposal.md
@@ -18,6 +18,16 @@
 > the Approved drag while plan→implement→preview quality is validated.
 > Promotion to Phase B is the operator flipping `FACTORY_PHASE` on the plist.
 >
+> **In Test iteration (this update)**: a reporter comment on an In Test card
+> rolls it back to In Progress; the factory revises on the **same** PR branch
+> (the slot/worktree now persist across In Progress↔In Review↔In Test) and it
+> flows back to In Test. The implementer bundle gained `revisionComments` (the
+> new owner comments since a `lastFeedbackAt` high-water mark), pure
+> approval/noise comments are ignored, and approval stays the explicit Approved
+> drag. Lets a reporter who dislikes the preview request changes without
+> touching GitHub internals — the realistic "even if the plan looked fine"
+> path.
+>
 > **What's landed**:
 >
 > - **Wave 1 — Foundations** (PR #386, merged 2026-05-06): all 16 labels

--- a/docs/features/dark-factory.md
+++ b/docs/features/dark-factory.md
@@ -11,7 +11,7 @@ A "vibe-kanban-style" pipeline where moving a card on a GitHub Projects v2 board
 The runtime phase is set by `FACTORY_PHASE` on the launchd plist (see the runbook). The phases:
 
 - **Phase A (Plan-only).** `--plan` watches `status:ready` issues, posts a structured plan comment, and stops at `status:plan-review`. `--implement` posts a one-time "implementation skipped" stub; `--watch` / `--release` are no-ops.
-- **Phase B (Web-only, staged).** Approving a plan (drag Plan Review → In Progress) runs the real engine: `--implement` takes a worktree slot, implements the approved plan in `worktrees/factory-issue-<n>`, opens a PR, and runs the parity post-check (mobile/desktop changes are auto-blocked — Phase B is web-only). `--watch` then drives the PR: it runs a `/push`-style fix loop on failing CI / unresolved review comments and, once CI is green and the Vercel preview is reachable, advances the card to **In Test** and posts the preview URL. **`--release` (auto-merge on Approved) is deliberately deferred in this staged rollout** — the operator merges the PR by hand at the Approved drag while plan→implement→preview quality is proven. Promote per phase only after ≥5 clean runs without human intervention.
+- **Phase B (Web-only, staged).** Approving a plan (drag Plan Review → In Progress) runs the real engine: `--implement` takes a worktree slot, implements the approved plan in `worktrees/factory-issue-<n>`, opens a PR, and runs the parity post-check (mobile/desktop changes are auto-blocked — Phase B is web-only). `--watch` then drives the PR: it runs a `/push`-style fix loop on failing CI / unresolved review comments and, once CI is green and the Vercel preview is reachable, advances the card to **In Test** and posts the preview URL. **In Test iteration:** while a card sits in In Test, commenting on the issue with a change request rolls it back to **In Progress**; the factory revises on the **same** PR branch (reusing the slot, worktree, and preview URL) and it flows back to In Test. Repeat until you're happy. A pure "thanks/looks good" comment is treated as noise (no rework); approval stays explicit — drag to **Approved** (or, household, reply "ship it"). **`--release` (auto-merge on Approved) is deliberately deferred in this staged rollout** — the operator merges the PR by hand at the Approved drag while plan→implement→preview quality is proven. Promote per phase only after ≥5 clean runs without human intervention.
 
 ## The board
 
@@ -109,6 +109,10 @@ The factory's `--watch` mode loops `/push`-style: it reads CI failures and revie
 ### "Vercel preview never appeared in In Test"
 
 The factory advances In Review → In Test only when (a) CI is green AND (b) the Vercel bot has commented with a preview URL on the PR. If CI is green but Vercel hasn't run, check the Vercel project's GitHub integration is wired up; sometimes the bot misses a push and a force-push to bump the PR head re-triggers it.
+
+### "I tested the preview and want changes"
+
+Comment the change on the **issue** while the card is in **In Test** (e.g. "the close button overlaps the title — move it left"). On the next `--watch` tick the factory rolls the card back to **In Progress** and posts "🏭 revising…"; the next `--implement` tick applies your feedback on the **same** PR branch (the approved plan still bounds scope — a request outside it is Blocked for a re-plan), and the card flows back through In Review → In Test with the preview redeployed. Iterate as many rounds as you like. To stop and ship instead, drag the card to **Approved** (a "looks good"/"thanks" comment is treated as noise, not a ship signal — approval is always the explicit drag). The factory only acts on comments posted _after_ the preview it last showed you, so older discussion doesn't re-trigger work.
 
 ### "Allowlisted reporter's email reply didn't move the card"
 

--- a/scripts/__tests__/factory-bundle.test.mjs
+++ b/scripts/__tests__/factory-bundle.test.mjs
@@ -297,6 +297,32 @@ describe("buildFactoryImplementBundle", () => {
     assert.equal(bundle.priorPr.headRef, "factory/issue-1");
     assert.equal(bundle.attempts, 2);
   });
+
+  it("envelopes revisionComments (In Test feedback) and defaults to []", () => {
+    const fresh = buildFactoryImplementBundle({
+      issue: { number: 1, title: "x", body: SAMPLE_BODY, labels: [] },
+      config: { phase: "B" },
+      repo: { nameWithOwner: "JakubAnderwald/drafto" },
+    });
+    assert.deepEqual(
+      fresh.revisionComments,
+      [],
+      "first implementation carries no revision comments",
+    );
+
+    const revision = buildFactoryImplementBundle({
+      issue: { number: 1, title: "x", body: SAMPLE_BODY, labels: [] },
+      priorPr: { number: 7, url: "u", headRef: "factory/issue-1", state: "OPEN" },
+      revisionComments: [{ id: 3, user: { login: "jane" }, body: "move the button top-right" }],
+      config: { phase: "B" },
+      repo: { nameWithOwner: "JakubAnderwald/drafto" },
+    });
+    assert.equal(revision.revisionComments.length, 1);
+    assert.match(
+      revision.revisionComments[0].body,
+      /<comment>move the button top-right<\/comment>/,
+    );
+  });
 });
 
 describe("buildFactoryWatchBundle", () => {

--- a/scripts/__tests__/factory-intest-iteration.test.mjs
+++ b/scripts/__tests__/factory-intest-iteration.test.mjs
@@ -1,0 +1,144 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Tests for the In Test iteration loop: a reporter comment on an In Test card
+// rolls it back to In Progress for a revision on the same PR branch. Covers the
+// two new bash helpers (behaviourally, by extracting the real definitions from
+// the script) and the structural wiring in factory-agent.sh.
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const agentPath = resolve(HERE, "..", "factory-agent.sh");
+const script = readFileSync(agentPath, "utf8");
+
+// Run a bash snippet that extracts a function definition from the real script
+// (start of `name()` through its first column-0 `}`) and exercises it.
+function withFn(fn, body) {
+  const snippet = `
+set -euo pipefail
+eval "$(awk '/^${fn}\\(\\)/{f=1} f{print} f&&/^}/{exit}' "${agentPath}")"
+${body}
+`;
+  const r = spawnSync("bash", ["-c", snippet], { encoding: "utf8" });
+  assert.equal(r.status, 0, `bash failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+describe("is_noise_comment (extracted from factory-agent.sh)", () => {
+  const noise = ["thanks!", "Thank you", "LGTM 👍", "👍", "Looks good.", "ship it", "perfect", "x"];
+  const actionable = [
+    "move the button to the top-right",
+    "the close button overlaps the title",
+    "add an Esc key handler please",
+  ];
+  for (const c of noise) {
+    it(`treats ${JSON.stringify(c)} as noise`, () => {
+      assert.equal(
+        withFn(
+          "is_noise_comment",
+          `is_noise_comment ${JSON.stringify(c)} && echo NOISE || echo ACTIONABLE`,
+        ),
+        "NOISE",
+      );
+    });
+  }
+  for (const c of actionable) {
+    it(`treats ${JSON.stringify(c)} as actionable`, () => {
+      assert.equal(
+        withFn(
+          "is_noise_comment",
+          `is_noise_comment ${JSON.stringify(c)} && echo NOISE || echo ACTIONABLE`,
+        ),
+        "ACTIONABLE",
+      );
+    });
+  }
+});
+
+describe("owner_comments_since (extracted from factory-agent.sh)", () => {
+  const cjson = JSON.stringify([
+    {
+      id: 1,
+      user: { login: "x" },
+      body: "old",
+      createdAt: "2026-05-24T10:00:00Z",
+      authorAssociation: "OWNER",
+    },
+    {
+      id: 2,
+      user: { login: "bot" },
+      body: "<!-- drafto-factory-in-test -->preview",
+      createdAt: "2026-05-24T12:00:00Z",
+      authorAssociation: "OWNER",
+    },
+    {
+      id: 3,
+      user: { login: "x" },
+      body: "move the button",
+      createdAt: "2026-05-24T13:00:00Z",
+      authorAssociation: "OWNER",
+    },
+    {
+      id: 4,
+      user: { login: "ext" },
+      body: "not owner",
+      createdAt: "2026-05-24T13:30:00Z",
+      authorAssociation: "NONE",
+    },
+  ]);
+
+  it("returns only new OWNER comments, excluding factory markers and non-owners", () => {
+    const out = withFn(
+      "owner_comments_since",
+      `owner_comments_since ${JSON.stringify(cjson)} "2026-05-24T11:00:00Z" | jq -c '[.[].id]'`,
+    );
+    assert.equal(out, "[3]");
+  });
+
+  it("returns [] when no baseline (since empty)", () => {
+    const out = withFn("owner_comments_since", `owner_comments_since ${JSON.stringify(cjson)} ""`);
+    assert.equal(out, "[]");
+  });
+});
+
+describe("factory-agent.sh structural wiring (In Test iteration)", () => {
+  it("passes bash -n", () => {
+    const r = spawnSync("bash", ["-n", agentPath], { encoding: "utf8" });
+    assert.equal(r.status, 0, r.stderr);
+  });
+
+  it("cleanup keep-set retains slots for in-progress (so the worktree survives a revision bounce)", () => {
+    assert.match(
+      script,
+      /any\(\. == "status:in-progress" or \. == "status:in-review" or \. == "status:in-test"\)/,
+    );
+  });
+
+  it("has an In Test feedback sweep that returns cards to In Progress", () => {
+    assert.match(script, /In Test feedback sweep/);
+    assert.match(script, /query-status-items \\\n\s*--status "In Test"/);
+    assert.match(script, /drafto-factory-revising/);
+    assert.match(script, /transition_status "\$ITEM_ID" "\$ISSUE_NUM" "In Progress"/);
+  });
+
+  it("feeds revision comments to the implementer bundle when a prior PR exists", () => {
+    assert.match(script, /REVISION_COMMENTS=\$\(owner_comments_since/);
+    assert.match(
+      script,
+      /build_implement_bundle "\$ISSUE_RECORD" "\$PLAN_COMMENT_JSON" "\$PRIOR_PR" "\$ATTEMPTS" "\$REVISION_COMMENTS"/,
+    );
+  });
+
+  it("a revision no-op re-presents the existing preview (back to In Test)", () => {
+    assert.match(script, /drafto-factory-revise-noop/);
+    assert.match(script, /IS_REVISION" -eq 1 \]\]; then\n\s*# The feedback needed no code change/);
+  });
+
+  it("advances the feedback high-water mark only after consuming comments", () => {
+    // lastFeedbackAt is set in --implement (consume), not in the sweep (detect).
+    assert.match(script, /lastFeedbackAt "\$NOW_ISO"/);
+  });
+});

--- a/scripts/__tests__/factory-state.test.mjs
+++ b/scripts/__tests__/factory-state.test.mjs
@@ -244,6 +244,13 @@ describe("per-issue counters", () => {
     assert.throws(() => setIssueField(s, 1, "arbitraryField", "x"), /unknown field/);
   });
 
+  it("tracks lastFeedbackAt (In Test iteration high-water mark)", () => {
+    const s = emptyFactoryState();
+    assert.equal(s.issues["1"] === undefined || s.issues["1"].lastFeedbackAt == null, true);
+    setIssueField(s, 7, "lastFeedbackAt", "2026-05-24T13:00:00.000Z");
+    assert.equal(s.issues["7"].lastFeedbackAt, "2026-05-24T13:00:00.000Z");
+  });
+
   it("setIssueField clears the field on empty/null/'null' sentinels", () => {
     const s = emptyFactoryState();
     setIssueField(s, 1, "lastError", "boom");

--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -559,6 +559,7 @@ build_implement_bundle() {
   local approved_plan="${2:-null}"
   local prior_pr="${3:-null}"
   local attempts="${4:-0}"
+  local revision_comments="${5:-[]}"
   local repo_head_ref
   repo_head_ref=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
   jq -n \
@@ -566,6 +567,7 @@ build_implement_bundle() {
     --argjson plan "$approved_plan" \
     --argjson priorPr "$prior_pr" \
     --arg attempts "$attempts" \
+    --argjson revisionComments "$revision_comments" \
     --arg allowlist "$SUPPORT_ALLOWLIST" \
     --arg oauthUserEmail "$OAUTH_USER_EMAIL" \
     --arg phase "$PHASE" \
@@ -583,6 +585,7 @@ build_implement_bundle() {
        priorPr: $priorPr,
        attempts: ($attempts | tonumber? // 0),
        comments: [],
+       revisionComments: $revisionComments,
        config: {
          phase: $phase,
          allowlist: ($allowlist | split(",") | map(ascii_downcase | sub("^\\s+";"") | sub("\\s+$";""))),
@@ -591,6 +594,40 @@ build_implement_bundle() {
        repo: { nameWithOwner: $repoNwo, headRef: $headRef }
      }' \
     | node "$SCRIPT_DIR/lib/factory-bundle.mjs"
+}
+
+# OWNER comments strictly newer than <since-iso>, excluding the factory's own
+# marker comments (so a "revising"/"in-test" comment we posted can't be read
+# back as fresh feedback). Customer replies forwarded by support-agent land
+# under the Mac mini's gh identity (OWNER) with no factory marker, so they're
+# included. Prints a JSON array of {id,user,body,createdAt}; "[]" if since is
+# empty (no baseline yet → nothing counts as feedback).
+owner_comments_since() {
+  local comments_json="$1"
+  local since="$2"
+  if [[ -z "$since" || "$since" == "null" ]]; then echo "[]"; return 0; fi
+  echo "$comments_json" | jq -c --arg since "$since" \
+    '[ .[] | select(
+         (.authorAssociation == "OWNER")
+         and ((.createdAt) > $since)
+         and (((.body // "") | test("<!-- drafto-factory")) | not)
+       ) ]'
+}
+
+# Is a comment body pure approval / acknowledgement noise (so it must NOT
+# trigger a code revision)? Strips to lowercase alphanumerics and matches a
+# small set of approving words; emoji-only / ≤2-char comments are noise too.
+# Per the agreed model, approval is the Approved drag — these are skipped, not
+# treated as ship signals.
+is_noise_comment() {
+  local norm
+  norm=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]')
+  case "$norm" in
+    ""|thanks|thankyou|ty|thx|lgtm|looksgood|looksgreat|great|greatwork|perfect|nice|cool|\
+ship|shipit|approved|approve|done|ok|okay|okthanks|yes|yep|yeah|awesome|love|loveit)
+      return 0 ;;
+  esac
+  [[ ${#norm} -le 2 ]]
 }
 
 # Build the factory_watch bundle. $2 approved-plan obj|null, $3 prior-PR obj,
@@ -1321,14 +1358,33 @@ Drag it back to **Ready** so the factory can plan it first.
 
     PRIOR_PR=$(find_prior_pr "$ISSUE_NUM"); [[ -n "$PRIOR_PR" ]] || PRIOR_PR="null"
 
-    # Acquire a slot (reuse the issue's own slot on a retry).
+    # Revision feedback: when a PR already exists, new OWNER comments since the
+    # last consumed feedback are change requests from the In Test preview to
+    # apply on the same branch. Fresh implementations have none — the approved
+    # plan is the source of truth there.
+    REVISION_COMMENTS="[]"
+    IS_REVISION=0
+    if [[ "$PRIOR_PR" != "null" ]]; then
+      FEEDBACK_HWM=$(node "$SCRIPT_DIR/lib/state-cli.mjs" factory:get-issue "$ISSUE_NUM" \
+        --state-file "$STATE_FILE" 2>>"$LOG_FILE" | jq -r '.lastFeedbackAt // ""' 2>/dev/null || echo "")
+      REVISION_COMMENTS=$(owner_comments_since "$COMMENTS_JSON" "$FEEDBACK_HWM")
+      [[ -n "$REVISION_COMMENTS" ]] || REVISION_COMMENTS="[]"
+      REV_COUNT=$(echo "$REVISION_COMMENTS" | jq 'length' 2>/dev/null || echo "0")
+      [[ "$REV_COUNT" =~ ^[0-9]+$ ]] || REV_COUNT=0
+      if [[ "$REV_COUNT" -gt 0 ]]; then
+        IS_REVISION=1
+        log "Issue #$ISSUE_NUM: revision run ($REV_COUNT new feedback comment(s) on the open PR)"
+      fi
+    fi
+
+    # Acquire a slot (reuse the issue's own slot on a retry / revision).
     SLOT=$(slot_for_issue "$ISSUE_NUM")
     if [[ -z "$SLOT" ]]; then
       log "Issue #$ISSUE_NUM: both worktree slots busy; deferring to a later tick"
       break
     fi
 
-    if ! BUNDLE=$(build_implement_bundle "$ISSUE_RECORD" "$PLAN_COMMENT_JSON" "$PRIOR_PR" "$ATTEMPTS"); then
+    if ! BUNDLE=$(build_implement_bundle "$ISSUE_RECORD" "$PLAN_COMMENT_JSON" "$PRIOR_PR" "$ATTEMPTS" "$REVISION_COMMENTS"); then
       log "ERROR: build_implement_bundle failed for #$ISSUE_NUM"; continue
     fi
     AFFECTED=$(echo "$BUNDLE" | jq -r '.spec.affectedPlatforms // [] | join(",")')
@@ -1401,11 +1457,12 @@ Drag it back to **Ready** so the factory can plan it first.
     ACTION=$(echo "$SUMMARY_LINE" | sed -E 's/.*action=([^ ]+).*/\1/')
     PR_URL=$(echo "$SUMMARY_LINE" | sed -E 's/.*pr=([^ ]+).*/\1/')
 
+    NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     case "$ACTION" in
-      implemented|noop)
+      implemented)
         PR_OBJ=$(find_prior_pr "$ISSUE_NUM")
         if [[ -z "$PR_OBJ" || "$PR_OBJ" == "null" ]]; then
-          log "WARNING: #$ISSUE_NUM action=$ACTION but no PR on head factory/issue-$ISSUE_NUM; keeping slot for retry"
+          log "WARNING: #$ISSUE_NUM action=implemented but no PR on head factory/issue-$ISSUE_NUM; keeping slot for retry"
           node "$SCRIPT_DIR/lib/state-cli.mjs" factory:bump-attempts "$ISSUE_NUM" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
           continue
         fi
@@ -1436,10 +1493,47 @@ drag the card back to **In Progress**.
           continue
         fi
         # Happy path: advance to In Review. KEEP slot + worktree for --watch.
+        # Advancing lastFeedbackAt = now marks every comment up to this point as
+        # consumed, so a revision we just applied can't re-trigger next tick.
         transition_status "$ITEM_ID" "$ISSUE_NUM" "In Review" || true
-        node "$SCRIPT_DIR/lib/state-cli.mjs" factory:set-issue-field "$ISSUE_NUM" lastImplementAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+        node "$SCRIPT_DIR/lib/state-cli.mjs" factory:set-issue-field "$ISSUE_NUM" lastImplementAt "$NOW_ISO" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+        node "$SCRIPT_DIR/lib/state-cli.mjs" factory:set-issue-field "$ISSUE_NUM" lastFeedbackAt "$NOW_ISO" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
         node "$SCRIPT_DIR/lib/state-cli.mjs" factory:reset-attempts "$ISSUE_NUM" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
-        log "Issue #$ISSUE_NUM: advanced to In Review (PR $PR_URL; slot $SLOT retained for --watch)"
+        if [[ "$IS_REVISION" -eq 1 ]]; then
+          log "Issue #$ISSUE_NUM: revision pushed → In Review (PR $PR_URL; slot $SLOT retained)"
+        else
+          log "Issue #$ISSUE_NUM: advanced to In Review (PR $PR_URL; slot $SLOT retained for --watch)"
+        fi
+        ;;
+      noop)
+        if [[ "$IS_REVISION" -eq 1 ]]; then
+          # The feedback needed no code change. The existing PR + preview are
+          # still valid, so re-present in In Test instead of re-running CI.
+          transition_status "$ITEM_ID" "$ISSUE_NUM" "In Test" || true
+          node "$SCRIPT_DIR/lib/state-cli.mjs" factory:set-issue-field "$ISSUE_NUM" lastFeedbackAt "$NOW_ISO" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+          node "$SCRIPT_DIR/lib/state-cli.mjs" factory:reset-attempts "$ISSUE_NUM" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+          gh issue comment "$ISSUE_NUM" --repo JakubAnderwald/drafto \
+            --body "🏭 **No code change was needed for that.**
+
+The preview is unchanged. Drag to **Approved** to ship it, or comment a more \
+specific change.
+
+<!-- drafto-factory-revise-noop -->" >>"$LOG_FILE" 2>&1 || true
+          log "Issue #$ISSUE_NUM: revision no-op; returned to In Test"
+        else
+          # Fresh idempotency hit: a PR already exists from a prior attempt.
+          PR_OBJ=$(find_prior_pr "$ISSUE_NUM")
+          if [[ -z "$PR_OBJ" || "$PR_OBJ" == "null" ]]; then
+            log "WARNING: #$ISSUE_NUM action=noop but no PR found; keeping slot for retry"
+            node "$SCRIPT_DIR/lib/state-cli.mjs" factory:bump-attempts "$ISSUE_NUM" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+            continue
+          fi
+          PR_URL=$(echo "$PR_OBJ" | jq -r '.url')
+          transition_status "$ITEM_ID" "$ISSUE_NUM" "In Review" || true
+          node "$SCRIPT_DIR/lib/state-cli.mjs" factory:set-issue-field "$ISSUE_NUM" lastFeedbackAt "$NOW_ISO" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+          node "$SCRIPT_DIR/lib/state-cli.mjs" factory:reset-attempts "$ISSUE_NUM" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+          log "Issue #$ISSUE_NUM: noop (PR $PR_URL already open); advanced to In Review"
+        fi
         ;;
       blocked)
         transition_status "$ITEM_ID" "$ISSUE_NUM" "Blocked" || true
@@ -1495,7 +1589,7 @@ if [[ "$MODE_WATCH" -eq 1 ]]; then
       continue
     fi
     STILL_ACTIVE=$(echo "$ISSUE_META" | jq -r \
-      '((.state == "OPEN") and ((.labels | map(.name)) | any(. == "status:in-review" or . == "status:in-test")))')
+      '((.state == "OPEN") and ((.labels | map(.name)) | any(. == "status:in-progress" or . == "status:in-review" or . == "status:in-test")))')
     if [[ "$STILL_ACTIVE" != "true" ]]; then
       log "Slot $SLOT: issue #$SLOT_ISSUE left In Review/In Test; releasing slot + worktree"
       if [[ "$DRY_RUN" -eq 0 ]]; then
@@ -1704,6 +1798,88 @@ Review it, then drag the card to **Approved** to merge (the operator merges \
 the PR by hand in this staged Phase B rollout).
 
 <!-- drafto-factory-in-test -->" >>"$LOG_FILE" 2>&1 || true
+  done
+
+  # ── In Test feedback sweep: a reporter comment requests a revision ──────────
+  # A reporter testing the preview asks for changes by commenting. A new OWNER
+  # comment (newer than the consumed-feedback high-water mark) that isn't pure
+  # approval/noise rolls the card back to In Progress; the next --implement tick
+  # revises on the same PR branch and it flows back to In Test. Approval stays
+  # explicit (drag to Approved / email accept-signal), so a "looks good" comment
+  # is treated as noise here — never a ship signal.
+  if ! INTEST_JSON=$(node "$SCRIPT_DIR/lib/factory-project.mjs" query-status-items \
+      --status "In Test" 2>>"$LOG_FILE"); then
+    log "WARNING: query-status-items 'In Test' failed (transient?); skipping feedback sweep this tick"
+    log "=== factory-agent --watch completed in $(( $(date +%s) - START_TIME ))s ==="
+    exit 0
+  fi
+  INTEST_COUNT=$(echo "$INTEST_JSON" | jq 'length' 2>/dev/null || echo "0")
+  [[ "$INTEST_COUNT" =~ ^[0-9]+$ ]] || INTEST_COUNT=0
+  log "--watch In Test feedback sweep: $INTEST_COUNT item(s)"
+
+  for ((IDX=0; IDX<INTEST_COUNT; IDX++)); do
+    ITEM=$(echo "$INTEST_JSON" | jq ".[${IDX}]")
+    ITEM_ID=$(echo "$ITEM" | jq -r '.itemId')
+    ISSUE_NUM=$(echo "$ITEM" | jq -r '.issueNumber')
+    ITEM_LABELS=$(echo "$ITEM" | jq -r '.labels // [] | join(",")')
+    [[ ",$ITEM_LABELS," == *",factory-pause,"* ]] && continue
+
+    if ! COMMENTS_JSON=$(fetch_issue_comments "$ISSUE_NUM"); then
+      log "WARNING: fetch_issue_comments failed for #$ISSUE_NUM (feedback sweep); skipping"; continue
+    fi
+    HWM=$(node "$SCRIPT_DIR/lib/state-cli.mjs" factory:get-issue "$ISSUE_NUM" \
+      --state-file "$STATE_FILE" 2>>"$LOG_FILE" | jq -r '.lastFeedbackAt // ""' 2>/dev/null || echo "")
+    if [[ -z "$HWM" || "$HWM" == "null" ]]; then
+      # No baseline yet (e.g. a card that reached In Test before this feature).
+      # Establish it now so only comments posted AFTER this count as feedback.
+      log "Issue #$ISSUE_NUM: establishing In Test feedback baseline"
+      if [[ "$DRY_RUN" -eq 0 ]]; then
+        node "$SCRIPT_DIR/lib/state-cli.mjs" factory:set-issue-field "$ISSUE_NUM" \
+          lastFeedbackAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+      fi
+      continue
+    fi
+
+    NEW_COMMENTS=$(owner_comments_since "$COMMENTS_JSON" "$HWM")
+    NEW_COUNT=$(echo "$NEW_COMMENTS" | jq 'length' 2>/dev/null || echo "0")
+    [[ "$NEW_COUNT" =~ ^[0-9]+$ ]] || NEW_COUNT=0
+    [[ "$NEW_COUNT" -eq 0 ]] && continue
+
+    # Actionable = at least one non-noise comment among the new ones.
+    ACTIONABLE=0
+    for ((CIDX=0; CIDX<NEW_COUNT; CIDX++)); do
+      CBODY=$(echo "$NEW_COMMENTS" | jq -r ".[${CIDX}].body")
+      if ! is_noise_comment "$CBODY"; then ACTIONABLE=1; break; fi
+    done
+    NEWEST=$(echo "$NEW_COMMENTS" | jq -r 'sort_by(.createdAt) | .[-1].createdAt')
+
+    if [[ "$ACTIONABLE" -eq 0 ]]; then
+      # Only approval/thanks since the preview: advance the mark so we don't
+      # re-scan them; leave the card in In Test for the operator to approve.
+      log "Issue #$ISSUE_NUM: only non-actionable comments on In Test; advancing feedback mark"
+      if [[ "$DRY_RUN" -eq 0 ]]; then
+        node "$SCRIPT_DIR/lib/state-cli.mjs" factory:set-issue-field "$ISSUE_NUM" \
+          lastFeedbackAt "$NEWEST" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+      fi
+      continue
+    fi
+
+    log "Issue #$ISSUE_NUM: new feedback on In Test card → returning to In Progress for revision"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      log "DRY-RUN: would move #$ISSUE_NUM In Test → In Progress (revision)"; continue
+    fi
+    # Do NOT advance lastFeedbackAt here — the next --implement tick consumes the
+    # comments and advances the mark, so the feedback actually reaches the
+    # implementer. Reset attempts so the revision gets a fresh budget.
+    transition_status "$ITEM_ID" "$ISSUE_NUM" "In Progress" || true
+    node "$SCRIPT_DIR/lib/state-cli.mjs" factory:reset-attempts "$ISSUE_NUM" --state-file "$STATE_FILE" >>"$LOG_FILE" 2>&1 || true
+    gh issue comment "$ISSUE_NUM" --repo JakubAnderwald/drafto \
+      --body "🏭 **Revising — picking up your feedback.**
+
+I'll update the open PR on the same branch and redeploy the preview. (To ship \
+as-is instead, drag the card to **Approved**.)
+
+<!-- drafto-factory-revising -->" >>"$LOG_FILE" 2>&1 || true
   done
 
   log "=== factory-agent --watch completed in $(( $(date +%s) - START_TIME ))s ==="

--- a/scripts/factory-prompt.md
+++ b/scripts/factory-prompt.md
@@ -50,6 +50,7 @@ last fenced ` ```json ` block). It has shape:
     "bodyEnveloped": "<factory-plan>...</factory-plan>"
   },
   "comments": [ /* additional issue context */ ],
+  "revisionComments": [ /* reporter change requests from the In Test preview */ ],
   "reporter": { "allowlisted": true|false, "email": "...", "zohoThreadId": "..." },
   "priorPr": { "number", "url", "headRef", "state" } | null,
   "attempts": 0,
@@ -117,6 +118,31 @@ Refuse:
 - Any command that touches the host's launchd, environment, or other
   worktrees.
 - Any `claude` / `node scripts/...` subprocess.
+
+## Revision runs (when `revisionComments` is non-empty)
+
+If `revisionComments` contains entries, this is **not** a first implementation —
+the reporter tested the In Test preview and is asking for changes. In that case:
+
+- A **PR already exists** (`priorPr`) and its branch `factory/issue-<n>` is
+  already checked out in your worktree with the prior implementation's commits.
+  **Make the requested changes on top of what's there** — do not start over,
+  do not reset, do not branch.
+- Treat each `revisionComments` entry as an **authoritative change request**,
+  layered on the approved plan. The plan still bounds scope and phase; a comment
+  that asks for something outside the plan's scope or the phase's allowed paths
+  → `action=blocked` (the operator can re-plan instead).
+- After making the changes, run the verification matrix, commit (a `fix:` or
+  `refactor:` conventional message describing the tweak), and `git push` to the
+  **existing** branch (it already tracks origin — no `-u`, never `--force`).
+  **Do not** run `gh pr create`; the PR is already open. Update the PR body's
+  "Drift vs. approved plan" note to record what the revision changed.
+- Emit `action=implemented pr=<existing-url>`.
+- If the comments are **not actionable as code** (e.g. a question, or pure
+  praise that slipped past the bash noise filter), make no changes and emit
+  `action=noop pr=<existing-url>` — bash will re-present the unchanged preview.
+
+For a first implementation, `revisionComments` is empty; ignore this section.
 
 ## Decision flow
 

--- a/scripts/lib/factory-bundle.mjs
+++ b/scripts/lib/factory-bundle.mjs
@@ -297,6 +297,7 @@ export function buildFactoryImplementBundle({
   issue,
   approvedPlan,
   comments = [],
+  revisionComments = [],
   priorPr = null,
   attempts = 0,
   config,
@@ -324,6 +325,9 @@ export function buildFactoryImplementBundle({
         }
       : null,
     comments: envelopeComments(comments),
+    // Reporter change requests from the In Test preview, to apply on top of the
+    // approved plan, on the existing PR branch. Empty on a first implementation.
+    revisionComments: envelopeComments(revisionComments),
     reporter: reporterFromBody(issue.body ?? ""),
     priorPr: priorPr
       ? {
@@ -428,6 +432,7 @@ async function main() {
       issue: input.issue,
       approvedPlan: input.approvedPlan,
       comments: input.comments,
+      revisionComments: input.revisionComments,
       priorPr: input.priorPr,
       attempts: input.attempts,
       config: input.config,

--- a/scripts/lib/factory-state.mjs
+++ b/scripts/lib/factory-state.mjs
@@ -76,6 +76,11 @@ function emptyIssue() {
     lastProd: null,
     lastStatus: null,
     lastError: null,
+    // High-water mark: the createdAt of the newest reporter feedback comment
+    // the factory has already consumed. The In Test feedback sweep only treats
+    // comments newer than this as new change requests, so a handled comment
+    // never re-triggers a revision.
+    lastFeedbackAt: null,
   };
 }
 
@@ -252,6 +257,7 @@ const MUTABLE_ISSUE_FIELDS = new Set([
   "lastProd",
   "lastStatus",
   "lastError",
+  "lastFeedbackAt",
 ]);
 
 export function setIssueField(state, issueNumber, field, value) {


### PR DESCRIPTION
## Summary

Adds the missing feedback loop at **In Test**. A reporter who tests the preview and dislikes it (even if the plan looked fine) can now comment a change request and the factory iterates on the **same** PR — no GitHub internals, no fresh branch.

Before this, In Test was a dead end for feedback: the implementer ignored comments (hardcoded `comments: []`) and `--watch`'s fix loop only fired on failing CI.

### What changed
- **Persistent slot/worktree/branch** across `In Progress ↔ In Review ↔ In Test` (cleanup keep-set now includes `in-progress`), so revisions stack on the same PR + preview URL instead of orphaning the branch.
- **In Test feedback sweep** in `--watch`: a new owner comment (newer than the consumed-feedback high-water mark) that isn't pure approval/noise rolls the card back to **In Progress** and posts "🏭 revising…". Pure "thanks/ship it/👍" is treated as noise (no rework).
- **`--implement` feeds `revisionComments`** to the implementer (new bundle field); it revises on the existing branch, or `noop`s straight back to In Test if nothing's actionable.
- **High-water mark** (`factory-state.lastFeedbackAt`) advances only after the implement consumes the comments, so nothing re-triggers and mid-flight feedback isn't dropped.

Approval stays the explicit **Approved** drag (or household email accept-signal) — comments mean "change this", per the agreed model. `--release` is still deferred.

## Parity report
Backend/automation only (`scripts/**` + docs) — no app code; cross-platform parity mandate N/A.

## Test plan
- [x] `node --test scripts/__tests__/*.test.mjs` — 355 passing (new: `factory-intest-iteration.test.mjs` exercises the real `is_noise_comment` / `owner_comments_since` helpers + structural wiring; `revisionComments` bundle + `lastFeedbackAt` state)
- [x] `bash -n scripts/factory-agent.sh`
- [x] Live dry-run: `--watch --phase B --dry-run` runs the new In Test sweep against the real board (found #418, would establish baseline), no mutations
- [x] prettier clean on all changed JS/MD

🤖 Generated with [Claude Code](https://claude.com/claude-code)