### PR TITLE
fix(dark-factory): stop --release crash-looping on empty parity platforms

### DIFF
--- a/scripts/__tests__/factory-agent-release.test.mjs
+++ b/scripts/__tests__/factory-agent-release.test.mjs
@@ -84,6 +84,47 @@ describe("migration_violation (extracted from factory-agent.sh)", () => {
   });
 });
 
+describe("parity_violation (extracted from factory-agent.sh)", () => {
+  // parity_violation reads the $PHASE global; the extracted snippet must set it
+  // or `set -u` trips before the function body even runs.
+  const callAt = (phase, platforms, override, diff) =>
+    withFn(
+      "parity_violation",
+      `PHASE=${phase}\nparity_violation ${JSON.stringify(platforms)} ${JSON.stringify(override)} ${JSON.stringify(diff)}`,
+    );
+
+  it("does not crash on the --release call site's empty platforms (bash 3.2 set -u regression)", () => {
+    // The --release gate invokes `parity_violation "" "" "$DIFF_FILES"` to
+    // exercise only the phase-scope guard. An empty platforms CSV used to
+    // expand an empty array under `set -u`, aborting the whole --release run
+    // with "unbound variable" on bash 3.2 (the Mac mini's /bin/bash) — which
+    // crash-looped the release engine and spammed failure issues. withFn runs
+    // the snippet under `set -euo pipefail`, so any recurrence fails the test.
+    const out = callAt("C", "", "", "docs/README.md\nCLAUDE.md");
+    assert.equal(out, "", "empty platforms must yield no violation, not a crash");
+  });
+
+  it("holds a Phase B PR that touches mobile/desktop (web-only rule)", () => {
+    const out = callAt("B", "", "", "apps/mobile/src/x.ts");
+    assert.match(out, /Phase B is web-only/);
+  });
+
+  it("flags a claimed platform that has no matching diff", () => {
+    const out = callAt("C", "web", "", "docs/README.md");
+    assert.match(out, /claimed platform 'web' has no apps\/web changes/);
+  });
+
+  it("passes when the claimed platform is present in the diff", () => {
+    const out = callAt("C", "web", "", "apps/web/src/x.ts");
+    assert.equal(out, "");
+  });
+
+  it("skips the cross-platform mandate when a parity override is set", () => {
+    const out = callAt("C", "", "web-only", "apps/web/src/x.ts");
+    assert.equal(out, "");
+  });
+});
+
 describe("--release engine wiring", () => {
   it("queries the Approved board column", () => {
     assert.match(releaseBlock, /query-status-items \\?\s*\n?\s*--status "Approved"/);

--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -816,6 +816,11 @@ parity_violation() {
   # A parity:*-only override authorises a single-platform PR — skip the
   # cross-platform mandate entirely.
   if [[ -n "$override" ]]; then echo ""; return 0; fi
+  # No platform claims to check (e.g. the --release call site passes "" to
+  # exercise only the phase-scope guard above) — nothing to enforce. Returning
+  # here also avoids expanding an empty array below, which trips
+  # `set -u` ("unbound variable") on bash 3.2 (the Mac mini's /bin/bash).
+  if [[ -z "$platforms_csv" ]]; then echo ""; return 0; fi
   local plat
   IFS=',' read -ra _plats <<< "$platforms_csv"
   for plat in "${_plats[@]}"; do


### PR DESCRIPTION
## Problem

The factory's `--release` lane was crash-looping on the Mac mini. Every cycle that saw an **Approved** card aborted with exit 1 and auto-filed a `factory-agent --release failed` issue (#541, #542, …). The Approved card itself (#508 — a docs-only PR, #528, with fully green CI) could never ship.

## Root cause

`--release` calls `parity_violation "" "" "$DIFF_FILES"` to exercise only the phase-scope guard. With an empty platforms CSV, `IFS=',' read -ra _plats <<< ""` yields an empty array, and expanding `"${_plats[@]}"` under `set -u` throws `unbound variable` on **bash 3.2** (the Mac mini's `/bin/bash`). The `ERR` trap then aborts the whole run.

Same bug class as #490 (which fixed the `--implement` path); this is the `--release` call site.

## Fix

Return "no violation" early when `platforms_csv` is empty, before the array expansion. The Phase B/C phase-scope guard above still runs. Adds a behavioral regression test that executes `parity_violation` under `set -euo pipefail` so a recurrence fails CI.

## Verification

- `bash -n` clean
- `scripts/` suite: 47/47 pass, including the 5 new `parity_violation` cases
- Reproduced the original crash on bash 3.2.57 and confirmed the patched function returns `""` for the empty-platforms `--release` call

## Follow-up (not in this PR)

- Close noise issues #541/#542 once merged
- #508/#528 will auto-ship on the next release cycle; stale slots in `logs/factory-state.json` (dead PIDs for #508/#536) self-clear once #508 releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)