### PR TITLE
docs(dark-factory): record B→C phase promotion in runbook

### DIFF
--- a/docs/operations/factory-runbook.md
+++ b/docs/operations/factory-runbook.md
@@ -110,6 +110,14 @@ launchctl load -w ~/Library/LaunchAgents/eu.drafto.factory.plist
 
 There is no "auto-promote". The phase change is always a deliberate operator action so a regression at one phase can't silently unlock the next.
 
+### Promotion log
+
+A dated record of actual phase changes so the current operating phase is auditable from the repo (the plist itself is a local, untracked file).
+
+| Date       | Change | Operator | Rationale                                                                                                                                                                                                                                                         |
+| ---------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-23 | B → C  | Jakub    | Unblock native (mobile/desktop) parity work — notably #537 (forgot-password parity), which the Phase-B web-only scope had blocked at plan time. Phase C implementation code (#535) was already merged. Beta dispatch stays dormant until a later C → D promotion. |
+
 **`--release` runs at Phase B+.** The A→B→C→D phases control implementation _scope_ (web → web+mobile/desktop → beta dispatch); `--release` is the merge step layered on top. Each tick it scans the **Approved** column and, for a card a human dragged there, squash-merges the green PR via the GitHub API (`gh api --method PUT …/merge -f merge_method=squash`) and advances it to **Released** (Vercel auto-deploys main → prod for web). It is bounded by three hard rules:
 
 1. It only ever acts on a card a human (or an allowlisted reporter) moved to **Approved** — the Approved drag _is_ the merge-authorisation gate (ADR-0026); the factory never moves a card to Approved itself.


### PR DESCRIPTION
## What

Adds a **Promotion log** table to `docs/operations/factory-runbook.md` recording the **B → C** phase promotion made on 2026-06-23.

## Why

The factory's runtime phase lives in the launchd plist (`FACTORY_PHASE`), which is a local, untracked file — so there was no in-repo record of which phase the factory is actually operating at. This log makes the current phase auditable from the repo.

The B→C promotion itself was an operator action (plist edit + `launchctl` reload, verified live at `phase=C`). Its purpose: unblock native mobile/desktop parity work that Phase B's web-only scope had blocked at plan time — notably **#537** (forgot-password parity for mobile + desktop). Phase C implementation code (#535) was already merged; beta dispatch stays dormant until a later C→D promotion.

## Scope

Docs only. No code or runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the factory operations runbook with a promotion log documenting a phase transition and its planning rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->