### PR TITLE
fix(web): stop Evernote import dropping note text + dead attachments

### DIFF
--- a/apps/web/__tests__/unit/enml-to-blocknote.test.ts
+++ b/apps/web/__tests__/unit/enml-to-blocknote.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { convertEnmlToBlocks } from "@/lib/import/enml-to-blocknote";
 
 describe("convertEnmlToBlocks", () => {
-  const emptyMap = new Map<string, string>();
+  const emptyMap = new Map<string, { url: string; name: string }>();
 
   it("converts a simple paragraph", () => {
     const enml = "<en-note><p>Hello world</p></en-note>";
@@ -116,14 +116,26 @@ describe("convertEnmlToBlocks", () => {
     expect(content[0].text).toBe("Task done");
   });
 
-  it("converts en-media images with URL from map", () => {
-    const urlMap = new Map([["abc123", "https://storage.example.com/image.png"]]);
+  it("converts en-media images with the durable attachment:// URL from the map", () => {
+    const urlMap = new Map([
+      ["abc123", { url: "attachment://user/note/image.png", name: "image.png" }],
+    ]);
     const enml = '<en-note><en-media type="image/png" hash="abc123"/></en-note>';
     const blocks = convertEnmlToBlocks(enml, urlMap);
 
     const image = blocks.find((b) => b.type === "image");
     expect(image).toBeDefined();
-    expect(image?.props?.url).toBe("https://storage.example.com/image.png");
+    expect(image?.props?.url).toBe("attachment://user/note/image.png");
+    // `width` is not a valid BlockNote image prop and must not be emitted.
+    expect(image?.props && "width" in image.props).toBe(false);
+  });
+
+  it("matches the en-media hash case-insensitively", () => {
+    const urlMap = new Map([["abc123def", { url: "attachment://user/note/i.png", name: "i.png" }]]);
+    const enml = '<en-note><en-media type="image/png" hash="ABC123DEF"/></en-note>';
+    const blocks = convertEnmlToBlocks(enml, urlMap);
+
+    expect(blocks.find((b) => b.type === "image")?.props?.url).toBe("attachment://user/note/i.png");
   });
 
   it("shows placeholder for en-media without URL", () => {
@@ -132,6 +144,63 @@ describe("convertEnmlToBlocks", () => {
 
     expect(blocks).toHaveLength(1);
     expect(blocks[0].type).toBe("paragraph");
+  });
+
+  it("keeps content that FOLLOWS an inline en-media (RC1 regression)", () => {
+    // linkedom parses <en-media/> as non-void; before the fix it swallowed all
+    // following siblings, silently dropping every block after the first image.
+    const urlMap = new Map([["img", { url: "attachment://u/n/i.png", name: "i.png" }]]);
+    const enml =
+      '<en-note><en-media type="image/png" hash="img"/><div>A1 - T/T</div><div>A2 - T/?</div></en-note>';
+    const blocks = convertEnmlToBlocks(enml, urlMap);
+
+    expect(blocks[0].type).toBe("image");
+    const paraTexts = blocks
+      .filter((b) => b.type === "paragraph")
+      .map((b) => (b.content as Array<{ text: string }>).map((c) => c.text).join(""));
+    expect(paraTexts).toContain("A1 - T/T");
+    expect(paraTexts).toContain("A2 - T/?");
+  });
+
+  it("keeps a list and a paragraph that follow an inline en-media", () => {
+    const enml =
+      '<en-note><en-media type="image/png" hash="missing"/><ul><li>one</li><li>two</li></ul><p>tail</p></en-note>';
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    expect(blocks.filter((b) => b.type === "bulletListItem")).toHaveLength(2);
+    expect(
+      blocks.some(
+        (b) =>
+          b.type === "paragraph" &&
+          (b.content as Array<{ text: string }>).some((c) => c.text === "tail"),
+      ),
+    ).toBe(true);
+  });
+
+  it("handles multiple en-media in sequence without dropping the text between them", () => {
+    const enml =
+      '<en-note><en-media type="image/png" hash="a"/><p>between</p><en-media type="image/png" hash="b"/><p>after</p></en-note>';
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    const paraTexts = blocks
+      .filter((b) => b.type === "paragraph")
+      .map((b) => (b.content as Array<{ text: string }>).map((c) => c.text).join(""));
+    expect(paraTexts).toContain("between");
+    expect(paraTexts).toContain("after");
+  });
+
+  it("recovers child content inside a paired <en-media></en-media> element", () => {
+    // A paired (non-self-closed) en-media is left untouched by normalization and
+    // reaches convertElement with real children — the recovery path must surface
+    // that text rather than dropping it.
+    const enml =
+      '<en-note><en-media type="image/png" hash="missing"><div>caption text</div></en-media></en-note>';
+    const blocks = convertEnmlToBlocks(enml, emptyMap);
+
+    const texts = blocks
+      .filter((b) => b.type === "paragraph")
+      .map((b) => (b.content as Array<{ text: string }>).map((c) => c.text).join(""));
+    expect(texts).toContain("caption text");
   });
 
   it("converts tables", () => {
@@ -259,21 +328,17 @@ describe("convertEnmlToBlocks", () => {
     expect(content[0].styles.italic).toBe(true);
   });
 
-  it("converts non-image attachment as canonical link when URL exists", () => {
-    const urlMap = new Map([["def456", "https://storage.example.com/doc.pdf"]]);
+  it("converts a non-image attachment to a native file block with the durable URL", () => {
+    const urlMap = new Map([
+      ["def456", { url: "attachment://user/note/doc.pdf", name: "doc.pdf" }],
+    ]);
     const enml = '<en-note><en-media type="application/pdf" hash="def456"/></en-note>';
     const blocks = convertEnmlToBlocks(enml, urlMap);
 
     expect(blocks).toHaveLength(1);
-    expect(blocks[0].type).toBe("paragraph");
-    const content = blocks[0].content as Array<{
-      type: string;
-      href?: string;
-      content?: Array<{ text: string }>;
-    }>;
-    expect(content[0].type).toBe("link");
-    expect(content[0].href).toBe("https://storage.example.com/doc.pdf");
-    expect(content[0].content?.[0]?.text).toContain("application/pdf");
+    expect(blocks[0].type).toBe("file");
+    expect(blocks[0].props?.url).toBe("attachment://user/note/doc.pdf");
+    expect(blocks[0].props?.name).toBe("doc.pdf");
   });
 
   it("converts hr to paragraph with ---", () => {
@@ -367,13 +432,16 @@ describe("convertEnmlToBlocks", () => {
     expect(blocks[0].type).toBe("paragraph");
   });
 
-  it("handles image with width attribute", () => {
-    const urlMap = new Map([["img123", "https://storage.example.com/photo.jpg"]]);
+  it("ignores the legacy width attribute (not a valid BlockNote prop)", () => {
+    const urlMap = new Map([
+      ["img123", { url: "attachment://user/note/photo.jpg", name: "photo.jpg" }],
+    ]);
     const enml = '<en-note><en-media type="image/jpeg" hash="img123" width="400"/></en-note>';
     const blocks = convertEnmlToBlocks(enml, urlMap);
 
     const image = blocks.find((b) => b.type === "image");
-    expect(image?.props?.width).toBe(400);
+    expect(image?.props?.url).toBe("attachment://user/note/photo.jpg");
+    expect(image?.props && "width" in image.props).toBe(false);
   });
 
   it("handles del and strike tags for strikethrough", () => {

--- a/apps/web/__tests__/unit/import-evernote-api.test.ts
+++ b/apps/web/__tests__/unit/import-evernote-api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash } from "node:crypto";
 import { NextRequest } from "next/server";
 import type { ImportBatchRequest } from "@/lib/import/types";
 
@@ -26,7 +27,6 @@ const mockSingle = vi.fn();
 const mockUpdate = vi.fn();
 const mockEq = vi.fn();
 const mockUpload = vi.fn();
-const mockCreateSignedUrl = vi.fn();
 const mockRemove = vi.fn();
 
 const mockSupabase = {
@@ -43,7 +43,6 @@ const mockSupabase = {
   storage: {
     from: vi.fn(() => ({
       upload: mockUpload,
-      createSignedUrl: mockCreateSignedUrl,
       remove: mockRemove,
     })),
   },
@@ -295,7 +294,7 @@ describe("POST /api/import/evernote", () => {
     expect(mockErrorResponse).toHaveBeenCalledWith("Failed to create notebook", 500);
   });
 
-  it("uploads attachments and maps them for ENML conversion", async () => {
+  it("uploads attachments and maps them by MD5 to a durable attachment:// URL", async () => {
     // Notebook creation
     mockSingle.mockResolvedValueOnce({
       data: { id: "nb-1" },
@@ -313,10 +312,6 @@ describe("POST /api/import/evernote", () => {
     });
 
     mockUpload.mockResolvedValue({ error: null });
-    mockCreateSignedUrl.mockResolvedValue({
-      data: { signedUrl: "https://storage.example.com/file.png" },
-      error: null,
-    });
 
     const body: ImportBatchRequest = {
       notebookName: "Import",
@@ -330,7 +325,6 @@ describe("POST /api/import/evernote", () => {
             {
               data: "aGVsbG8=", // base64 "hello"
               mime: "image/png",
-              hash: "abc123",
               fileName: "photo.png",
             },
           ],
@@ -348,8 +342,19 @@ describe("POST /api/import/evernote", () => {
     await POST(req);
 
     expect(mockUpload).toHaveBeenCalled();
-    expect(mockCreateSignedUrl).toHaveBeenCalled();
-    expect(mockConvertEnmlToBlocks).toHaveBeenCalledWith(expect.any(String), expect.any(Map), []);
+    // The map must be keyed by the MD5 of the decoded binary (what en-media's
+    // `hash` references), with a durable attachment:// URL as the value — never
+    // an expiring signed URL.
+    const md5Hello = createHash("md5").update(Buffer.from("hello")).digest("hex");
+    const mapArg = mockConvertEnmlToBlocks.mock.calls[0][1] as Map<
+      string,
+      { url: string; name: string }
+    >;
+    const entry = mapArg.get(md5Hello);
+    // Display name keeps the original filename; the storage path gets a
+    // collision-safe timestamp+UUID suffix from sanitizeAndBuildPath.
+    expect(entry?.name).toBe("photo.png");
+    expect(entry?.url).toMatch(/^attachment:\/\/user-1\/note-1\/photo-\d+-[0-9a-f]{8}\.png$/);
     expect(mockSuccessResponse).toHaveBeenCalledWith(
       expect.objectContaining({ notesImported: 1 }),
       200,
@@ -382,7 +387,6 @@ describe("POST /api/import/evernote", () => {
             {
               data: "aGVsbG8=",
               mime: "image/png",
-              hash: "abc",
               fileName: "bad.png",
             },
           ],
@@ -438,7 +442,6 @@ describe("POST /api/import/evernote", () => {
             {
               data: "aGVsbG8=",
               mime: "image/png",
-              hash: "abc",
               fileName: "file.png",
             },
           ],

--- a/apps/web/src/app/api/import/evernote/route.ts
+++ b/apps/web/src/app/api/import/evernote/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from "next/server";
 import { getAuthenticatedUserFast, errorResponse, successResponse } from "@/lib/api/utils";
 import { convertEnmlToBlocks } from "@/lib/import/enml-to-blocknote";
+import { sanitizeAndBuildPath } from "@/lib/api/sanitize-filename";
 import type {
   ImportBatchRequest,
   ImportBatchResult,
@@ -9,7 +10,8 @@ import type {
 } from "@/lib/import/types";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database, Json } from "@/lib/supabase/database.types";
-import { BUCKET_NAME, SIGNED_URL_EXPIRY_SECONDS } from "@drafto/shared";
+import { createHash } from "node:crypto";
+import { BUCKET_NAME, toAttachmentUrl } from "@drafto/shared";
 
 export async function POST(request: NextRequest) {
   const { data: auth, error: authError } = await getAuthenticatedUserFast(request);
@@ -93,14 +95,20 @@ async function importNote(
     throw new Error(`Failed to create note: ${noteError?.message || "unknown"}`);
   }
 
-  // Upload attachments and build hash→URL map
-  const attachmentUrlMap = new Map<string, string>();
+  // Upload attachments and build an en-media hash → attachment map. The
+  // `<en-media hash="...">` value is the MD5 of the resource binary, so key the
+  // map by exactly that — computed server-side, where Node crypto has MD5.
+  // Identical-content resources share an MD5 and therefore one entry, matching
+  // Evernote's content-addressed en-media semantics.
+  const attachmentUrlMap = new Map<string, { url: string; name: string }>();
 
   for (const resource of note.resources) {
     try {
-      const url = await uploadResource(supabase, userId, noteRow.id, resource);
-      if (url) {
-        attachmentUrlMap.set(resource.hash, url);
+      const bytes = decodeBase64(resource.data);
+      const md5 = createHash("md5").update(bytes).digest("hex");
+      const uploaded = await uploadResource(supabase, userId, noteRow.id, resource, bytes);
+      if (uploaded) {
+        attachmentUrlMap.set(md5, uploaded);
       }
     } catch {
       // Skip failed attachments — partial import is acceptable
@@ -121,27 +129,26 @@ async function importNote(
   }
 }
 
+function decodeBase64(data: string): Uint8Array {
+  const binaryString = atob(data);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}
+
 async function uploadResource(
   supabase: SupabaseClient<Database>,
   userId: string,
   noteId: string,
   resource: EnexResource,
-): Promise<string | null> {
-  // Decode base64 to buffer
-  const binaryString = atob(resource.data);
-  const bytes = new Uint8Array(binaryString.length);
-  for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-
-  // Sanitize filename
-  const fileName = resource.fileName
-    .replace(/[/\\]/g, "_")
-    .replace(/\.\./g, "_")
-    .replace(/[<>:"|?*\x00-\x1f]/g, "_")
-    .slice(0, 255);
-
-  const filePath = `${userId}/${noteId}/${fileName}`;
+  bytes: Uint8Array,
+): Promise<{ url: string; name: string } | null> {
+  // Reuse the shared path builder so imported attachments get the same
+  // collision-safe, sanitized storage path as native uploads (a timestamp+UUID
+  // suffix keeps two same-named resources in one note from clobbering each other).
+  const { fileName, filePath } = sanitizeAndBuildPath(resource.fileName, userId, noteId);
 
   // Upload to storage
   const { error: uploadError } = await supabase.storage.from(BUCKET_NAME).upload(filePath, bytes, {
@@ -172,14 +179,9 @@ async function uploadResource(
     return null;
   }
 
-  // Generate signed URL
-  const { data: urlData, error: urlError } = await supabase.storage
-    .from(BUCKET_NAME)
-    .createSignedUrl(filePath, SIGNED_URL_EXPIRY_SECONDS);
-
-  if (urlError || !urlData?.signedUrl) {
-    return null;
-  }
-
-  return urlData.signedUrl;
+  // Store the durable attachment:// reference, not a signed URL. GET
+  // /api/notes/[id] resolves a fresh signed URL at read time, so the note never
+  // holds an expiring URL. The block's display name keeps the original Evernote
+  // filename; the storage path (and DB file_name) carries the uniqueness suffix.
+  return { url: toAttachmentUrl(filePath), name: resource.fileName };
 }

--- a/apps/web/src/lib/import/enex-parser.ts
+++ b/apps/web/src/lib/import/enex-parser.ts
@@ -71,17 +71,13 @@ function parseResourceElement(resEl: Element): EnexResource | null {
 
   const mime = resEl.querySelector("mime")?.textContent?.trim() || "application/octet-stream";
 
-  // Hash from recognition or resource-attributes
-  const hash =
-    resEl.querySelector("recognition")?.textContent?.match(/hash="([^"]+)"/)?.[1] ||
-    resEl.querySelector("resource-attributes > source-url")?.textContent?.trim() ||
-    generateSimpleHash(data);
-
+  // en-media matching is done server-side by the MD5 of the decoded binary (see
+  // the import route), so the parser intentionally does not compute a hash here.
   const fileName =
     resEl.querySelector("resource-attributes > file-name")?.textContent?.trim() ||
     `attachment.${mimeToExtension(mime)}`;
 
-  return { data, mime, hash, fileName };
+  return { data, mime, fileName };
 }
 
 /**
@@ -117,16 +113,4 @@ function mimeToExtension(mime: string): string {
     "audio/wav": "wav",
   };
   return map[mime] || "bin";
-}
-
-/**
- * Generate a simple hash from base64 data for en-media matching.
- * Not cryptographic — just enough to match resources to en-media tags.
- */
-function generateSimpleHash(data: string): string {
-  let hash = 0;
-  for (let i = 0; i < Math.min(data.length, 1000); i++) {
-    hash = (hash * 31 + data.charCodeAt(i)) | 0;
-  }
-  return Math.abs(hash).toString(16).padStart(8, "0");
 }

--- a/apps/web/src/lib/import/enml-to-blocknote.ts
+++ b/apps/web/src/lib/import/enml-to-blocknote.ts
@@ -36,13 +36,25 @@ interface TableContent {
   rows: { cells: InlineContent[][] }[];
 }
 
+/** A resolved attachment: its durable `attachment://` URL and display name. */
+interface AttachmentRef {
+  url: string;
+  name: string;
+}
+
+/**
+ * Maps an `<en-media hash="...">` value (the lowercase MD5 of the resource
+ * binary) to its uploaded attachment.
+ */
+type AttachmentMap = Map<string, AttachmentRef>;
+
 /**
  * Convert ENML (Evernote Markup Language) to BlockNote blocks.
  * Uses linkedom for server-side DOM parsing.
  */
 export function convertEnmlToBlocks(
   enml: string,
-  attachmentUrlMap: Map<string, string>,
+  attachmentUrlMap: AttachmentMap,
   tasks?: EnexTask[],
 ): Block[] {
   if (!enml.trim()) {
@@ -72,6 +84,14 @@ export function convertEnmlToBlocks(
   const cleaned = enml
     .replace(/<\?xml[^>]*\?>/g, "")
     .replace(/<!DOCTYPE[^>]*>/g, "")
+    // linkedom's parseHTML treats a self-closed hyphenated custom element
+    // (`<en-media .../>`) as NON-void, so it never closes and swallows every
+    // following sibling as a child — silently dropping all note content after
+    // the first inline image/PDF/audio. Expand only en-media into an explicit
+    // empty element so its siblings stay siblings. `<en-todo/>` is deliberately
+    // left self-closing: convertElement's en-todo case relies on that same
+    // swallow to capture its label text.
+    .replace(/<en-media(?=[\s/>])([^>]*?)\/>/g, "<en-media$1></en-media>")
     .trim();
 
   const { document } = parseHTML(`<body>${cleaned}</body>`);
@@ -93,7 +113,7 @@ export function convertEnmlToBlocks(
 
 function processChildren(
   parent: Element,
-  attachmentUrlMap: Map<string, string>,
+  attachmentUrlMap: AttachmentMap,
   taskMap: Map<string, EnexTask[]>,
 ): Block[] {
   const blocks: Block[] = [];
@@ -126,7 +146,7 @@ function processChildren(
 function convertElement(
   el: Element,
   tag: string,
-  attachmentUrlMap: Map<string, string>,
+  attachmentUrlMap: AttachmentMap,
   taskMap: Map<string, EnexTask[]>,
 ): Block | Block[] | null {
   switch (tag) {
@@ -188,8 +208,18 @@ function convertElement(
       };
     }
 
-    case "en-media":
-      return convertEnMedia(el, attachmentUrlMap);
+    case "en-media": {
+      // After the cleaning step en-media is an explicit empty element and
+      // normally has no children. Still process them as a safety net: if a
+      // self-closed en-media ever slips past normalization, linkedom will have
+      // nested the following siblings inside it and we must not drop them.
+      const media = convertEnMedia(el, attachmentUrlMap);
+      const recovered = processChildren(el, attachmentUrlMap, taskMap);
+      const out: Block[] = [];
+      if (media) out.push(media);
+      out.push(...recovered);
+      return out.length > 0 ? out : null;
+    }
 
     case "table": {
       const unwrapped = tryUnwrapLayoutTable(el, attachmentUrlMap, taskMap);
@@ -222,7 +252,7 @@ function convertElement(
 function convertList(
   listEl: Element,
   blockType: string,
-  attachmentUrlMap: Map<string, string>,
+  attachmentUrlMap: AttachmentMap,
   taskMap: Map<string, EnexTask[]>,
 ): Block[] {
   const items: Block[] = [];
@@ -245,7 +275,7 @@ function convertList(
 
 function processNestedLists(
   li: Element,
-  attachmentUrlMap: Map<string, string>,
+  attachmentUrlMap: AttachmentMap,
   taskMap: Map<string, EnexTask[]>,
 ): Block[] {
   const nested: Block[] = [];
@@ -313,30 +343,33 @@ function applyStyles(item: InlineContent, styles: Record<string, boolean>): Inli
   return { ...item, styles: { ...item.styles, ...styles } };
 }
 
-function convertEnMedia(el: Element, attachmentUrlMap: Map<string, string>): Block | null {
-  const hash = el.getAttribute("hash") || "";
+function convertEnMedia(el: Element, attachmentUrlMap: AttachmentMap): Block | null {
+  // `<en-media hash="...">` references the lowercase MD5 of the resource binary.
+  const hash = (el.getAttribute("hash") || "").toLowerCase();
   const type = el.getAttribute("type") || "";
-  const url = attachmentUrlMap.get(hash);
+  const attachment = attachmentUrlMap.get(hash);
 
-  if (!url) {
+  if (!attachment) {
     return createParagraph([
       { type: "text", text: `[Attachment: ${type || "unknown"}]`, styles: {} },
     ]);
   }
 
   if (type.startsWith("image/")) {
+    // `url` is a durable attachment:// reference; the note GET route resolves a
+    // fresh signed URL at read time. (`width` is not a valid BlockNote prop —
+    // the schema uses `previewWidth` — so we omit it rather than emit junk.)
     return {
       type: "image",
-      props: {
-        url,
-        caption: "",
-        width: parseInt(el.getAttribute("width") || "0", 10) || undefined,
-      },
+      props: { url: attachment.url, caption: "" },
     };
   }
 
-  // Non-image attachment — render as text link
-  return createParagraph([createLink(`[Attachment: ${type}]`, url)]);
+  // Non-image attachment — native file block (also a durable attachment:// URL).
+  return {
+    type: "file",
+    props: { url: attachment.url, name: attachment.name, caption: "" },
+  };
 }
 
 function convertTable(tableEl: Element): Block {
@@ -387,7 +420,7 @@ const BLOCK_TAGS = new Set([
  */
 function tryUnwrapLayoutTable(
   tableEl: Element,
-  attachmentUrlMap: Map<string, string>,
+  attachmentUrlMap: AttachmentMap,
   taskMap: Map<string, EnexTask[]>,
 ): Block[] | null {
   if (tableEl.querySelector("th")) return null;

--- a/apps/web/src/lib/import/types.ts
+++ b/apps/web/src/lib/import/types.ts
@@ -1,7 +1,6 @@
 export interface EnexResource {
   data: string; // base64-encoded
   mime: string;
-  hash: string; // MD5 hash for en-media matching
   fileName: string;
 }
 

--- a/packages/shared/src/editor/__tests__/markdown-converter.test.ts
+++ b/packages/shared/src/editor/__tests__/markdown-converter.test.ts
@@ -105,6 +105,17 @@ describe("blockNoteToMarkdown", () => {
     expect(blockNoteToMarkdown(blocks)).toBe("![A photo](https://example.com/img.png)");
   });
 
+  it("converts file blocks to a durable attachment link", () => {
+    const blocks: BlockNoteBlock[] = [
+      {
+        type: "file",
+        props: { url: "attachment://user/note/doc.pdf", name: "doc.pdf", caption: "" },
+        children: [],
+      },
+    ];
+    expect(blockNoteToMarkdown(blocks)).toBe("[doc.pdf](attachment://user/note/doc.pdf)");
+  });
+
   it("converts tables", () => {
     const tableContent: BlockNoteTableContent = {
       type: "tableContent",
@@ -304,5 +315,15 @@ describe("round-trip", () => {
     const md = "- [x] Done";
     const result = blockNoteToMarkdown(markdownToBlockNote(md));
     expect(result).toBe(md);
+  });
+
+  it("preserves attachment file blocks through round-trip", () => {
+    const md = "[doc.pdf](attachment://user/note/doc.pdf)";
+    const blocks = markdownToBlockNote(md);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("file");
+    expect(blocks[0].props?.url).toBe("attachment://user/note/doc.pdf");
+    expect(blocks[0].props?.name).toBe("doc.pdf");
+    expect(blockNoteToMarkdown(blocks)).toBe(md);
   });
 });


### PR DESCRIPTION
## Context

Importing Evernote `.enex` files into Drafto silently lost data — e.g. the **"Diagnoza ADHD"** note showed only `[Attachment: application/pdf]` while the source had a 950 KB PDF **plus** ~30 paragraphs of text. Diagnosed empirically (ran the real `linkedom` parser, computed MD5s, cross-checked live notes via the Drafto MCP). This PR fixes three of the four root causes. **Web-only** — mobile/desktop have no `.enex` importer.

## Fixes

- **RC1 — `en-media` swallowed all following content (catastrophic text loss).** `linkedom`'s `parseHTML` treats a self-closed `<en-media .../>` as a *non-void* custom element, so it never closes and every following sibling becomes its child; `convertEnMedia` ignored those children. Now we normalize `<en-media .../>` → `<en-media ...></en-media>` before parsing so siblings stay siblings (`<en-todo/>` deliberately left alone — its case relies on the swallow), plus a recovery net that processes any children of a paired `en-media`.
- **RC2 — dead `[Attachment: …]` placeholders.** `<en-media hash="…">` is the **MD5 of the resource binary**, but the parser keyed attachments by a custom non-MD5 hash, so every lookup missed. We now compute `md5(bytes)` server-side (Node `crypto`) and key the map by it (case-insensitive).
- **RC4 — link-rot + wrong block type.** The importer baked a **7-day signed URL** into the block and rendered non-images as a plain text link. Now it stores the durable `attachment://<path>` URL (resolved to a fresh signed URL at read time by `GET /api/notes/[id]`) and emits native `image` / `file` blocks. The invalid `width` image prop (BlockNote 0.51 uses `previewWidth`) is dropped.

Also reuses the shared `sanitizeAndBuildPath` for collision-safe storage paths (matches native uploads; the displayed name keeps the original Evernote filename).

## Tests
- `enml-to-blocknote.test.ts`: content after inline en-media survives; list+paragraph after media; multiple en-media; paired-en-media recovery; case-insensitive hash; `file` block for non-images; no `width` prop.
- `import-evernote-api.test.ts`: map keyed by `md5(bytes)` → durable `attachment://` URL; no signed-URL call at import.
- `markdown-converter.test.ts`: `file` block ↔ `[name](attachment://…)` round-trip.

Full web suite (758) + shared suite (239) pass; lint/typecheck/format clean.

## Follow-up
Client large-file / >4.5 MB-batch robustness (RC3 — size-aware batching, loud retryable errors, direct-to-Storage upload, streaming parse for the 480 MB file) is a separate **Wave 2** PR. Recovery of already-corrupted prod notes (re-import → verify via MCP → trash old) follows after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evernote import now properly renders attachments as image or file blocks
  * Attachment URLs changed to persistent references instead of temporary signed URLs
  * Attachments deduplicated by content hash for improved accuracy

* **Tests**
  * Expanded test coverage for Evernote attachment handling and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->