### PR TITLE
fix(mobile,desktop): reset local DB on sign-out

### DIFF
--- a/apps/desktop/src/providers/auth-provider.tsx
+++ b/apps/desktop/src/providers/auth-provider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState, useCallback } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 
+import { database } from "@/db";
 import { getCachedApproval, setCachedApproval, clearCachedApproval } from "@/lib/approval-cache";
 import { supabase } from "@/lib/supabase";
 
@@ -71,6 +72,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setIsApproved(false);
     if (userId) {
       await clearCachedApproval(userId);
+    }
+    // Wipe the offline cache so a different account/environment starts clean and stale
+    // notes can't carry across logins. Best-effort: a reset failure must not block sign-out.
+    try {
+      await database.write(() => database.unsafeResetDatabase());
+    } catch (error) {
+      console.error("Failed to reset local database on sign-out:", error);
     }
   }, [session?.user?.id]);
 

--- a/apps/mobile/__tests__/providers/auth-provider.test.tsx
+++ b/apps/mobile/__tests__/providers/auth-provider.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { renderHook, act, waitFor } from "@testing-library/react-native";
 import type { User } from "@supabase/supabase-js";
 
+import { database } from "@/db";
 import { AuthProvider, useAuth } from "@/providers/auth-provider";
 import { supabase } from "@/lib/supabase";
 import * as approvalCache from "@/lib/approval-cache";
@@ -21,8 +22,19 @@ jest.mock("@/lib/supabase", () => ({
 
 jest.mock("@/lib/approval-cache");
 
+jest.mock("@/db", () => ({
+  database: {
+    write: jest.fn((work: () => Promise<void>) => work()),
+    unsafeResetDatabase: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
 const mockSupabase = supabase as jest.Mocked<typeof supabase>;
 const mockApprovalCache = approvalCache as jest.Mocked<typeof approvalCache>;
+const mockDatabase = database as unknown as {
+  write: jest.Mock;
+  unsafeResetDatabase: jest.Mock;
+};
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return <AuthProvider>{children}</AuthProvider>;
@@ -162,6 +174,30 @@ describe("AuthProvider", () => {
     });
 
     expect(mockApprovalCache.clearCachedApproval).toHaveBeenCalledWith("user-123");
+    expect(mockDatabase.unsafeResetDatabase).toHaveBeenCalled();
     expect(result.current.isApproved).toBe(false);
+  });
+
+  it("completes sign out even if the local database reset fails", async () => {
+    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { user: TEST_USER } },
+    });
+    mockProfileQuery({ is_approved: true }, null);
+    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
+    mockDatabase.unsafeResetDatabase.mockRejectedValueOnce(new Error("reset failed"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await expect(result.current.signOut()).resolves.toBeUndefined();
+    });
+
+    expect(result.current.isApproved).toBe(false);
+    errorSpy.mockRestore();
   });
 });

--- a/apps/mobile/src/providers/auth-provider.tsx
+++ b/apps/mobile/src/providers/auth-provider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState, useCallback } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 
+import { database } from "@/db";
 import { getCachedApproval, setCachedApproval, clearCachedApproval } from "@/lib/approval-cache";
 import { supabase } from "@/lib/supabase";
 
@@ -71,6 +72,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setIsApproved(false);
     if (userId) {
       await clearCachedApproval(userId);
+    }
+    // Wipe the offline cache so a different account/environment starts clean and stale
+    // notes can't carry across logins. Best-effort: a reset failure must not block sign-out.
+    try {
+      await database.write(() => database.unsafeResetDatabase());
+    } catch (error) {
+      console.error("Failed to reset local database on sign-out:", error);
     }
   }, [session?.user?.id]);
 


### PR DESCRIPTION
## Context

While fixing the macOS build's dev/prod Supabase issue, switching the desktop app from a dev-pointed build to prod left the **dev test notebooks visible** even though the app was correctly pointing at prod. Root cause: **sign-out doesn't reset the offline WatermelonDB** — it only clears the Supabase session, so locally-cached notes from the previous account/environment persist.

(Prod data was verified intact and uncontaminated; this is purely a stale local-cache issue.)

## Fix

- `apps/{mobile,desktop}/src/providers/auth-provider.tsx`: on `signOut()`, after clearing the session/approval cache, call `database.write(() => database.unsafeResetDatabase())`. Best-effort — a reset failure is logged and never blocks sign-out.
- Web is online-only (no WatermelonDB) — confirmed no local store to reset, no change needed.
- Mobile test updated: mocks `@/db` and asserts the reset fires on sign-out, plus a case proving sign-out still completes if the reset throws.

## Follow-up (not in this PR)

The sync layer (`apps/{mobile,desktop}/src/db/sync.ts`) has no per-user/per-project guard on push — a latent cross-environment contamination risk. It didn't bite here (a dev session is invalid against prod), but worth a defensive `user_id` guard in a separate change.

## Verification

`pnpm --filter @drafto/{desktop,mobile} typecheck && lint && test` (desktop 281, mobile 119+ incl. new cases), prettier — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)