### PR TITLE
fix(desktop): guard macOS release against shipping dev Supabase credentials

### DIFF
--- a/apps/desktop/fastlane/Fastfile
+++ b/apps/desktop/fastlane/Fastfile
@@ -103,14 +103,16 @@ platform :mac do
       UI.user_error!(".env.production must point at the prod Supabase project (#{known_prod_ref}); found #{prod_env_ref.inspect} — refusing to build")
     end
 
-    env_backup = File.exist?(dev_env) ? File.read(dev_env) : nil
-    FileUtils.cp(prod_env, dev_env)
+    # Also require the anon key to be present, so a build can't ship with a valid prod
+    # URL but an empty key (the bundle guard below only checks the project ref). The
+    # value itself is never logged.
+    prod_anon_key = File.read(prod_env)[/^SUPABASE_ANON_KEY=(.+)$/, 1]
+    if prod_anon_key.nil? || prod_anon_key.strip.empty?
+      UI.user_error!(".env.production is missing SUPABASE_ANON_KEY — refusing to build")
+    end
 
-    # Clear Metro/babel caches so react-native-dotenv re-inlines the prod `.env` instead
-    # of reusing a stale dev transform left over from a prior debug build.
-    Dir.glob(File.join(Dir.tmpdir, "metro-*")).each { |f| FileUtils.rm_rf(f) }
-    Dir.glob(File.join(Dir.tmpdir, "haste-map-*")).each { |f| FileUtils.rm_rf(f) }
-    FileUtils.rm_rf(File.join(PROJECT_ROOT, "node_modules", ".cache"))
+    # Capture the current `.env` so it can be restored after bundling (see the ensure block).
+    env_backup = File.exist?(dev_env) ? File.read(dev_env) : nil
 
     # Install CocoaPods dependencies
     cocoapods(
@@ -215,11 +217,21 @@ platform :mac do
       end
     )
 
-    # Build and export .app (skip .pkg — we create it separately with the installer cert).
-    # Wrapped in begin/ensure so the prod-credential `.env` swap is ALWAYS reverted,
-    # even if the build or the bundle guard fails — otherwise a failed release would
-    # leave `.env` pointing at prod and silently send local debug builds to prod.
+    # Swap in the prod `.env`, build, verify, and ALWAYS restore `.env` via ensure.
+    # The swap happens here — immediately before bundling — rather than earlier, so a
+    # CocoaPods/match/signing failure above never clobbers `.env`; only the JS bundle
+    # phase inside build_mac_app actually reads it. Without the restore, a failed or
+    # dev-pointed release would leave `.env` as prod and silently send local debug builds there.
     begin
+      FileUtils.cp(prod_env, dev_env)
+
+      # Clear Metro/babel caches so react-native-dotenv re-inlines the prod `.env`
+      # instead of reusing a stale dev transform left over from a prior debug build.
+      Dir.glob(File.join(Dir.tmpdir, "metro-*")).each { |f| FileUtils.rm_rf(f) }
+      Dir.glob(File.join(Dir.tmpdir, "haste-map-*")).each { |f| FileUtils.rm_rf(f) }
+      FileUtils.rm_rf(File.join(PROJECT_ROOT, "node_modules", ".cache"))
+
+      # Build and export .app (skip .pkg — we create it separately with the installer cert).
       build_mac_app(
         workspace: File.join(PROJECT_ROOT, "macos", "Drafto.xcworkspace"),
         scheme: "Drafto-macOS",

--- a/apps/desktop/fastlane/Fastfile
+++ b/apps/desktop/fastlane/Fastfile
@@ -82,14 +82,35 @@ platform :mac do
   private_lane :build_and_submit do |options|
     destination = options[:destination]
 
-    # Load production Supabase credentials (copies .env.production → .env so Metro bundles prod config)
+    # Known Supabase project refs (public — they appear in URLs and shipped bundles; not secrets).
+    known_prod_ref = "tbmjbxxseonkciqovnpl"
+    known_dev_ref = "huhzactreblzcogqkbsd"
+
+    # Bundle PROD Supabase credentials into this release.
+    #
+    # react-native-dotenv inlines values from `.env` at bundle time (babel.config.js,
+    # path: ".env"), so a release must temporarily replace `.env` with `.env.production`.
+    # Fail-fast: require `.env.production` and verify it actually points at the prod
+    # project — this guards against a dev/prod swap, the cause of 0.3.2 build 28 shipping
+    # dev credentials. Non-destructive: the original `.env` is restored after the bundle
+    # phase (see the ensure block around build_mac_app) so local debug builds keep using dev.
     prod_env = File.join(PROJECT_ROOT, ".env.production")
     dev_env = File.join(PROJECT_ROOT, ".env")
-    FileUtils.cp(prod_env, dev_env) if File.exist?(prod_env)
+    UI.user_error!("Missing apps/desktop/.env.production — cannot bundle prod credentials") unless File.exist?(prod_env)
 
-    # Clear Metro cache so react-native-dotenv picks up the new .env values
+    prod_env_ref = File.read(prod_env)[%r{^SUPABASE_URL=https://([a-z0-9]+)\.supabase\.co}, 1]
+    unless prod_env_ref == known_prod_ref
+      UI.user_error!(".env.production must point at the prod Supabase project (#{known_prod_ref}); found #{prod_env_ref.inspect} — refusing to build")
+    end
+
+    env_backup = File.exist?(dev_env) ? File.read(dev_env) : nil
+    FileUtils.cp(prod_env, dev_env)
+
+    # Clear Metro/babel caches so react-native-dotenv re-inlines the prod `.env` instead
+    # of reusing a stale dev transform left over from a prior debug build.
     Dir.glob(File.join(Dir.tmpdir, "metro-*")).each { |f| FileUtils.rm_rf(f) }
     Dir.glob(File.join(Dir.tmpdir, "haste-map-*")).each { |f| FileUtils.rm_rf(f) }
+    FileUtils.rm_rf(File.join(PROJECT_ROOT, "node_modules", ".cache"))
 
     # Install CocoaPods dependencies
     cocoapods(
@@ -194,20 +215,47 @@ platform :mac do
       end
     )
 
-    # Build and export .app (skip .pkg — we create it separately with the installer cert)
-    build_mac_app(
-      workspace: File.join(PROJECT_ROOT, "macos", "Drafto.xcworkspace"),
-      scheme: "Drafto-macOS",
-      export_method: "app-store",
-      output_directory: File.join(PROJECT_ROOT, "macos", "build"),
-      skip_package_pkg: true,
-      export_options: {
-        signingStyle: "manual",
-        provisioningProfiles: {
-          BUNDLE_ID => "match AppStore eu.drafto.mobile macos"
+    # Build and export .app (skip .pkg — we create it separately with the installer cert).
+    # Wrapped in begin/ensure so the prod-credential `.env` swap is ALWAYS reverted,
+    # even if the build or the bundle guard fails — otherwise a failed release would
+    # leave `.env` pointing at prod and silently send local debug builds to prod.
+    begin
+      build_mac_app(
+        workspace: File.join(PROJECT_ROOT, "macos", "Drafto.xcworkspace"),
+        scheme: "Drafto-macOS",
+        export_method: "app-store",
+        output_directory: File.join(PROJECT_ROOT, "macos", "build"),
+        skip_package_pkg: true,
+        export_options: {
+          signingStyle: "manual",
+          provisioningProfiles: {
+            BUNDLE_ID => "match AppStore eu.drafto.mobile macos"
+          }
         }
-      }
-    )
+      )
+
+      # Keystone guard: verify the COMPILED bundle points at the prod Supabase project
+      # and contains no dev reference, before anything is uploaded. This is what makes it
+      # structurally impossible to ship a dev-pointed build again (the cause of 0.3.2
+      # build 28). Matches only the public project ref/URL — never the anon key.
+      js_bundle = File.join(PROJECT_ROOT, "macos", "build", "Drafto.app", "Contents", "Resources", "main.jsbundle")
+      UI.user_error!("Built bundle not found at #{js_bundle}") unless File.exist?(js_bundle)
+      bundle_strings = `strings -a "#{js_bundle}"`
+      unless bundle_strings.include?(known_prod_ref)
+        UI.user_error!("Release bundle does not reference the prod Supabase project (#{known_prod_ref}) — aborting upload")
+      end
+      if bundle_strings.include?(known_dev_ref)
+        UI.user_error!("Release bundle references the DEV Supabase project (#{known_dev_ref}) — aborting upload")
+      end
+      UI.success("Verified release bundle points at prod Supabase project #{known_prod_ref}")
+    ensure
+      # Restore the original `.env` (dev). It is only consumed during the bundle phase above.
+      if env_backup
+        File.write(dev_env, env_backup)
+      else
+        FileUtils.rm_f(dev_env)
+      end
+    end
 
     # Create .pkg with the "3rd Party Mac Developer Installer" cert (created via Xcode)
     app_path = File.join(PROJECT_ROOT, "macos", "build", "Drafto.app")

--- a/apps/desktop/src/lib/supabase.ts
+++ b/apps/desktop/src/lib/supabase.ts
@@ -8,7 +8,8 @@ import { supabaseUrl, supabaseAnonKey } from "./config";
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error(
     "Missing Supabase configuration. " +
-      "Set SUPABASE_URL and SUPABASE_ANON_KEY in src/lib/config.ts.",
+      "Set SUPABASE_URL and SUPABASE_ANON_KEY in apps/desktop/.env (debug builds) " +
+      "or .env.production (release builds).",
   );
 }
 

--- a/docs/operations/builds-and-releases.md
+++ b/docs/operations/builds-and-releases.md
@@ -195,7 +195,7 @@ This configures the certificate repository and creates distribution certificates
 cd apps/desktop && pnpm release:beta
 ```
 
-What it does: validate `apps/desktop/.env.production` points at the prod Supabase project → copy it to `.env` → CocoaPods install → `match` (fetch macOS signing creds) → sync version from `package.json` → `build_mac_app` (signed `.pkg`) → **verify the compiled JS bundle references the prod Supabase project and not dev** → restore the dev `.env` → `upload_to_testflight` → post release notes.
+What it does: validate `apps/desktop/.env.production` points at the prod Supabase project (URL + anon key) → CocoaPods install → `match` (fetch macOS signing creds) → sync version from `package.json` → copy `.env.production` to `.env` → `build_mac_app` (signed `.app`; `skip_package_pkg: true`) → **verify the compiled JS bundle references the prod Supabase project and not dev** → restore the dev `.env` → sign the `.pkg` via `productbuild` → `upload_to_testflight` → post release notes.
 
 > The lane aborts before upload if `.env.production` is missing or doesn't point at prod, or if the compiled bundle still references the dev project. This is what prevents shipping a dev-pointed "production" build (the cause of 0.3.2 build 28 connecting to the dev Supabase project). `mac production` shares the same checks.
 

--- a/docs/operations/builds-and-releases.md
+++ b/docs/operations/builds-and-releases.md
@@ -195,7 +195,9 @@ This configures the certificate repository and creates distribution certificates
 cd apps/desktop && pnpm release:beta
 ```
 
-What it does: CocoaPods install → `match` (fetch macOS signing creds) → sync version from `package.json` → `build_mac_app` (signed `.pkg`) → `upload_to_testflight` → post release notes.
+What it does: validate `apps/desktop/.env.production` points at the prod Supabase project → copy it to `.env` → CocoaPods install → `match` (fetch macOS signing creds) → sync version from `package.json` → `build_mac_app` (signed `.pkg`) → **verify the compiled JS bundle references the prod Supabase project and not dev** → restore the dev `.env` → `upload_to_testflight` → post release notes.
+
+> The lane aborts before upload if `.env.production` is missing or doesn't point at prod, or if the compiled bundle still references the dev project. This is what prevents shipping a dev-pointed "production" build (the cause of 0.3.2 build 28 connecting to the dev Supabase project). `mac production` shares the same checks.
 
 ### Release to Mac App Store
 


### PR DESCRIPTION
## Problem

The macOS **0.3.2 (28)** build connected to the **dev** Supabase project, surfacing E2E / dark-factory test notebooks (`Target …`, `Export NB …`, `XPlat NB …`) in production. Confirmed at the byte level: the installed `main.jsbundle` contains `https://huhzactreblzcogqkbsd.supabase.co` (dev) and **zero** references to the prod project (`tbmjbxxseonkciqovnpl`).

## Root cause

The desktop app's Supabase project is chosen entirely from a gitignored `.env` that react-native-dotenv inlines at bundle time. The release lane copied `.env.production` → `.env` before bundling but **never verified the result**, so a dev/prod env-file swap (cf. commit `7530d74`) or a stale Metro transform from a prior debug build could silently ship dev credentials under a production version label. Build 28 was produced locally (the CI release workflow has never run).

## Changes

- **`apps/desktop/fastlane/Fastfile`** (`build_and_submit`, shared by beta + production):
  - Require `.env.production` and verify it points at the prod project — aborts on a dev/prod swap.
  - Back up and **restore** `.env` in an `ensure` block, so a release no longer leaves `.env` clobbered as prod (which previously sent subsequent local *debug* builds to prod).
  - Clear Metro/babel caches (`metro-*`, `haste-map-*`, `node_modules/.cache`).
  - **Keystone guard:** after `build_mac_app`, grep the compiled `main.jsbundle` and abort the upload unless it references the prod project and **not** dev. Matches only the public project ref/URL — never the anon key.
- **`apps/desktop/src/lib/supabase.ts`**: fix the misleading "set in `src/lib/config.ts`" message (creds come from `.env`). The existing unconditional guard here already covers the runtime "missing creds" case, matching mobile.
- **`docs/operations/builds-and-releases.md`**: document the new release gates.

## Verification

- `pnpm --filter @drafto/desktop typecheck && lint && test` (281 pass), `pnpm format:check`, `ruby -c Fastfile` — all green.
- Next step (separate, pre-authorized): rebuild a TestFlight beta and confirm the guard passes + the installed bundle references prod only. Production App Store re-release will be gated on explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced production release build validation to prevent accidental credential misconfigurations and ensure proper environment references in shipped artifacts.

* **Documentation**
  * Updated release build documentation and configuration error messages with guidance on proper environment setup for debug and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->