### PR TITLE
chore(dark-factory): auto-sync the factory loop to origin/main each tick

### DIFF
--- a/docs/operations/factory-runbook.md
+++ b/docs/operations/factory-runbook.md
@@ -55,6 +55,7 @@ Run these in order, on a workstation with `gh` authenticated as the project owne
 
    ```bash
    cd /Users/jakub/code/drafto
+   git fetch origin main
    git worktree add --detach /Users/jakub/code/drafto-factory origin/main
    cd /Users/jakub/code/drafto-factory
    pnpm install                       # worktrees don't share node_modules

--- a/docs/operations/factory-runbook.md
+++ b/docs/operations/factory-runbook.md
@@ -41,11 +41,38 @@ Run these in order, on a workstation with `gh` authenticated as the project owne
 
    Verify with `gh auth status` — the listed scopes should include `project`. Without it the agent's first board read fails on every tick with a `factory-project find-project failed` warning.
 
-5. **Install the factory launchd job.**
+5. **Create the dedicated factory checkout (Deployment).**
+
+   The factory runs from its **own git worktree pinned to `main`**, never from your
+   everyday dev checkout. This guarantees it only ever executes reviewed,
+   CI-gated code, and keeps its tick-start `git reset --hard` from ever touching
+   uncommitted work in your dev tree. (History: the factory once ran straight
+   from a feature branch in the dev checkout and shipped an unmerged `--release`
+   crash to production — the dedicated tree exists to make that impossible.)
+
+   Create it once as a **detached** worktree at `origin/main` (detached so it
+   doesn't collide with `main` being checked out in the primary repo):
+
+   ```bash
+   cd /Users/jakub/code/drafto
+   git worktree add --detach /Users/jakub/code/drafto-factory origin/main
+   cd /Users/jakub/code/drafto-factory
+   pnpm install                       # worktrees don't share node_modules
+   bash scripts/worktree-bootstrap.sh # gitignored env/config files
+   ```
+
+   Each tick, `factory-agent-loop.sh` runs `git fetch origin main` +
+   `git reset --hard origin/main` before the agent modes (guarded by
+   `FACTORY_AUTOPULL=1`, the default), so a merged PR — or a revert — goes live
+   on the next 5-min cycle with no manual pull. If the wrapper itself changed in
+   that sync, it re-execs the fresh copy once. Set `FACTORY_AUTOPULL=0` only for
+   ad-hoc manual runs against a dirty tree.
+
+6. **Install the factory launchd job.**
 
    On the Mac mini, drop a plist at `~/Library/LaunchAgents/eu.drafto.factory.plist` modelled on `eu.drafto.support-agent.plist` with:
    - `Label = eu.drafto.factory`
-   - `ProgramArguments = [/bin/bash, /Users/jakub/code/drafto/scripts/factory-agent-loop.sh]`
+   - `ProgramArguments = [/bin/bash, /Users/jakub/code/drafto-factory/scripts/factory-agent-loop.sh]` (the **dedicated** checkout from step 5, not the dev tree)
    - `StartInterval = 300` (5 min)
    - `EnvironmentVariables.FACTORY_PHASE = A`
    - Stdout/stderr paths under `logs/launchd-factory-*.log`
@@ -58,13 +85,15 @@ Run these in order, on a workstation with `gh` authenticated as the project owne
    tail -f /Users/jakub/code/drafto/logs/launchd-factory-stdout.log
    ```
 
-   The first tick should log `=== factory-agent --plan run started (phase=A …) ===` followed by `=== factory-agent --plan completed in <N>s ===`. Subsequent ticks fire every 5 min.
+   The first tick should log `self-update: synced to origin/main @ <sha>` then
+   `=== factory-agent --plan run started (phase=A …) ===` followed by
+   `=== factory-agent --plan completed in <N>s ===`. Subsequent ticks fire every 5 min.
 
 ## Phase progression criteria
 
 | Promote from → to | Required signals before promotion                                                                                                                                                                                                                                                                                                                                                                   |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| (initial) → A     | Setup steps 1–5 above complete. `launchctl list \| grep eu.drafto.factory` shows the job registered, and a manual `launchctl kickstart` logs a clean `--plan` tick (board fetched, no `factory-failure` issue filed).                                                                                                                                                                               |
+| (initial) → A     | Setup steps 1–6 above complete. `launchctl list \| grep eu.drafto.factory` shows the job registered, and a manual `launchctl kickstart` logs a clean `--plan` tick (board fetched, no `factory-failure` issue filed).                                                                                                                                                                               |
 | A → B             | ≥5 successful `--plan` runs (Ready → Planning → Plan Review with a usable plan comment). Zero `factory-failure` issues. Operator has read at least 3 plans and judges they were accurate enough to act on. `--implement` no-op confirmed: dragging Plan Review → In Progress in Phase A logs a "phase=A; implementation skipped" comment and leaves the card in In Progress without further action. |
 | B → C             | ≥5 successful end-to-end web-only runs (Ready → Plan Review → In Progress → In Review → In Test → **auto-merged + Released** after the operator drags to Approved), each with green CI, a reachable Vercel preview, and zero parity violations. SonarCloud quality gate green on all factory-authored PRs.                                                                                          |
 | C → D             | ≥5 successful runs that include mobile or desktop changes. Operator manually fired beta dispatches (TestFlight, Play internal) per Phase C — confirms the dispatch payloads work before the factory automates them.                                                                                                                                                                                 |

--- a/scripts/__tests__/factory-agent-release.test.mjs
+++ b/scripts/__tests__/factory-agent-release.test.mjs
@@ -388,4 +388,25 @@ describe("launchd loop wrapper", () => {
     const releaseIdx = loop.indexOf('/bin/bash "$AGENT" --release');
     assert.ok(releaseIdx > watchIdx, "--release should run after --watch");
   });
+
+  it("self-updates to origin/main before running any mode", () => {
+    // The factory must only ever execute reviewed, CI-gated code. The sync
+    // must happen before the agent invocations, and inside the mutex (after the
+    // lock is acquired) so two ticks can't reset the tree concurrently.
+    assert.match(loop, /git -C "\$SCRIPT_DIR" fetch --quiet origin main/);
+    assert.match(loop, /git -C "\$SCRIPT_DIR" reset --hard --quiet origin\/main/);
+    const lockIdx = loop.indexOf('echo "$$" > "$LOCK_PID_FILE"');
+    const syncIdx = loop.indexOf("reset --hard --quiet origin/main");
+    const firstMode = loop.indexOf('/bin/bash "$AGENT" --plan');
+    assert.ok(lockIdx !== -1 && syncIdx > lockIdx, "sync must run after lock acquisition");
+    assert.ok(syncIdx < firstMode, "sync must run before the first agent mode");
+  });
+
+  it("is escapable via FACTORY_AUTOPULL=0 and re-execs on its own change", () => {
+    assert.match(loop, /FACTORY_AUTOPULL:-1/);
+    // Re-exec guard: prevents running a stale wrapper after it changes in the
+    // sync, with an env guard against an infinite re-exec loop.
+    assert.match(loop, /FACTORY_LOOP_REEXECED/);
+    assert.match(loop, /exec \/bin\/bash "\$\{BASH_SOURCE\[0\]\}"/);
+  });
 });

--- a/scripts/__tests__/factory-agent-release.test.mjs
+++ b/scripts/__tests__/factory-agent-release.test.mjs
@@ -401,7 +401,10 @@ describe("launchd loop wrapper", () => {
     const firstMode = loop.indexOf('/bin/bash "$AGENT" --plan');
     assert.ok(lockIdx !== -1 && fetchIdx > lockIdx, "fetch must run after lock acquisition");
     assert.ok(lockIdx !== -1 && syncIdx > lockIdx, "sync must run after lock acquisition");
-    assert.ok(fetchIdx < firstMode && syncIdx < firstMode, "sync must run before the first agent mode");
+    assert.ok(
+      fetchIdx < firstMode && syncIdx < firstMode,
+      "sync must run before the first agent mode",
+    );
   });
 
   it("is escapable via FACTORY_AUTOPULL=0 and re-execs on its own change", () => {

--- a/scripts/__tests__/factory-agent-release.test.mjs
+++ b/scripts/__tests__/factory-agent-release.test.mjs
@@ -396,14 +396,21 @@ describe("launchd loop wrapper", () => {
     assert.match(loop, /git -C "\$SCRIPT_DIR" fetch --quiet origin main/);
     assert.match(loop, /git -C "\$SCRIPT_DIR" reset --hard --quiet origin\/main/);
     const lockIdx = loop.indexOf('echo "$$" > "$LOCK_PID_FILE"');
+    const fetchIdx = loop.indexOf("fetch --quiet origin main");
     const syncIdx = loop.indexOf("reset --hard --quiet origin/main");
     const firstMode = loop.indexOf('/bin/bash "$AGENT" --plan');
+    assert.ok(lockIdx !== -1 && fetchIdx > lockIdx, "fetch must run after lock acquisition");
     assert.ok(lockIdx !== -1 && syncIdx > lockIdx, "sync must run after lock acquisition");
-    assert.ok(syncIdx < firstMode, "sync must run before the first agent mode");
+    assert.ok(fetchIdx < firstMode && syncIdx < firstMode, "sync must run before the first agent mode");
   });
 
   it("is escapable via FACTORY_AUTOPULL=0 and re-execs on its own change", () => {
-    assert.match(loop, /FACTORY_AUTOPULL:-1/);
+    // Assert fetch/reset are actually gated by the FACTORY_AUTOPULL guard, not
+    // merely that the token appears somewhere in the file.
+    assert.match(
+      loop,
+      /if \[\[ "\$\{FACTORY_AUTOPULL:-1\}" == "1" \]\]; then[\s\S]*git -C "\$SCRIPT_DIR" fetch --quiet origin main[\s\S]*git -C "\$SCRIPT_DIR" reset --hard --quiet origin\/main[\s\S]*fi/,
+    );
     // Re-exec guard: prevents running a stale wrapper after it changes in the
     // sync, with an env guard against an infinite re-exec loop.
     assert.match(loop, /FACTORY_LOOP_REEXECED/);

--- a/scripts/factory-agent-loop.sh
+++ b/scripts/factory-agent-loop.sh
@@ -51,6 +51,41 @@ fi
 echo "$$" > "$LOCK_PID_FILE" 2>/dev/null || true
 trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
 
+# ── Self-update: only ever run reviewed, CI-gated code from origin/main ──
+# The factory deploys from a dedicated git worktree pinned to main (detached
+# HEAD; see docs/operations/factory-runbook.md → "Deployment"). Fast-forward to
+# the latest origin/main at the start of every tick so a merged fix — or a
+# revert — goes live on the very next cycle with zero manual pull, and the
+# factory can never again run unmerged, un-CI'd code (the failure mode that
+# shipped the bash-3.2 --release crash). Runs INSIDE the mutex so two ticks
+# can't reset the tree out from under each other. Set FACTORY_AUTOPULL=0 for
+# ad-hoc local runs against a dirty tree.
+if [[ "${FACTORY_AUTOPULL:-1}" == "1" ]]; then
+  _ts() { date "+%Y-%m-%d %H:%M:%S"; }
+  _loop_before="$(shasum "${BASH_SOURCE[0]}" 2>/dev/null | awk '{print $1}')"
+  if git -C "$SCRIPT_DIR" fetch --quiet origin main 2>/dev/null; then
+    if git -C "$SCRIPT_DIR" reset --hard --quiet origin/main 2>/dev/null; then
+      echo "[$(_ts)] self-update: synced to origin/main @ $(git -C "$SCRIPT_DIR" rev-parse --short HEAD)"
+    else
+      echo "[$(_ts)] self-update: reset to origin/main FAILED; running the checked-out tree as-is" >&2
+    fi
+  else
+    echo "[$(_ts)] self-update: fetch origin main FAILED (offline?); running the checked-out tree as-is" >&2
+  fi
+  # If this wrapper itself changed in the sync, the running bash is now executing
+  # a stale file (byte-offset reads can misbehave). Re-exec the fresh copy once;
+  # the guard env prevents an infinite loop, and we drop the lock first so the
+  # re-exec's fresh run can re-acquire it (exec replaces the process, so the EXIT
+  # trap never fires to release it for us).
+  _loop_after="$(shasum "${BASH_SOURCE[0]}" 2>/dev/null | awk '{print $1}')"
+  if [[ -n "$_loop_before" && "$_loop_before" != "$_loop_after" && "${FACTORY_LOOP_REEXECED:-0}" != "1" ]]; then
+    echo "[$(_ts)] self-update: loop wrapper changed; re-exec'ing the new version"
+    rm -rf "$LOCK_DIR" 2>/dev/null || true
+    export FACTORY_LOOP_REEXECED=1
+    exec /bin/bash "${BASH_SOURCE[0]}"
+  fi
+fi
+
 # Each mode is independent; if one fails, still try the others so a
 # transient GitHub hiccup in --plan doesn't starve --watch/--release. Use the
 # absolute /bin/bash rather than relying on PATH — launchd's PATH is


### PR DESCRIPTION
## Why

The launchd loop (`factory-agent-loop.sh`) executed `scripts/factory-agent.sh` from **whatever branch the dev checkout happened to be on, with no pull**. That's the root cause behind today's incident: the factory was running an unmerged feature branch and shipped the bash-3.2 `--release` crash (#545) straight to the live pipeline, where it crash-looped and spammed failure issues (#541/#542).

Decided with the user: the factory should **only ever run reviewed, CI-gated code from `main`**, from a checkout dedicated to it.

## What

- **Tick-start self-update** in the loop wrapper, inside the existing mutex: `git fetch origin main` + `git reset --hard origin/main` before the agent modes. A merged PR or a revert goes live on the next 5-min cycle, no manual pull. Guarded by `FACTORY_AUTOPULL` (default on); `=0` for ad-hoc local runs against a dirty tree.
- **Re-exec guard**: if the wrapper file itself changed during the sync, it drops the lock and `exec`s the fresh copy once (env-guarded against a re-exec loop) so bash never runs a half-stale script.
- **Runbook deployment section**: the factory runs from a dedicated **detached** worktree pinned to `origin/main` (`/Users/jakub/code/drafto-factory`), separate from the dev tree so the tick-start reset can never clobber uncommitted work. launchd `ProgramArguments` points there.
- **Tests**: loop-wrapper regression tests assert sync ordering (after lock, before first mode) and the `FACTORY_AUTOPULL` / re-exec escape hatches.

## Verification

- `bash -n` clean; `scripts/` suite 49/49 pass.

## Follow-up after merge (operator, manual)

1. `git worktree add --detach /Users/jakub/code/drafto-factory origin/main` + `pnpm install` + `bash scripts/worktree-bootstrap.sh`
2. Point `~/Library/LaunchAgents/eu.drafto.factory.plist` `ProgramArguments` at the new path; reload launchd.

I'll handle these once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Factory service now automatically syncs with the latest version before each operation, with an option to disable this behavior.
  * Added version verification to ensure the factory runs updated code after synchronization.

* **Documentation**
  * Updated factory setup guide with new one-time configuration steps for dedicated checkout.
  * Updated phase progression requirements.

* **Tests**
  * Enhanced test coverage for auto-sync and environment guard mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->