### PR TITLE
fix(desktop): load note content via real editor-ready signal (#551)

### DIFF
--- a/apps/desktop/__tests__/components/notes/note-content-loader.test.ts
+++ b/apps/desktop/__tests__/components/notes/note-content-loader.test.ts
@@ -1,11 +1,10 @@
 import {
   classifyNoteContent,
   escapeHtml,
-  hasAttachmentUrls,
   resolveImageUrlsOrFallback,
   textToHtml,
 } from "@/components/notes/note-content-loader";
-import type { TipTapDoc, TipTapNode } from "@drafto/shared";
+import type { TipTapDoc } from "@drafto/shared";
 
 describe("classifyNoteContent", () => {
   it("treats empty content as empty", () => {
@@ -75,79 +74,6 @@ describe("textToHtml / escapeHtml", () => {
 
   it("escapes all five HTML-sensitive characters", () => {
     expect(escapeHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#039;");
-  });
-});
-
-describe("hasAttachmentUrls", () => {
-  it("returns false for a doc with no images", () => {
-    const nodes: TipTapNode[] = [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }];
-    expect(hasAttachmentUrls(nodes)).toBe(false);
-  });
-
-  it("detects a top-level image still pointing at attachment://", () => {
-    const nodes: TipTapNode[] = [{ type: "image", attrs: { src: "attachment://photo.png" } }];
-    expect(hasAttachmentUrls(nodes)).toBe(true);
-  });
-
-  it("ignores images that are already signed/remote URLs", () => {
-    const nodes: TipTapNode[] = [{ type: "image", attrs: { src: "https://signed.example/x" } }];
-    expect(hasAttachmentUrls(nodes)).toBe(false);
-  });
-
-  it("detects a file node pointing at attachment://", () => {
-    const nodes: TipTapNode[] = [{ type: "file", attrs: { src: "attachment://doc.pdf" } }];
-    expect(hasAttachmentUrls(nodes)).toBe(true);
-  });
-
-  it("detects an inline link mark with an attachment:// href (non-image attachment)", () => {
-    const nodes: TipTapNode[] = [
-      {
-        type: "paragraph",
-        content: [
-          {
-            type: "text",
-            text: "report.pdf",
-            marks: [{ type: "link", attrs: { href: "attachment://report.pdf" } }],
-          },
-        ],
-      },
-    ];
-    expect(hasAttachmentUrls(nodes)).toBe(true);
-  });
-
-  it("ignores link marks with a normal https href", () => {
-    const nodes: TipTapNode[] = [
-      {
-        type: "paragraph",
-        content: [
-          {
-            type: "text",
-            text: "site",
-            marks: [{ type: "link", attrs: { href: "https://example.com" } }],
-          },
-        ],
-      },
-    ];
-    expect(hasAttachmentUrls(nodes)).toBe(false);
-  });
-
-  it("recurses into nested content", () => {
-    const nodes: TipTapNode[] = [
-      {
-        type: "blockquote",
-        content: [{ type: "image", attrs: { src: "attachment://nested.png" } }],
-      },
-    ];
-    expect(hasAttachmentUrls(nodes)).toBe(true);
-  });
-
-  it("returns false for an image node missing a src", () => {
-    const nodes: TipTapNode[] = [{ type: "image", attrs: {} }];
-    expect(hasAttachmentUrls(nodes)).toBe(false);
-  });
-
-  it("returns false for an empty node list", () => {
-    expect(hasAttachmentUrls([])).toBe(false);
   });
 });
 

--- a/apps/desktop/__tests__/components/notes/note-content-loader.test.ts
+++ b/apps/desktop/__tests__/components/notes/note-content-loader.test.ts
@@ -95,10 +95,16 @@ describe("resolveImageUrlsOrFallback", () => {
 
   it("falls back to the input doc when resolution throws (never blanks the note)", async () => {
     const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
-    // A malformed doc with no `content` array makes resolveTipTapImageUrls throw.
-    const malformed = { type: "doc" } as unknown as TipTapDoc;
-    const out = await resolveImageUrlsOrFallback(malformed, async () => "https://signed.example/x");
-    expect(out).toBe(malformed);
-    warn.mockRestore();
+    try {
+      // A malformed doc with no `content` array makes resolveTipTapImageUrls throw.
+      const malformed = { type: "doc" } as unknown as TipTapDoc;
+      const out = await resolveImageUrlsOrFallback(
+        malformed,
+        async () => "https://signed.example/x",
+      );
+      expect(out).toBe(malformed);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/apps/desktop/__tests__/components/notes/note-content-loader.test.ts
+++ b/apps/desktop/__tests__/components/notes/note-content-loader.test.ts
@@ -1,10 +1,11 @@
 import {
   classifyNoteContent,
   escapeHtml,
+  hasAttachmentUrls,
   resolveImageUrlsOrFallback,
   textToHtml,
 } from "@/components/notes/note-content-loader";
-import type { TipTapDoc } from "@drafto/shared";
+import type { TipTapDoc, TipTapNode } from "@drafto/shared";
 
 describe("classifyNoteContent", () => {
   it("treats empty content as empty", () => {
@@ -50,8 +51,8 @@ describe("classifyNoteContent", () => {
     expect(classifyNoteContent(JSON.stringify({ foo: 1 })).kind).toBe("html");
   });
 
-  it("falls back to plain text for an empty JSON array (no recognisable blocks)", () => {
-    expect(classifyNoteContent("[]").kind).toBe("html");
+  it('classifies an empty JSON array as empty (empty editor, not literal "[]")', () => {
+    expect(classifyNoteContent("[]")).toEqual({ kind: "empty" });
   });
 
   it("never classifies real, non-empty content as empty (data-loss invariant)", () => {
@@ -59,7 +60,6 @@ describe("classifyNoteContent", () => {
       JSON.stringify([{ type: "paragraph", content: [{ type: "text", text: "x" }] }]),
       JSON.stringify({ type: "doc", content: [{ type: "paragraph" }] }),
       "just some prose",
-      "[]",
       "42",
     ];
     for (const raw of samples) {
@@ -75,6 +75,79 @@ describe("textToHtml / escapeHtml", () => {
 
   it("escapes all five HTML-sensitive characters", () => {
     expect(escapeHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#039;");
+  });
+});
+
+describe("hasAttachmentUrls", () => {
+  it("returns false for a doc with no images", () => {
+    const nodes: TipTapNode[] = [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }];
+    expect(hasAttachmentUrls(nodes)).toBe(false);
+  });
+
+  it("detects a top-level image still pointing at attachment://", () => {
+    const nodes: TipTapNode[] = [{ type: "image", attrs: { src: "attachment://photo.png" } }];
+    expect(hasAttachmentUrls(nodes)).toBe(true);
+  });
+
+  it("ignores images that are already signed/remote URLs", () => {
+    const nodes: TipTapNode[] = [{ type: "image", attrs: { src: "https://signed.example/x" } }];
+    expect(hasAttachmentUrls(nodes)).toBe(false);
+  });
+
+  it("detects a file node pointing at attachment://", () => {
+    const nodes: TipTapNode[] = [{ type: "file", attrs: { src: "attachment://doc.pdf" } }];
+    expect(hasAttachmentUrls(nodes)).toBe(true);
+  });
+
+  it("detects an inline link mark with an attachment:// href (non-image attachment)", () => {
+    const nodes: TipTapNode[] = [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "report.pdf",
+            marks: [{ type: "link", attrs: { href: "attachment://report.pdf" } }],
+          },
+        ],
+      },
+    ];
+    expect(hasAttachmentUrls(nodes)).toBe(true);
+  });
+
+  it("ignores link marks with a normal https href", () => {
+    const nodes: TipTapNode[] = [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "site",
+            marks: [{ type: "link", attrs: { href: "https://example.com" } }],
+          },
+        ],
+      },
+    ];
+    expect(hasAttachmentUrls(nodes)).toBe(false);
+  });
+
+  it("recurses into nested content", () => {
+    const nodes: TipTapNode[] = [
+      {
+        type: "blockquote",
+        content: [{ type: "image", attrs: { src: "attachment://nested.png" } }],
+      },
+    ];
+    expect(hasAttachmentUrls(nodes)).toBe(true);
+  });
+
+  it("returns false for an image node missing a src", () => {
+    const nodes: TipTapNode[] = [{ type: "image", attrs: {} }];
+    expect(hasAttachmentUrls(nodes)).toBe(false);
+  });
+
+  it("returns false for an empty node list", () => {
+    expect(hasAttachmentUrls([])).toBe(false);
   });
 });
 

--- a/apps/desktop/__tests__/components/notes/note-content-loader.test.ts
+++ b/apps/desktop/__tests__/components/notes/note-content-loader.test.ts
@@ -1,0 +1,105 @@
+import {
+  classifyNoteContent,
+  escapeHtml,
+  resolveImageUrlsOrFallback,
+  textToHtml,
+} from "@/components/notes/note-content-loader";
+import type { TipTapDoc } from "@drafto/shared";
+
+describe("classifyNoteContent", () => {
+  it("treats empty content as empty", () => {
+    expect(classifyNoteContent("")).toEqual({ kind: "empty" });
+  });
+
+  it("classifies a BlockNote array as structured and preserves the parsed value", () => {
+    const raw = JSON.stringify([
+      { type: "paragraph", content: [{ type: "text", text: "hello" }], children: [] },
+    ]);
+    const result = classifyNoteContent(raw);
+    expect(result.kind).toBe("structured");
+    if (result.kind === "structured") {
+      expect(result.value).toEqual([
+        { type: "paragraph", content: [{ type: "text", text: "hello" }], children: [] },
+      ]);
+    }
+  });
+
+  it("classifies a TipTap doc as structured", () => {
+    const raw = JSON.stringify({ type: "doc", content: [{ type: "paragraph" }] });
+    expect(classifyNoteContent(raw).kind).toBe("structured");
+  });
+
+  it("renders non-JSON content as escaped paragraph HTML", () => {
+    expect(classifyNoteContent("line one\nline two")).toEqual({
+      kind: "html",
+      html: "<p>line one</p><p>line two</p>",
+    });
+  });
+
+  it("escapes HTML metacharacters in plain-text content", () => {
+    const result = classifyNoteContent("<script>alert(1)</script>");
+    expect(result.kind).toBe("html");
+    if (result.kind === "html") {
+      expect(result.html).not.toContain("<script>");
+      expect(result.html).toContain("&lt;script&gt;");
+    }
+  });
+
+  it("falls back to plain text for valid JSON that is not an editor document", () => {
+    expect(classifyNoteContent("42").kind).toBe("html");
+    expect(classifyNoteContent(JSON.stringify({ foo: 1 })).kind).toBe("html");
+  });
+
+  it("falls back to plain text for an empty JSON array (no recognisable blocks)", () => {
+    expect(classifyNoteContent("[]").kind).toBe("html");
+  });
+
+  it("never classifies real, non-empty content as empty (data-loss invariant)", () => {
+    const samples = [
+      JSON.stringify([{ type: "paragraph", content: [{ type: "text", text: "x" }] }]),
+      JSON.stringify({ type: "doc", content: [{ type: "paragraph" }] }),
+      "just some prose",
+      "[]",
+      "42",
+    ];
+    for (const raw of samples) {
+      expect(classifyNoteContent(raw).kind).not.toBe("empty");
+    }
+  });
+});
+
+describe("textToHtml / escapeHtml", () => {
+  it("maps blank lines to <br> so paragraph breaks survive", () => {
+    expect(textToHtml("a\n\nb")).toBe("<p>a</p><p><br></p><p>b</p>");
+  });
+
+  it("escapes all five HTML-sensitive characters", () => {
+    expect(escapeHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#039;");
+  });
+});
+
+describe("resolveImageUrlsOrFallback", () => {
+  it("returns the same doc when there are no image URLs to resolve", async () => {
+    const doc: TipTapDoc = { type: "doc", content: [{ type: "paragraph" }] };
+    const out = await resolveImageUrlsOrFallback(doc, async () => "https://signed.example/x");
+    expect(out).toBe(doc);
+  });
+
+  it("resolves attachment image srcs to signed URLs", async () => {
+    const doc: TipTapDoc = {
+      type: "doc",
+      content: [{ type: "image", attrs: { src: "attachment://photo.png" } }],
+    };
+    const out = await resolveImageUrlsOrFallback(doc, async () => "https://signed.example/photo");
+    expect(out.content[0]?.attrs?.src).toBe("https://signed.example/photo");
+  });
+
+  it("falls back to the input doc when resolution throws (never blanks the note)", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    // A malformed doc with no `content` array makes resolveTipTapImageUrls throw.
+    const malformed = { type: "doc" } as unknown as TipTapDoc;
+    const out = await resolveImageUrlsOrFallback(malformed, async () => "https://signed.example/x");
+    expect(out).toBe(malformed);
+    warn.mockRestore();
+  });
+});

--- a/apps/desktop/src/components/notes/note-content-loader.ts
+++ b/apps/desktop/src/components/notes/note-content-loader.ts
@@ -1,0 +1,97 @@
+import { resolveTipTapImageUrls } from "@drafto/shared";
+import type { TipTapDoc } from "@drafto/shared";
+
+// Pure, side-effect-free helpers for the note editor's content-load path.
+// Splitting this branch logic out of `note-editor-panel.tsx` keeps it unit
+// testable without standing up the tentap WebView bridge — the branch behind
+// the macOS "note opens blank" bug (issue #551).
+
+type UrlResolver = (filePath: string) => Promise<string>;
+
+/**
+ * Classification of a note's stored `content` string into the action the editor
+ * load path should take.
+ *
+ * - `empty`      — no content; clear the editor.
+ * - `html`       — plain text or unrecognised JSON; render as paragraph HTML.
+ * - `structured` — a BlockNote array or TipTap doc to convert and load.
+ *
+ * Crucially, only a genuinely empty string maps to `empty`; any non-empty
+ * content is always either `html` or `structured`, never `empty`. That guards
+ * the data-loss invariant — the load path must never blank a note that actually
+ * has content (the 2026-04-24 / 2026-04-27 incident class).
+ */
+export type NoteContentLoad =
+  | { kind: "empty" }
+  | { kind: "html"; html: string }
+  | { kind: "structured"; value: unknown };
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/** Convert plain text to the paragraph-per-line HTML tentap's setContent accepts. */
+export function textToHtml(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => `<p>${escapeHtml(line) || "<br>"}</p>`)
+    .join("");
+}
+
+export function classifyNoteContent(rawContent: string): NoteContentLoad {
+  if (!rawContent) return { kind: "empty" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch {
+    // Not JSON — render as plain text.
+    return { kind: "html", html: textToHtml(rawContent) };
+  }
+
+  const isBlockNote =
+    Array.isArray(parsed) && parsed.length > 0 && Boolean((parsed[0] as { type?: string })?.type);
+  const isTipTap =
+    typeof parsed === "object" &&
+    parsed !== null &&
+    !Array.isArray(parsed) &&
+    (parsed as { type?: string }).type === "doc";
+
+  if (!isBlockNote && !isTipTap) {
+    // Valid JSON but not a recognised editor document (a bare number, an empty
+    // array, an unknown object shape). Fall back to plain text rather than
+    // handing setContent a doc it can't parse and silently blanking the note.
+    return { kind: "html", html: textToHtml(rawContent) };
+  }
+
+  return { kind: "structured", value: parsed };
+}
+
+/**
+ * Resolve a doc's `attachment://` image URLs to signed URLs, but never let a
+ * resolution failure blank the note. On error, return the unresolved doc so
+ * text and structure still render and images degrade to a placeholder. This is
+ * display-only: `attachment://` is the canonical stored form, so the gated
+ * autosave can persist the unresolved doc back without corruption.
+ *
+ * `resolveTipTapImageUrls` already tolerates per-URL failures internally (it
+ * uses `Promise.allSettled`); this guard covers the rarer case where the call
+ * itself throws (e.g. a malformed doc), which would otherwise route the entire
+ * load into the gated `catch` and leave the editor blank.
+ */
+export async function resolveImageUrlsOrFallback(
+  doc: TipTapDoc,
+  resolver: UrlResolver,
+): Promise<TipTapDoc> {
+  try {
+    return await resolveTipTapImageUrls(doc, resolver);
+  } catch (err) {
+    console.warn("[note-editor] image URL resolution failed; rendering unresolved doc", err);
+    return doc;
+  }
+}

--- a/apps/desktop/src/components/notes/note-content-loader.ts
+++ b/apps/desktop/src/components/notes/note-content-loader.ts
@@ -60,7 +60,9 @@ export function classifyNoteContent(rawContent: string): NoteContentLoad {
   if (Array.isArray(parsed) && parsed.length === 0) return { kind: "empty" };
 
   const isBlockNote =
-    Array.isArray(parsed) && parsed.length > 0 && Boolean((parsed[0] as { type?: string })?.type);
+    Array.isArray(parsed) &&
+    parsed.length > 0 &&
+    typeof (parsed[0] as { type?: unknown })?.type === "string";
   const isTipTap =
     typeof parsed === "object" &&
     parsed !== null &&

--- a/apps/desktop/src/components/notes/note-content-loader.ts
+++ b/apps/desktop/src/components/notes/note-content-loader.ts
@@ -1,5 +1,5 @@
-import { isAttachmentUrl, resolveTipTapImageUrls } from "@drafto/shared";
-import type { TipTapDoc, TipTapNode } from "@drafto/shared";
+import { resolveTipTapImageUrls } from "@drafto/shared";
+import type { TipTapDoc } from "@drafto/shared";
 
 // Pure, side-effect-free helpers for the note editor's content-load path.
 // Splitting this branch logic out of `note-editor-panel.tsx` keeps it unit
@@ -55,9 +55,8 @@ export function classifyNoteContent(rawContent: string): NoteContentLoad {
   }
 
   // An empty array is an empty BlockNote document — render an empty editor, not
-  // the literal text "[]". `"[]"` is a real stored value (web persists it for a
-  // legacy-empty doc, which then syncs to desktop); contentToTiptap([]) on
-  // mobile/web maps it to an empty doc, so do the same here.
+  // the literal text "[]". "[]" is a real stored value (web persists it for a
+  // legacy-empty doc, which then syncs to desktop).
   if (Array.isArray(parsed) && parsed.length === 0) return { kind: "empty" };
 
   const isBlockNote =
@@ -76,50 +75,6 @@ export function classifyNoteContent(rawContent: string): NoteContentLoad {
   }
 
   return { kind: "structured", value: parsed };
-}
-
-// Node types that carry an attachment in attrs.src (mirrors the shared resolver
-// resolveTipTapImageUrls, which handles both image and file nodes).
-const ATTACHMENT_NODE_TYPES = new Set(["image", "file"]);
-
-/**
- * Whether a TipTap node tree contains any `attachment://` URL that must be
- * resolved to a signed URL before the editor can display/open it. Drives whether
- * the editor surface waits on URL resolution before mounting (so it hydrates
- * with resolved URLs in one shot) rather than mounting with unresolved
- * `attachment://` references.
- *
- * This MUST stay in lockstep with what `resolveTipTapImageUrls` actually
- * resolves — image AND file nodes (via `attrs.src`) and inline link marks (via
- * `attrs.href`, the form a non-image attachment is stored as). A narrower gate
- * would skip resolution and leave those references dead.
- */
-export function hasAttachmentUrls(nodes: TipTapNode[]): boolean {
-  for (const node of nodes) {
-    if (
-      typeof node.type === "string" &&
-      ATTACHMENT_NODE_TYPES.has(node.type) &&
-      typeof node.attrs?.src === "string" &&
-      isAttachmentUrl(node.attrs.src)
-    ) {
-      return true;
-    }
-    if (Array.isArray(node.marks)) {
-      for (const mark of node.marks) {
-        if (
-          mark?.type === "link" &&
-          typeof mark.attrs?.href === "string" &&
-          isAttachmentUrl(mark.attrs.href)
-        ) {
-          return true;
-        }
-      }
-    }
-    if (node.content && hasAttachmentUrls(node.content)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 /**

--- a/apps/desktop/src/components/notes/note-content-loader.ts
+++ b/apps/desktop/src/components/notes/note-content-loader.ts
@@ -1,5 +1,5 @@
-import { resolveTipTapImageUrls } from "@drafto/shared";
-import type { TipTapDoc } from "@drafto/shared";
+import { isAttachmentUrl, resolveTipTapImageUrls } from "@drafto/shared";
+import type { TipTapDoc, TipTapNode } from "@drafto/shared";
 
 // Pure, side-effect-free helpers for the note editor's content-load path.
 // Splitting this branch logic out of `note-editor-panel.tsx` keeps it unit
@@ -54,6 +54,12 @@ export function classifyNoteContent(rawContent: string): NoteContentLoad {
     return { kind: "html", html: textToHtml(rawContent) };
   }
 
+  // An empty array is an empty BlockNote document — render an empty editor, not
+  // the literal text "[]". `"[]"` is a real stored value (web persists it for a
+  // legacy-empty doc, which then syncs to desktop); contentToTiptap([]) on
+  // mobile/web maps it to an empty doc, so do the same here.
+  if (Array.isArray(parsed) && parsed.length === 0) return { kind: "empty" };
+
   const isBlockNote =
     Array.isArray(parsed) && parsed.length > 0 && Boolean((parsed[0] as { type?: string })?.type);
   const isTipTap =
@@ -70,6 +76,50 @@ export function classifyNoteContent(rawContent: string): NoteContentLoad {
   }
 
   return { kind: "structured", value: parsed };
+}
+
+// Node types that carry an attachment in attrs.src (mirrors the shared resolver
+// resolveTipTapImageUrls, which handles both image and file nodes).
+const ATTACHMENT_NODE_TYPES = new Set(["image", "file"]);
+
+/**
+ * Whether a TipTap node tree contains any `attachment://` URL that must be
+ * resolved to a signed URL before the editor can display/open it. Drives whether
+ * the editor surface waits on URL resolution before mounting (so it hydrates
+ * with resolved URLs in one shot) rather than mounting with unresolved
+ * `attachment://` references.
+ *
+ * This MUST stay in lockstep with what `resolveTipTapImageUrls` actually
+ * resolves — image AND file nodes (via `attrs.src`) and inline link marks (via
+ * `attrs.href`, the form a non-image attachment is stored as). A narrower gate
+ * would skip resolution and leave those references dead.
+ */
+export function hasAttachmentUrls(nodes: TipTapNode[]): boolean {
+  for (const node of nodes) {
+    if (
+      typeof node.type === "string" &&
+      ATTACHMENT_NODE_TYPES.has(node.type) &&
+      typeof node.attrs?.src === "string" &&
+      isAttachmentUrl(node.attrs.src)
+    ) {
+      return true;
+    }
+    if (Array.isArray(node.marks)) {
+      for (const mark of node.marks) {
+        if (
+          mark?.type === "link" &&
+          typeof mark.attrs?.href === "string" &&
+          isAttachmentUrl(mark.attrs.href)
+        ) {
+          return true;
+        }
+      }
+    }
+    if (node.content && hasAttachmentUrls(node.content)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/apps/desktop/src/components/notes/note-editor-panel.tsx
+++ b/apps/desktop/src/components/notes/note-editor-panel.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useState, useMemo, useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { View, Text, TextInput, StyleSheet, ActivityIndicator } from "react-native";
-import { useEditorBridge, TenTapStartKit } from "@10play/tentap-editor";
+import { useEditorBridge, useBridgeState, TenTapStartKit } from "@10play/tentap-editor";
 
 import { useNote } from "@/hooks/use-note";
 import { useAutoSave } from "@/hooks/use-auto-save";
@@ -26,6 +26,7 @@ import { AttachmentPicker } from "@/components/editor/attachment-picker";
 import { isCatastrophicEraseSave } from "@/components/notes/erase-tripwire";
 import {
   classifyNoteContent,
+  hasAttachmentUrls,
   resolveImageUrlsOrFallback,
 } from "@/components/notes/note-content-loader";
 
@@ -37,12 +38,35 @@ const saveStatusConfig: Record<SaveStatusKey, { label: string; variant: BadgeVar
   error: { label: "Error", variant: "error" },
 };
 
-// Autosave payloads carry the noteId of the note that was being edited when the
-// save was queued. Looking up the record by id inside the save handler (rather
-// than closing over the `note` prop) makes it impossible for a late-firing
-// debounced save to land on the wrong row if the user has since switched notes.
-type TitleSavePayload = { noteId: string; title: string };
-type ContentSavePayload = { noteId: string; content: string };
+// Bound on the editor.getJSON() WebView round-trip. If the WebView is torn down
+// (note switch) while a getJSON is in flight, AsyncMessages never resolves and
+// never rejects — wrapping it lets the listener be released instead of leaking.
+const GETJSON_TIMEOUT_MS = 4000;
+// Bound on image-URL resolution so a never-settling signed-URL fetch can't pin
+// the note on a spinner forever; on timeout we render the unresolved doc.
+const RESOLVE_TIMEOUT_MS = 8000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out`)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+// Serialize the editor's TipTap JSON into the BlockNote string stored in the DB,
+// rewriting signed URLs back to attachment:// so expiring tokens never persist.
+function serializeEditorContent(json: object): string {
+  return JSON.stringify(migrateSignedUrlsToAttachmentUrls(tiptapToBlocknote(json as TipTapDoc)));
+}
 
 function isImageMimeType(mimeType: string | null | undefined): boolean {
   return typeof mimeType === "string" && mimeType.startsWith("image/");
@@ -69,262 +93,75 @@ async function buildInsertNode(attachment: Attachment): Promise<TipTapNode> {
   };
 }
 
+// tentap accepts a TipTap doc OR an HTML string as `initialContent`.
+type InitialContent = TipTapDoc | string;
+
+// Resolve a note's stored content into the value handed to useEditorBridge as
+// `initialContent`. Mirrors the mobile editor: the content is computed BEFORE
+// the editor's WebView mounts, so tentap hydrates with it directly and there is
+// never an imperative setContent racing an un-ready WebView — the failure mode
+// behind issue #551 (note opens blank) and its note-switch variant (switching
+// notes kept showing the previous note). Attachment:// URLs (images, files,
+// inline links) resolve to signed URLs with a defensive fallback: a resolution
+// failure (or timeout) degrades them to placeholders rather than blanking the
+// note. `attachment://` is the canonical stored form, so persisting an
+// unresolved doc back is non-destructive.
+function useResolvedInitialContent(rawContent: string): {
+  content: InitialContent;
+  resolving: boolean;
+} {
+  const classified = useMemo(() => classifyNoteContent(rawContent), [rawContent]);
+  const initial = useMemo<InitialContent>(() => {
+    if (classified.kind === "empty") return "";
+    if (classified.kind === "html") return classified.html;
+    return contentToTiptap(classified.value);
+  }, [classified]);
+  const needsResolving = useMemo(
+    () => typeof initial !== "string" && hasAttachmentUrls(initial.content ?? []),
+    [initial],
+  );
+
+  const [content, setContent] = useState<InitialContent>(initial);
+  const [resolving, setResolving] = useState(needsResolving);
+
+  useEffect(() => {
+    if (!needsResolving || typeof initial === "string") return;
+    let settled = false;
+    const finish = (resolved: InitialContent) => {
+      if (settled) return;
+      settled = true;
+      setContent(resolved);
+      setResolving(false);
+    };
+    withTimeout(
+      resolveImageUrlsOrFallback(initial, getSignedUrl),
+      RESOLVE_TIMEOUT_MS,
+      "url resolve",
+    )
+      .then(finish)
+      .catch(() => finish(initial)); // timeout / failure → render the unresolved doc
+    return () => {
+      settled = true;
+    };
+  }, [initial, needsResolving]);
+
+  return { content, resolving };
+}
+
 interface NoteEditorPanelProps {
   noteId: string | undefined;
 }
 
+// Outer shell: resolves the selected note, then mounts a fresh editor per note
+// via `key={note.id}` on LoadedNoteEditor. Keying the editor on the note id is
+// what makes switching notes reliable — each note gets its own editor instance,
+// created with its own content as `initialContent`, instead of one long-lived
+// editor that must be imperatively re-pointed at each note (the setContent model
+// that silently dropped content on macOS's WKWebView).
 export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
   const { note, loading } = useNote(noteId);
   const { semantic } = useTheme();
   const styles = useMemo(() => createStyles(semantic), [semantic]);
-
-  const [title, setTitle] = useState("");
-
-  // noteIdRef tracks which note the panel is currently *displaying* (updated as
-  // soon as a note switch is intended). loadedNoteIdRef tracks which note's
-  // content is actually inside the WebView editor right now (set only after
-  // setContent has completed). Autosave is gated on loadedNoteIdRef so that
-  // onChange events emitted before a load finishes are ignored and cannot leak
-  // the previous note's content into the newly-switched-to row.
-  const noteIdRef = useRef<string | undefined>(undefined);
-  const loadedNoteIdRef = useRef<string | null>(null);
-
-  const handleSaveTitle = useCallback(async (payload: TitleSavePayload) => {
-    const record = await database.get<Note>("notes").find(payload.noteId);
-    await database.write(async () => {
-      await record.update((n) => {
-        n.title = payload.title;
-      });
-    });
-  }, []);
-
-  const handleSaveContent = useCallback(async (payload: ContentSavePayload) => {
-    const record = await database.get<Note>("notes").find(payload.noteId);
-    if (isCatastrophicEraseSave(record.content, payload.content)) {
-      console.warn(
-        "[note-editor] tripwire blocked catastrophic-erase save",
-        `noteId=${payload.noteId}`,
-        `existing=${record.content?.length ?? 0}B`,
-        `incoming=${payload.content.length}B`,
-      );
-      return;
-    }
-    await database.write(async () => {
-      await record.update((n) => {
-        n.content = payload.content;
-      });
-    });
-  }, []);
-
-  const titleAutoSave = useAutoSave<TitleSavePayload>({ onSave: handleSaveTitle });
-  const contentAutoSave = useAutoSave<ContentSavePayload>({ onSave: handleSaveContent });
-
-  const titleAutoSaveRef = useRef(titleAutoSave);
-  const contentAutoSaveRef = useRef(contentAutoSave);
-  titleAutoSaveRef.current = titleAutoSave;
-  contentAutoSaveRef.current = contentAutoSave;
-
-  const [editorReady, setEditorReady] = useState(false);
-
-  const handleEditorChange = useCallback(() => {
-    const editor = editorRef.current;
-    if (!editor) return;
-    // Guard: only persist edits for the note whose content is actually loaded
-    // into the editor. Spurious onChange emissions during note switches (or any
-    // tentap internal transition) would otherwise read stale editor JSON and
-    // save it to the wrong note — the exact incident that corrupted data in
-    // prod on 2026-04-24.
-    const loaded = loadedNoteIdRef.current;
-    if (!loaded || loaded !== noteIdRef.current) return;
-    editor
-      .getJSON()
-      .then((json: object) => {
-        // Re-check after the async boundary; the user may have switched notes
-        // while getJSON() was in flight.
-        if (loadedNoteIdRef.current !== loaded || noteIdRef.current !== loaded) return;
-        const blocknote = tiptapToBlocknote(json as TipTapDoc);
-        // Rewrite any signed URLs back to attachment:// before persisting so
-        // expiring tokens never reach the DB. Display-side resolution happens
-        // on note load via resolveTipTapImageUrls.
-        const migrated = migrateSignedUrlsToAttachmentUrls(blocknote);
-        contentAutoSaveRef.current?.trigger({
-          noteId: loaded,
-          content: JSON.stringify(migrated),
-        });
-      })
-      .catch((err: unknown) => {
-        console.warn("Editor getJSON failed:", err);
-      });
-  }, []);
-
-  const editorRef = useRef<ReturnType<typeof useEditorBridge> | null>(null);
-  const editor = useEditorBridge({
-    autofocus: false,
-    avoidIosKeyboard: false,
-    bridgeExtensions: TenTapStartKit,
-    initialContent: "",
-    onChange: handleEditorChange,
-  });
-  editorRef.current = editor;
-
-  // Gate content loads on tentap's real readiness signal instead of polling
-  // editor.getJSON(). A resolved getJSON() only proves the WebView bridge can
-  // round-trip a message — NOT that the ProseMirror view is mounted and able to
-  // accept setContent. On macOS that gap left the very first setContent silently
-  // dropped, so notes opened blank even though their content was present and
-  // valid in the DB (issue #551). `isReady` flips true off the web editor's
-  // onCreate state update, which is the first instant setContent is honoured.
-  // (This is the same signal the library's own useBridgeState hook reads; we
-  // subscribe directly and unsubscribe once ready to avoid re-rendering the
-  // panel on every keystroke.)
-  useEffect(() => {
-    if (editorReady) return;
-    if (editor.getEditorState().isReady) {
-      setEditorReady(true);
-      return;
-    }
-    return editor._subscribeToEditorStateUpdate((state) => {
-      if (state.isReady) setEditorReady(true);
-    });
-  }, [editor, editorReady]);
-
-  // Sync local state when a different note is loaded.
-  useEffect(() => {
-    if (!editorReady) return;
-
-    if (note && note.id !== noteIdRef.current) {
-      // Flush pending autosaves BEFORE switching the noteId refs so any
-      // still-in-flight save goes through with the previous note's payload
-      // (which already carries that note's id, so it lands on the right row).
-      titleAutoSaveRef.current?.flush();
-      contentAutoSaveRef.current?.flush();
-
-      noteIdRef.current = note.id;
-      loadedNoteIdRef.current = null; // gate autosave until setContent completes
-      setTitle(note.title || "");
-
-      const rawContent = note.content || "";
-      let cancelled = false;
-      const targetNoteId = note.id;
-
-      const markLoaded = () => {
-        if (cancelled) return;
-        // Only flip the gate if the user hasn't switched notes again while we
-        // were loading; otherwise another effect run is already handling the
-        // newer note.
-        if (noteIdRef.current === targetNoteId) {
-          loadedNoteIdRef.current = targetNoteId;
-        }
-      };
-
-      (async () => {
-        try {
-          const load = classifyNoteContent(rawContent);
-          if (load.kind === "empty") {
-            editor.setContent("");
-            markLoaded();
-            return;
-          }
-          if (load.kind === "html") {
-            editor.setContent(load.html);
-            markLoaded();
-            return;
-          }
-          const tiptapDoc = contentToTiptap(load.value);
-          // Resolve image URLs defensively: a resolution failure degrades images
-          // to placeholders rather than blanking the whole (otherwise valid) note.
-          const resolved = await resolveImageUrlsOrFallback(tiptapDoc, getSignedUrl);
-          if (cancelled || noteIdRef.current !== targetNoteId) return;
-          editor.setContent(resolved);
-          markLoaded();
-        } catch (err) {
-          // Intentionally do NOT call editor.setContent("") or markLoaded()
-          // here. Wiping the editor would only cosmetically clear the WebView;
-          // calling markLoaded would open the autosave gate, allowing the
-          // editor's empty bootstrap onChange to persist an empty BlockNote
-          // and overwrite real DB content. The 2026-04-24 and 2026-04-27
-          // incidents both took this exact path. Leaving the gate closed on
-          // load failure means a stuck editor (the user can close+reopen),
-          // never a destructively-persisted empty doc.
-          console.warn(
-            "[note-editor] content load failed; leaving autosave gated",
-            `noteId=${targetNoteId}`,
-            err,
-          );
-        }
-      })();
-
-      return () => {
-        cancelled = true;
-      };
-    } else if (!note) {
-      titleAutoSaveRef.current?.flush();
-      contentAutoSaveRef.current?.flush();
-      noteIdRef.current = undefined;
-      loadedNoteIdRef.current = null;
-      setTitle("");
-      try {
-        editor.setContent("");
-      } catch {
-        // Editor not ready — safe to ignore
-      }
-    }
-  }, [note?.id, editor, editorReady]);
-
-  const handleAttachmentReady = useCallback(
-    async (attachment: Attachment) => {
-      // Only append if the editor is actually loaded with the right note.
-      const active = loadedNoteIdRef.current;
-      if (!active || active !== noteIdRef.current) return;
-      try {
-        const node = await buildInsertNode(attachment);
-        const currentJson = (await editor.getJSON()) as TipTapDoc;
-        if (loadedNoteIdRef.current !== active || noteIdRef.current !== active) return;
-        const appended: TipTapDoc = {
-          type: "doc",
-          content: [...(currentJson.content ?? []), node],
-        };
-        editor.setContent(appended);
-        // setContent doesn't reliably trigger onChange in tentap. Persist
-        // directly, addressing the note by id rather than via the prop closure
-        // so a mid-flight note switch can't reroute the write. Supersede any
-        // pending pre-attachment autosave first — otherwise its 800 ms debounce
-        // would fire later with stale content and strand the inline reference.
-        const blocks = tiptapToBlocknote(appended);
-        const migrated = migrateSignedUrlsToAttachmentUrls(blocks);
-        const serialized = JSON.stringify(migrated);
-        const record = await database.get<Note>("notes").find(active);
-        await database.write(async () => {
-          await record.update((n) => {
-            n.content = serialized;
-          });
-        });
-        // Cancel after the authoritative write completes — `setContent(appended)`
-        // may have synchronously fired tentap's onChange, which then async-resolves
-        // a fresh `trigger()` past the cancel. Clearing once the explicit write
-        // has landed guarantees no redundant debounced rewrite remains scheduled.
-        contentAutoSaveRef.current?.cancel();
-      } catch (err) {
-        console.warn("Failed to insert attachment inline:", err);
-      }
-    },
-    [editor],
-  );
-
-  // Flush pending autosaves on unmount.
-  useEffect(() => {
-    return () => {
-      titleAutoSaveRef.current?.flush();
-      contentAutoSaveRef.current?.flush();
-    };
-  }, []);
-
-  const handleTitleChange = useCallback((text: string) => {
-    setTitle(text);
-    const active = loadedNoteIdRef.current;
-    if (!active || active !== noteIdRef.current) return;
-    titleAutoSaveRef.current?.trigger({ noteId: active, title: text });
-  }, []);
 
   if (!noteId) {
     return (
@@ -346,6 +183,229 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
     );
   }
 
+  if (!note) {
+    return (
+      <View style={styles.container}>
+        <EmptyState icon="🔍" title="Note not found" subtitle="This note may have been deleted" />
+      </View>
+    );
+  }
+
+  return <LoadedNoteEditor key={note.id} note={note} />;
+}
+
+interface LoadedNoteEditorProps {
+  note: Note;
+}
+
+function LoadedNoteEditor({ note }: LoadedNoteEditorProps) {
+  const noteId = note.id;
+  const { semantic } = useTheme();
+  const styles = useMemo(() => createStyles(semantic), [semantic]);
+
+  // Capture the note's title + content ONCE per mount. `key={note.id}` on this
+  // component guarantees a remount whenever the selected note changes, so "once
+  // per mount" == "once per note". Live record re-emissions (the note prop
+  // updates on every autosave) therefore can't re-resolve content or reset the
+  // editor; only the metadata below reads the live `note` prop.
+  const [initialContent] = useState(() => note.content || "");
+  const [title, setTitle] = useState(() => note.title || "");
+  const { content: resolvedContent, resolving } = useResolvedInitialContent(initialContent);
+
+  // editorReadyRef gates autosave on tentap's real readiness signal. onChange
+  // emissions during WebView bootstrap (before the ProseMirror view is mounted)
+  // must not persist — an empty/partial editor state could otherwise overwrite
+  // real DB content (the 2026-04-24 / 2026-04-27 incident class). Because the
+  // editor is created WITH this note's content as initialContent, the first
+  // honoured state already holds the real content, so a ready-state onChange
+  // re-saves the same content rather than blanking it.
+  const editorReadyRef = useRef(false);
+  // True while this per-note editor instance is mounted. The content save reads
+  // the editor LIVE while mounted (so a save always reflects the current state);
+  // once unmounted (note switch / close) the WebView is gone, so the flush falls
+  // back to latestContentRef instead of a getJSON that would never resolve.
+  const mountedRef = useRef(true);
+
+  // Dead-WebView fallback: the latest serialized content captured from a RESOLVED
+  // getJSON, kept warm on every edit. captureGenRef stamps each capture so a
+  // slow/older getJSON resolving after a newer edit (or an attachment insert)
+  // can't move this ref backwards. null until the first capture.
+  const latestContentRef = useRef<string | null>(null);
+  const captureGenRef = useRef(0);
+
+  // Declared before the save handlers so handleSaveContent can read the editor.
+  const editorRef = useRef<ReturnType<typeof useEditorBridge> | null>(null);
+
+  const handleSaveTitle = useCallback(
+    async (newTitle: string) => {
+      // Don't let a transient clear (select-all+delete, or a flush firing
+      // mid-edit) overwrite a real title with empty/whitespace.
+      if (!newTitle.trim()) return;
+      const record = await database.get<Note>("notes").find(noteId);
+      await database.write(async () => {
+        await record.update((n) => {
+          n.title = newTitle;
+        });
+      });
+    },
+    [noteId],
+  );
+
+  const handleSaveContent = useCallback(async () => {
+    let content: string | null;
+    const editor = editorRef.current;
+    if (editor && mountedRef.current) {
+      // Mounted: read the editor LIVE so the save reflects the CURRENT state,
+      // immune to capture timing and stale in-flight getJSONs.
+      try {
+        const serialized = serializeEditorContent(
+          await withTimeout(editor.getJSON(), GETJSON_TIMEOUT_MS, "getJSON"),
+        );
+        // This live read is the freshest content — supersede older in-flight
+        // onChange captures (bump AFTER a successful read so a failed read does
+        // NOT invalidate the in-flight capture for this same edit) and record it
+        // as the dead-WebView fallback.
+        captureGenRef.current++;
+        latestContentRef.current = serialized;
+        content = serialized;
+      } catch {
+        // Live read failed (e.g. WebView mid-teardown) — fall back to whatever
+        // the latest still-valid capture has left in latestContentRef.
+        content = latestContentRef.current;
+      }
+    } else {
+      // Unmounted (flush during note switch / close): the WebView is gone, so a
+      // live getJSON would never resolve — persist the last captured snapshot.
+      content = latestContentRef.current;
+    }
+    if (content === null) return; // nothing captured yet
+    const record = await database.get<Note>("notes").find(noteId);
+    if (record.content === content) return; // already persisted — skip redundant write
+    // Tripwire: never let a save erase a non-trivial note down to (near) empty.
+    if (isCatastrophicEraseSave(record.content, content)) {
+      console.warn(
+        "[note-editor] tripwire blocked catastrophic-erase save",
+        `noteId=${noteId}`,
+        `existing=${record.content?.length ?? 0}B`,
+        `incoming=${content.length}B`,
+      );
+      return;
+    }
+    await database.write(async () => {
+      await record.update((n) => {
+        n.content = content;
+      });
+    });
+  }, [noteId]);
+
+  const titleAutoSave = useAutoSave<string>({ onSave: handleSaveTitle });
+  const contentAutoSave = useAutoSave<void>({ onSave: handleSaveContent });
+
+  const titleAutoSaveRef = useRef(titleAutoSave);
+  const contentAutoSaveRef = useRef(contentAutoSave);
+  titleAutoSaveRef.current = titleAutoSave;
+  contentAutoSaveRef.current = contentAutoSave;
+
+  const handleEditorChange = useCallback(() => {
+    // Gate on readiness so the editor's bootstrap onChange can't persist a
+    // partial state before the content has hydrated.
+    if (!editorReadyRef.current) return;
+    const editor = editorRef.current;
+    if (!editor) return;
+    // Arm the debounce synchronously so a pending save always exists after an
+    // edit — the unmount flush relies on it. The save reads the editor live, so
+    // it is NOT gated on the capture below; this only keeps the dead-WebView
+    // fallback warm, generation-guarded so a slow/older getJSON can't move it
+    // backwards past a newer edit or an attachment insert.
+    contentAutoSaveRef.current?.trigger();
+    const gen = ++captureGenRef.current;
+    withTimeout(editor.getJSON(), GETJSON_TIMEOUT_MS, "getJSON")
+      .then((json) => {
+        if (gen === captureGenRef.current) latestContentRef.current = serializeEditorContent(json);
+      })
+      .catch((err: unknown) => {
+        console.warn("Editor getJSON failed:", err);
+      });
+  }, []);
+
+  // Pass initialContent so tentap hydrates the WebView with the note's content
+  // when it first initialises — no setContent race.
+  const editor = useEditorBridge({
+    autofocus: false,
+    avoidIosKeyboard: false,
+    bridgeExtensions: TenTapStartKit,
+    initialContent: resolvedContent,
+    onChange: handleEditorChange,
+  });
+  editorRef.current = editor;
+
+  const { isReady } = useBridgeState(editor);
+  useEffect(() => {
+    editorReadyRef.current = isReady;
+  }, [isReady]);
+
+  // Flush pending autosaves on unmount (note switch or panel close) so the last
+  // edits land. The content save reads latestContentRef synchronously, so this
+  // persists the latest content captured before the switch without needing the
+  // (now tearing-down) editor; the save is keyed to this note via noteId.
+  // Mark unmounted in a LAYOUT-effect cleanup so it runs BEFORE passive-effect
+  // cleanups — including useAutoSave's own internal unmount flush (it registers
+  // `useEffect(() => flush)`). That ordering guarantees the flushed content save
+  // takes the latestContentRef fallback path instead of calling getJSON on the
+  // tearing-down WebView (which would hang until the timeout). The hook's own
+  // unmount flush persists both pending saves, so no explicit flush is needed.
+  useLayoutEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const handleTitleChange = useCallback((text: string) => {
+    setTitle(text);
+    titleAutoSaveRef.current?.trigger(text);
+  }, []);
+
+  const handleAttachmentReady = useCallback(
+    async (attachment: Attachment) => {
+      const editor = editorRef.current;
+      if (!editor || !editorReadyRef.current) return;
+      try {
+        const node = await buildInsertNode(attachment);
+        const currentJson = (await editor.getJSON()) as TipTapDoc;
+        const appended: TipTapDoc = {
+          type: "doc",
+          content: [...(currentJson.content ?? []), node],
+        };
+        editor.setContent(appended);
+        // setContent doesn't reliably trigger onChange in tentap. Persist
+        // directly, addressing the note by id. Supersede any pending
+        // pre-attachment autosave first — otherwise its debounce would fire
+        // later with stale content and strand the inline reference.
+        const blocks = tiptapToBlocknote(appended);
+        const migrated = migrateSignedUrlsToAttachmentUrls(blocks);
+        const serialized = JSON.stringify(migrated);
+        // Supersede any in-flight pre-attachment getJSON capture (bump the
+        // generation) so it can't resolve later and regress latestContentRef back
+        // to pre-attachment content, then set the fallback baseline to the
+        // appended content so a later flush doesn't overwrite this write.
+        captureGenRef.current++;
+        latestContentRef.current = serialized;
+        const record = await database.get<Note>("notes").find(noteId);
+        await database.write(async () => {
+          await record.update((n) => {
+            n.content = serialized;
+          });
+        });
+        // Cancel after the authoritative write lands — `setContent(appended)`
+        // may have synchronously armed a debounce via onChange.
+        contentAutoSaveRef.current?.cancel();
+      } catch (err) {
+        console.warn("Failed to insert attachment inline:", err);
+      }
+    },
+    [noteId],
+  );
+
   const saveStatusKey: SaveStatusKey | null =
     titleAutoSave.status === "saving" || contentAutoSave.status === "saving"
       ? "saving"
@@ -355,6 +415,16 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
           ? "saved"
           : null;
   const statusConfig = saveStatusKey ? saveStatusConfig[saveStatusKey] : null;
+
+  // Hold the editor surface back until image URLs have resolved so tentap
+  // hydrates with the fully-resolved content in a single shot.
+  if (resolving) {
+    return (
+      <View style={[styles.container, styles.loadingContainer]}>
+        <ActivityIndicator size="small" color={colors.primary[600]} />
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -370,25 +440,23 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
           {statusConfig && <Badge variant={statusConfig.variant} label={statusConfig.label} />}
         </View>
 
-        {note && (
-          <View style={styles.metadataRow}>
-            <View style={styles.metadataItem}>
-              <CalendarIcon size={14} color={semantic.fgSubtle} />
-              <Text style={styles.metadataText}>Created {formatRelativeTime(note.createdAt)}</Text>
-            </View>
-            <View style={styles.metadataItem}>
-              <ClockIcon size={14} color={semantic.fgSubtle} />
-              <Text style={styles.metadataText}>Modified {formatRelativeTime(note.updatedAt)}</Text>
-            </View>
+        <View style={styles.metadataRow}>
+          <View style={styles.metadataItem}>
+            <CalendarIcon size={14} color={semantic.fgSubtle} />
+            <Text style={styles.metadataText}>Created {formatRelativeTime(note.createdAt)}</Text>
           </View>
-        )}
+          <View style={styles.metadataItem}>
+            <ClockIcon size={14} color={semantic.fgSubtle} />
+            <Text style={styles.metadataText}>Modified {formatRelativeTime(note.updatedAt)}</Text>
+          </View>
+        </View>
       </View>
 
       <View style={styles.editorContainer}>
         <NoteEditor editor={editor} />
       </View>
 
-      {noteId && <AttachmentPicker noteId={noteId} onAttachmentReady={handleAttachmentReady} />}
+      <AttachmentPicker noteId={noteId} onAttachmentReady={handleAttachmentReady} />
     </View>
   );
 }

--- a/apps/desktop/src/components/notes/note-editor-panel.tsx
+++ b/apps/desktop/src/components/notes/note-editor-panel.tsx
@@ -11,7 +11,6 @@ import {
   formatRelativeTime,
   tiptapToBlocknote,
   toAttachmentUrl,
-  resolveTipTapImageUrls,
   migrateSignedUrlsToAttachmentUrls,
 } from "@drafto/shared";
 import type { TipTapDoc, TipTapNode } from "@drafto/shared";
@@ -25,6 +24,10 @@ import { ClockIcon } from "@/components/ui/icons/clock-icon";
 import { NoteEditor } from "@/components/editor/note-editor";
 import { AttachmentPicker } from "@/components/editor/attachment-picker";
 import { isCatastrophicEraseSave } from "@/components/notes/erase-tripwire";
+import {
+  classifyNoteContent,
+  resolveImageUrlsOrFallback,
+} from "@/components/notes/note-content-loader";
 
 type SaveStatusKey = "saving" | "saved" | "error";
 
@@ -164,20 +167,25 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
   });
   editorRef.current = editor;
 
+  // Gate content loads on tentap's real readiness signal instead of polling
+  // editor.getJSON(). A resolved getJSON() only proves the WebView bridge can
+  // round-trip a message — NOT that the ProseMirror view is mounted and able to
+  // accept setContent. On macOS that gap left the very first setContent silently
+  // dropped, so notes opened blank even though their content was present and
+  // valid in the DB (issue #551). `isReady` flips true off the web editor's
+  // onCreate state update, which is the first instant setContent is honoured.
+  // (This is the same signal the library's own useBridgeState hook reads; we
+  // subscribe directly and unsubscribe once ready to avoid re-rendering the
+  // panel on every keystroke.)
   useEffect(() => {
     if (editorReady) return;
-    const interval = setInterval(() => {
-      try {
-        editor
-          .getJSON()
-          .then(() => {
-            setEditorReady(true);
-            clearInterval(interval);
-          })
-          .catch(() => {});
-      } catch {}
-    }, 200);
-    return () => clearInterval(interval);
+    if (editor.getEditorState().isReady) {
+      setEditorReady(true);
+      return;
+    }
+    return editor._subscribeToEditorStateUpdate((state) => {
+      if (state.isReady) setEditorReady(true);
+    });
   }, [editor, editorReady]);
 
   // Sync local state when a different note is loaded.
@@ -211,42 +219,21 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
 
       (async () => {
         try {
-          if (!rawContent) {
+          const load = classifyNoteContent(rawContent);
+          if (load.kind === "empty") {
             editor.setContent("");
             markLoaded();
             return;
           }
-          let parsed: unknown;
-          try {
-            parsed = JSON.parse(rawContent);
-          } catch {
-            // Not JSON — treat as plain text
-            const htmlContent = rawContent
-              .split("\n")
-              .map((line: string) => `<p>${escapeHtml(line) || "<br>"}</p>`)
-              .join("");
-            editor.setContent(htmlContent);
+          if (load.kind === "html") {
+            editor.setContent(load.html);
             markLoaded();
             return;
           }
-          const isBlockNote =
-            Array.isArray(parsed) && parsed.length > 0 && (parsed[0] as { type?: string })?.type;
-          const isTipTap =
-            parsed &&
-            typeof parsed === "object" &&
-            !Array.isArray(parsed) &&
-            (parsed as { type?: string }).type === "doc";
-          if (!isBlockNote && !isTipTap) {
-            const htmlContent = rawContent
-              .split("\n")
-              .map((line: string) => `<p>${escapeHtml(line) || "<br>"}</p>`)
-              .join("");
-            editor.setContent(htmlContent);
-            markLoaded();
-            return;
-          }
-          const tiptapDoc = contentToTiptap(parsed);
-          const resolved = await resolveTipTapImageUrls(tiptapDoc, getSignedUrl);
+          const tiptapDoc = contentToTiptap(load.value);
+          // Resolve image URLs defensively: a resolution failure degrades images
+          // to placeholders rather than blanking the whole (otherwise valid) note.
+          const resolved = await resolveImageUrlsOrFallback(tiptapDoc, getSignedUrl);
           if (cancelled || noteIdRef.current !== targetNoteId) return;
           editor.setContent(resolved);
           markLoaded();
@@ -404,15 +391,6 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
       {noteId && <AttachmentPicker noteId={noteId} onAttachmentReady={handleAttachmentReady} />}
     </View>
   );
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
 }
 
 const createStyles = (semantic: SemanticColors) =>

--- a/apps/desktop/src/components/notes/note-editor-panel.tsx
+++ b/apps/desktop/src/components/notes/note-editor-panel.tsx
@@ -154,6 +154,10 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
   // content is set into the editor — so the previous note's stale body is never
   // visible during the swap. The editor/WebView itself is never unmounted.
   const [contentLoading, setContentLoading] = useState(false);
+  // Set when a note's content fails to load; drives an error overlay so a load
+  // failure shows an error instead of revealing the previous note's stale body
+  // under the new note's header (autosave stays gated via loadedNoteIdRef).
+  const [loadFailed, setLoadFailed] = useState(false);
 
   const handleEditorChange = useCallback(() => {
     const editor = editorRef.current;
@@ -231,6 +235,7 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
       noteIdRef.current = note.id;
       loadedNoteIdRef.current = null; // gate autosave until setContent completes
       setContentLoading(true); // overlay the editor until setContent() lands
+      setLoadFailed(false);
       setTitle(note.title || "");
 
       const rawContent = note.content || "";
@@ -288,9 +293,13 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
             `noteId=${targetNoteId}`,
             err,
           );
-          // Hide the overlay even on failure (show the editor as-is); the
-          // autosave stays gated above so a stale/empty doc can't persist.
-          if (!cancelled && noteIdRef.current === targetNoteId) setContentLoading(false);
+          // Swap the loading spinner for an error overlay (not the editor "as
+          // is") so a load failure never reveals the previous note's body under
+          // the new note's header. The autosave stays gated above.
+          if (!cancelled && noteIdRef.current === targetNoteId) {
+            setContentLoading(false);
+            setLoadFailed(true);
+          }
         }
       })();
 
@@ -303,6 +312,7 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
       noteIdRef.current = undefined;
       loadedNoteIdRef.current = null;
       setContentLoading(false);
+      setLoadFailed(false);
       setTitle("");
       try {
         editorRef.current?.setContent("");
@@ -443,6 +453,16 @@ export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
       {noteId && !loading && !note && (
         <View style={styles.overlay}>
           <EmptyState icon="🔍" title="Note not found" subtitle="This note may have been deleted" />
+        </View>
+      )}
+
+      {noteId && !loading && note && loadFailed && (
+        <View style={styles.overlay}>
+          <EmptyState
+            icon="⚠️"
+            title="Couldn't load this note"
+            subtitle="Switch away and back to retry"
+          />
         </View>
       )}
     </View>

--- a/apps/desktop/src/components/notes/note-editor-panel.tsx
+++ b/apps/desktop/src/components/notes/note-editor-panel.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo, useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { View, Text, TextInput, StyleSheet, ActivityIndicator } from "react-native";
-import { useEditorBridge, useBridgeState, TenTapStartKit } from "@10play/tentap-editor";
+import { useEditorBridge, TenTapStartKit } from "@10play/tentap-editor";
 
 import { useNote } from "@/hooks/use-note";
 import { useAutoSave } from "@/hooks/use-auto-save";
@@ -26,7 +26,6 @@ import { AttachmentPicker } from "@/components/editor/attachment-picker";
 import { isCatastrophicEraseSave } from "@/components/notes/erase-tripwire";
 import {
   classifyNoteContent,
-  hasAttachmentUrls,
   resolveImageUrlsOrFallback,
 } from "@/components/notes/note-content-loader";
 
@@ -38,35 +37,12 @@ const saveStatusConfig: Record<SaveStatusKey, { label: string; variant: BadgeVar
   error: { label: "Error", variant: "error" },
 };
 
-// Bound on the editor.getJSON() WebView round-trip. If the WebView is torn down
-// (note switch) while a getJSON is in flight, AsyncMessages never resolves and
-// never rejects — wrapping it lets the listener be released instead of leaking.
-const GETJSON_TIMEOUT_MS = 4000;
-// Bound on image-URL resolution so a never-settling signed-URL fetch can't pin
-// the note on a spinner forever; on timeout we render the unresolved doc.
-const RESOLVE_TIMEOUT_MS = 8000;
-
-function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`${label} timed out`)), ms);
-    promise.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (err) => {
-        clearTimeout(timer);
-        reject(err);
-      },
-    );
-  });
-}
-
-// Serialize the editor's TipTap JSON into the BlockNote string stored in the DB,
-// rewriting signed URLs back to attachment:// so expiring tokens never persist.
-function serializeEditorContent(json: object): string {
-  return JSON.stringify(migrateSignedUrlsToAttachmentUrls(tiptapToBlocknote(json as TipTapDoc)));
-}
+// Autosave payloads carry the noteId of the note that was being edited when the
+// save was queued. Looking up the record by id inside the save handler (rather
+// than closing over the `note` prop) makes it impossible for a late-firing
+// debounced save to land on the wrong row if the user has since switched notes.
+type TitleSavePayload = { noteId: string; title: string };
+type ContentSavePayload = { noteId: string; content: string };
 
 function isImageMimeType(mimeType: string | null | undefined): boolean {
   return typeof mimeType === "string" && mimeType.startsWith("image/");
@@ -93,318 +69,309 @@ async function buildInsertNode(attachment: Attachment): Promise<TipTapNode> {
   };
 }
 
-// tentap accepts a TipTap doc OR an HTML string as `initialContent`.
-type InitialContent = TipTapDoc | string;
+// Bound on image-URL resolution so a never-settling signed-URL fetch can't hang
+// a note load (and strand the loading overlay). On timeout, resolve to the
+// unresolved doc — images degrade to placeholders; attachment:// is the
+// canonical stored form, so persisting it back is non-destructive.
+const RESOLVE_TIMEOUT_MS = 8000;
 
-// Resolve a note's stored content into the value handed to useEditorBridge as
-// `initialContent`. Mirrors the mobile editor: the content is computed BEFORE
-// the editor's WebView mounts, so tentap hydrates with it directly and there is
-// never an imperative setContent racing an un-ready WebView — the failure mode
-// behind issue #551 (note opens blank) and its note-switch variant (switching
-// notes kept showing the previous note). Attachment:// URLs (images, files,
-// inline links) resolve to signed URLs with a defensive fallback: a resolution
-// failure (or timeout) degrades them to placeholders rather than blanking the
-// note. `attachment://` is the canonical stored form, so persisting an
-// unresolved doc back is non-destructive.
-function useResolvedInitialContent(rawContent: string): {
-  content: InitialContent;
-  resolving: boolean;
-} {
-  const classified = useMemo(() => classifyNoteContent(rawContent), [rawContent]);
-  const initial = useMemo<InitialContent>(() => {
-    if (classified.kind === "empty") return "";
-    if (classified.kind === "html") return classified.html;
-    return contentToTiptap(classified.value);
-  }, [classified]);
-  const needsResolving = useMemo(
-    () => typeof initial !== "string" && hasAttachmentUrls(initial.content ?? []),
-    [initial],
-  );
-
-  const [content, setContent] = useState<InitialContent>(initial);
-  const [resolving, setResolving] = useState(needsResolving);
-
-  useEffect(() => {
-    if (!needsResolving || typeof initial === "string") return;
-    let settled = false;
-    const finish = (resolved: InitialContent) => {
-      if (settled) return;
-      settled = true;
-      setContent(resolved);
-      setResolving(false);
-    };
-    withTimeout(
-      resolveImageUrlsOrFallback(initial, getSignedUrl),
-      RESOLVE_TIMEOUT_MS,
-      "url resolve",
-    )
-      .then(finish)
-      .catch(() => finish(initial)); // timeout / failure → render the unresolved doc
-    return () => {
-      settled = true;
-    };
-  }, [initial, needsResolving]);
-
-  return { content, resolving };
+function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return new Promise<T>((resolve) => {
+    const timer = setTimeout(() => resolve(fallback), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      () => {
+        clearTimeout(timer);
+        resolve(fallback);
+      },
+    );
+  });
 }
 
 interface NoteEditorPanelProps {
   noteId: string | undefined;
 }
 
-// Outer shell: resolves the selected note, then mounts a fresh editor per note
-// via `key={note.id}` on LoadedNoteEditor. Keying the editor on the note id is
-// what makes switching notes reliable — each note gets its own editor instance,
-// created with its own content as `initialContent`, instead of one long-lived
-// editor that must be imperatively re-pointed at each note (the setContent model
-// that silently dropped content on macOS's WKWebView).
 export function NoteEditorPanel({ noteId }: NoteEditorPanelProps) {
   const { note, loading } = useNote(noteId);
   const { semantic } = useTheme();
   const styles = useMemo(() => createStyles(semantic), [semantic]);
 
-  if (!noteId) {
-    return (
-      <View style={styles.container}>
-        <EmptyState
-          icon="✏️"
-          title="Select a note"
-          subtitle="Choose a note from the list to start editing"
-        />
-      </View>
-    );
-  }
+  const [title, setTitle] = useState("");
 
-  if (loading) {
-    return (
-      <View style={[styles.container, styles.loadingContainer]}>
-        <ActivityIndicator size="small" color={colors.primary[600]} />
-      </View>
-    );
-  }
+  // noteIdRef tracks which note the panel is currently *displaying* (updated as
+  // soon as a note switch is intended). loadedNoteIdRef tracks which note's
+  // content is actually inside the WebView editor right now (set only after
+  // setContent has completed). Autosave is gated on loadedNoteIdRef so that
+  // onChange events emitted before a load finishes are ignored and cannot leak
+  // the previous note's content into the newly-switched-to row.
+  const noteIdRef = useRef<string | undefined>(undefined);
+  const loadedNoteIdRef = useRef<string | null>(null);
 
-  if (!note) {
-    return (
-      <View style={styles.container}>
-        <EmptyState icon="🔍" title="Note not found" subtitle="This note may have been deleted" />
-      </View>
-    );
-  }
-
-  return <LoadedNoteEditor key={note.id} note={note} />;
-}
-
-interface LoadedNoteEditorProps {
-  note: Note;
-}
-
-function LoadedNoteEditor({ note }: LoadedNoteEditorProps) {
-  const noteId = note.id;
-  const { semantic } = useTheme();
-  const styles = useMemo(() => createStyles(semantic), [semantic]);
-
-  // Capture the note's title + content ONCE per mount. `key={note.id}` on this
-  // component guarantees a remount whenever the selected note changes, so "once
-  // per mount" == "once per note". Live record re-emissions (the note prop
-  // updates on every autosave) therefore can't re-resolve content or reset the
-  // editor; only the metadata below reads the live `note` prop.
-  const [initialContent] = useState(() => note.content || "");
-  const [title, setTitle] = useState(() => note.title || "");
-  const { content: resolvedContent, resolving } = useResolvedInitialContent(initialContent);
-
-  // editorReadyRef gates autosave on tentap's real readiness signal. onChange
-  // emissions during WebView bootstrap (before the ProseMirror view is mounted)
-  // must not persist — an empty/partial editor state could otherwise overwrite
-  // real DB content (the 2026-04-24 / 2026-04-27 incident class). Because the
-  // editor is created WITH this note's content as initialContent, the first
-  // honoured state already holds the real content, so a ready-state onChange
-  // re-saves the same content rather than blanking it.
-  const editorReadyRef = useRef(false);
-  // True while this per-note editor instance is mounted. The content save reads
-  // the editor LIVE while mounted (so a save always reflects the current state);
-  // once unmounted (note switch / close) the WebView is gone, so the flush falls
-  // back to latestContentRef instead of a getJSON that would never resolve.
-  const mountedRef = useRef(true);
-
-  // Dead-WebView fallback: the latest serialized content captured from a RESOLVED
-  // getJSON, kept warm on every edit. captureGenRef stamps each capture so a
-  // slow/older getJSON resolving after a newer edit (or an attachment insert)
-  // can't move this ref backwards. null until the first capture.
-  const latestContentRef = useRef<string | null>(null);
-  const captureGenRef = useRef(0);
-
-  // Declared before the save handlers so handleSaveContent can read the editor.
-  const editorRef = useRef<ReturnType<typeof useEditorBridge> | null>(null);
-
-  const handleSaveTitle = useCallback(
-    async (newTitle: string) => {
-      // Don't let a transient clear (select-all+delete, or a flush firing
-      // mid-edit) overwrite a real title with empty/whitespace.
-      if (!newTitle.trim()) return;
-      const record = await database.get<Note>("notes").find(noteId);
-      await database.write(async () => {
-        await record.update((n) => {
-          n.title = newTitle;
-        });
+  const handleSaveTitle = useCallback(async (payload: TitleSavePayload) => {
+    // Don't persist an empty/whitespace title over a real one (a transient clear,
+    // or a flush firing mid-edit).
+    if (!payload.title.trim()) return;
+    const record = await database.get<Note>("notes").find(payload.noteId);
+    await database.write(async () => {
+      await record.update((n) => {
+        n.title = payload.title;
       });
-    },
-    [noteId],
-  );
+    });
+  }, []);
 
-  const handleSaveContent = useCallback(async () => {
-    let content: string | null;
-    const editor = editorRef.current;
-    if (editor && mountedRef.current) {
-      // Mounted: read the editor LIVE so the save reflects the CURRENT state,
-      // immune to capture timing and stale in-flight getJSONs.
-      try {
-        const serialized = serializeEditorContent(
-          await withTimeout(editor.getJSON(), GETJSON_TIMEOUT_MS, "getJSON"),
-        );
-        // This live read is the freshest content — supersede older in-flight
-        // onChange captures (bump AFTER a successful read so a failed read does
-        // NOT invalidate the in-flight capture for this same edit) and record it
-        // as the dead-WebView fallback.
-        captureGenRef.current++;
-        latestContentRef.current = serialized;
-        content = serialized;
-      } catch {
-        // Live read failed (e.g. WebView mid-teardown) — fall back to whatever
-        // the latest still-valid capture has left in latestContentRef.
-        content = latestContentRef.current;
-      }
-    } else {
-      // Unmounted (flush during note switch / close): the WebView is gone, so a
-      // live getJSON would never resolve — persist the last captured snapshot.
-      content = latestContentRef.current;
-    }
-    if (content === null) return; // nothing captured yet
-    const record = await database.get<Note>("notes").find(noteId);
-    if (record.content === content) return; // already persisted — skip redundant write
-    // Tripwire: never let a save erase a non-trivial note down to (near) empty.
-    if (isCatastrophicEraseSave(record.content, content)) {
+  const handleSaveContent = useCallback(async (payload: ContentSavePayload) => {
+    const record = await database.get<Note>("notes").find(payload.noteId);
+    if (isCatastrophicEraseSave(record.content, payload.content)) {
       console.warn(
         "[note-editor] tripwire blocked catastrophic-erase save",
-        `noteId=${noteId}`,
+        `noteId=${payload.noteId}`,
         `existing=${record.content?.length ?? 0}B`,
-        `incoming=${content.length}B`,
+        `incoming=${payload.content.length}B`,
       );
       return;
     }
     await database.write(async () => {
       await record.update((n) => {
-        n.content = content;
+        n.content = payload.content;
       });
     });
-  }, [noteId]);
+  }, []);
 
-  const titleAutoSave = useAutoSave<string>({ onSave: handleSaveTitle });
-  const contentAutoSave = useAutoSave<void>({ onSave: handleSaveContent });
+  const titleAutoSave = useAutoSave<TitleSavePayload>({ onSave: handleSaveTitle });
+  const contentAutoSave = useAutoSave<ContentSavePayload>({ onSave: handleSaveContent });
 
   const titleAutoSaveRef = useRef(titleAutoSave);
   const contentAutoSaveRef = useRef(contentAutoSave);
   titleAutoSaveRef.current = titleAutoSave;
   contentAutoSaveRef.current = contentAutoSave;
 
+  const [editorReady, setEditorReady] = useState(false);
+  // Shown (as an overlay) from the moment a different note is selected until its
+  // content is set into the editor — so the previous note's stale body is never
+  // visible during the swap. The editor/WebView itself is never unmounted.
+  const [contentLoading, setContentLoading] = useState(false);
+
   const handleEditorChange = useCallback(() => {
-    // Gate on readiness so the editor's bootstrap onChange can't persist a
-    // partial state before the content has hydrated.
-    if (!editorReadyRef.current) return;
     const editor = editorRef.current;
     if (!editor) return;
-    // Arm the debounce synchronously so a pending save always exists after an
-    // edit — the unmount flush relies on it. The save reads the editor live, so
-    // it is NOT gated on the capture below; this only keeps the dead-WebView
-    // fallback warm, generation-guarded so a slow/older getJSON can't move it
-    // backwards past a newer edit or an attachment insert.
-    contentAutoSaveRef.current?.trigger();
-    const gen = ++captureGenRef.current;
-    withTimeout(editor.getJSON(), GETJSON_TIMEOUT_MS, "getJSON")
-      .then((json) => {
-        if (gen === captureGenRef.current) latestContentRef.current = serializeEditorContent(json);
+    // Guard: only persist edits for the note whose content is actually loaded
+    // into the editor. Spurious onChange emissions during note switches (or any
+    // tentap internal transition) would otherwise read stale editor JSON and
+    // save it to the wrong note — the exact incident that corrupted data in
+    // prod on 2026-04-24.
+    const loaded = loadedNoteIdRef.current;
+    if (!loaded || loaded !== noteIdRef.current) return;
+    editor
+      .getJSON()
+      .then((json: object) => {
+        // Re-check after the async boundary; the user may have switched notes
+        // while getJSON() was in flight.
+        if (loadedNoteIdRef.current !== loaded || noteIdRef.current !== loaded) return;
+        const blocknote = tiptapToBlocknote(json as TipTapDoc);
+        // Rewrite any signed URLs back to attachment:// before persisting so
+        // expiring tokens never reach the DB. Display-side resolution happens
+        // on note load via resolveTipTapImageUrls.
+        const migrated = migrateSignedUrlsToAttachmentUrls(blocknote);
+        contentAutoSaveRef.current?.trigger({
+          noteId: loaded,
+          content: JSON.stringify(migrated),
+        });
       })
       .catch((err: unknown) => {
         console.warn("Editor getJSON failed:", err);
       });
   }, []);
 
-  // Pass initialContent so tentap hydrates the WebView with the note's content
-  // when it first initialises — no setContent race.
+  const editorRef = useRef<ReturnType<typeof useEditorBridge> | null>(null);
   const editor = useEditorBridge({
     autofocus: false,
     avoidIosKeyboard: false,
     bridgeExtensions: TenTapStartKit,
-    initialContent: resolvedContent,
+    initialContent: "",
     onChange: handleEditorChange,
   });
   editorRef.current = editor;
 
-  const { isReady } = useBridgeState(editor);
+  // Gate content loads on tentap's real readiness signal instead of polling
+  // editor.getJSON(). A resolved getJSON() only proves the WebView bridge can
+  // round-trip a message — NOT that the ProseMirror view is mounted and able to
+  // accept setContent. On macOS that gap left the very first setContent silently
+  // dropped, so notes opened blank even though their content was present and
+  // valid in the DB (issue #551). `isReady` flips true off the web editor's
+  // onCreate state update, which is the first instant setContent is honoured.
+  // (This is the same signal the library's own useBridgeState hook reads; we
+  // subscribe directly and unsubscribe once ready to avoid re-rendering the
+  // panel on every keystroke.)
   useEffect(() => {
-    editorReadyRef.current = isReady;
-  }, [isReady]);
+    if (editorReady) return;
+    if (editor.getEditorState().isReady) {
+      setEditorReady(true);
+      return;
+    }
+    return editor._subscribeToEditorStateUpdate((state) => {
+      if (state.isReady) setEditorReady(true);
+    });
+  }, [editor, editorReady]);
 
-  // Flush pending autosaves on unmount (note switch or panel close) so the last
-  // edits land. The content save reads latestContentRef synchronously, so this
-  // persists the latest content captured before the switch without needing the
-  // (now tearing-down) editor; the save is keyed to this note via noteId.
-  // Mark unmounted in a LAYOUT-effect cleanup so it runs BEFORE passive-effect
-  // cleanups — including useAutoSave's own internal unmount flush (it registers
-  // `useEffect(() => flush)`). That ordering guarantees the flushed content save
-  // takes the latestContentRef fallback path instead of calling getJSON on the
-  // tearing-down WebView (which would hang until the timeout). The hook's own
-  // unmount flush persists both pending saves, so no explicit flush is needed.
-  useLayoutEffect(() => {
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  // Sync local state when a different note is loaded.
+  useEffect(() => {
+    if (!editorReady) return;
 
-  const handleTitleChange = useCallback((text: string) => {
-    setTitle(text);
-    titleAutoSaveRef.current?.trigger(text);
-  }, []);
+    if (note && note.id !== noteIdRef.current) {
+      // Flush pending autosaves BEFORE switching the noteId refs so any
+      // still-in-flight save goes through with the previous note's payload
+      // (which already carries that note's id, so it lands on the right row).
+      titleAutoSaveRef.current?.flush();
+      contentAutoSaveRef.current?.flush();
+
+      noteIdRef.current = note.id;
+      loadedNoteIdRef.current = null; // gate autosave until setContent completes
+      setContentLoading(true); // overlay the editor until setContent() lands
+      setTitle(note.title || "");
+
+      const rawContent = note.content || "";
+      let cancelled = false;
+      const targetNoteId = note.id;
+
+      const markLoaded = () => {
+        if (cancelled) return;
+        // Only flip the gate if the user hasn't switched notes again while we
+        // were loading; otherwise another effect run is already handling the
+        // newer note.
+        if (noteIdRef.current === targetNoteId) {
+          loadedNoteIdRef.current = targetNoteId;
+          setContentLoading(false);
+        }
+      };
+
+      (async () => {
+        try {
+          const load = classifyNoteContent(rawContent);
+          if (load.kind === "empty") {
+            editorRef.current?.setContent("");
+            markLoaded();
+            return;
+          }
+          if (load.kind === "html") {
+            editorRef.current?.setContent(load.html);
+            markLoaded();
+            return;
+          }
+          const tiptapDoc = contentToTiptap(load.value);
+          // Resolve image URLs defensively, bounded by a timeout so a
+          // never-settling signed-URL fetch can't strand the loading overlay: a
+          // resolution failure/timeout degrades images to placeholders rather
+          // than blanking the whole (otherwise valid) note.
+          const resolved = await withTimeout(
+            resolveImageUrlsOrFallback(tiptapDoc, getSignedUrl),
+            RESOLVE_TIMEOUT_MS,
+            tiptapDoc,
+          );
+          if (cancelled || noteIdRef.current !== targetNoteId) return;
+          editorRef.current?.setContent(resolved);
+          markLoaded();
+        } catch (err) {
+          // Intentionally do NOT call editor.setContent("") or markLoaded()
+          // here. Wiping the editor would only cosmetically clear the WebView;
+          // calling markLoaded would open the autosave gate, allowing the
+          // editor's empty bootstrap onChange to persist an empty BlockNote
+          // and overwrite real DB content. The 2026-04-24 and 2026-04-27
+          // incidents both took this exact path. Leaving the gate closed on
+          // load failure means a stuck editor (the user can close+reopen),
+          // never a destructively-persisted empty doc.
+          console.warn(
+            "[note-editor] content load failed; leaving autosave gated",
+            `noteId=${targetNoteId}`,
+            err,
+          );
+          // Hide the overlay even on failure (show the editor as-is); the
+          // autosave stays gated above so a stale/empty doc can't persist.
+          if (!cancelled && noteIdRef.current === targetNoteId) setContentLoading(false);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    } else if (!note) {
+      titleAutoSaveRef.current?.flush();
+      contentAutoSaveRef.current?.flush();
+      noteIdRef.current = undefined;
+      loadedNoteIdRef.current = null;
+      setContentLoading(false);
+      setTitle("");
+      try {
+        editorRef.current?.setContent("");
+      } catch {
+        // Editor not ready — safe to ignore
+      }
+    }
+    // `editor` is intentionally NOT a dependency here. useEditorBridge returns a
+    // NEW object every render, so depending on it re-ran this effect on every
+    // render — cancelling an in-flight async content resolve (via the cleanup's
+    // `cancelled = true`) and stranding the loading overlay for notes whose
+    // resolution didn't finish within a single microtask (attachment notes). The
+    // live editor is read through editorRef.current instead.
+  }, [note?.id, editorReady]);
 
   const handleAttachmentReady = useCallback(
     async (attachment: Attachment) => {
-      const editor = editorRef.current;
-      if (!editor || !editorReadyRef.current) return;
+      // Only append if the editor is actually loaded with the right note.
+      const active = loadedNoteIdRef.current;
+      if (!active || active !== noteIdRef.current) return;
       try {
         const node = await buildInsertNode(attachment);
         const currentJson = (await editor.getJSON()) as TipTapDoc;
+        if (loadedNoteIdRef.current !== active || noteIdRef.current !== active) return;
         const appended: TipTapDoc = {
           type: "doc",
           content: [...(currentJson.content ?? []), node],
         };
         editor.setContent(appended);
         // setContent doesn't reliably trigger onChange in tentap. Persist
-        // directly, addressing the note by id. Supersede any pending
-        // pre-attachment autosave first — otherwise its debounce would fire
-        // later with stale content and strand the inline reference.
+        // directly, addressing the note by id rather than via the prop closure
+        // so a mid-flight note switch can't reroute the write. Supersede any
+        // pending pre-attachment autosave first — otherwise its 800 ms debounce
+        // would fire later with stale content and strand the inline reference.
         const blocks = tiptapToBlocknote(appended);
         const migrated = migrateSignedUrlsToAttachmentUrls(blocks);
         const serialized = JSON.stringify(migrated);
-        // Supersede any in-flight pre-attachment getJSON capture (bump the
-        // generation) so it can't resolve later and regress latestContentRef back
-        // to pre-attachment content, then set the fallback baseline to the
-        // appended content so a later flush doesn't overwrite this write.
-        captureGenRef.current++;
-        latestContentRef.current = serialized;
-        const record = await database.get<Note>("notes").find(noteId);
+        const record = await database.get<Note>("notes").find(active);
         await database.write(async () => {
           await record.update((n) => {
             n.content = serialized;
           });
         });
-        // Cancel after the authoritative write lands — `setContent(appended)`
-        // may have synchronously armed a debounce via onChange.
+        // Cancel after the authoritative write completes — `setContent(appended)`
+        // may have synchronously fired tentap's onChange, which then async-resolves
+        // a fresh `trigger()` past the cancel. Clearing once the explicit write
+        // has landed guarantees no redundant debounced rewrite remains scheduled.
         contentAutoSaveRef.current?.cancel();
       } catch (err) {
         console.warn("Failed to insert attachment inline:", err);
       }
     },
-    [noteId],
+    [editor],
   );
+
+  // Flush pending autosaves on unmount.
+  useEffect(() => {
+    return () => {
+      titleAutoSaveRef.current?.flush();
+      contentAutoSaveRef.current?.flush();
+    };
+  }, []);
+
+  const handleTitleChange = useCallback((text: string) => {
+    setTitle(text);
+    const active = loadedNoteIdRef.current;
+    if (!active || active !== noteIdRef.current) return;
+    titleAutoSaveRef.current?.trigger({ noteId: active, title: text });
+  }, []);
 
   const saveStatusKey: SaveStatusKey | null =
     titleAutoSave.status === "saving" || contentAutoSave.status === "saving"
@@ -416,47 +383,68 @@ function LoadedNoteEditor({ note }: LoadedNoteEditorProps) {
           : null;
   const statusConfig = saveStatusKey ? saveStatusConfig[saveStatusKey] : null;
 
-  // Hold the editor surface back until image URLs have resolved so tentap
-  // hydrates with the fully-resolved content in a single shot.
-  if (resolving) {
-    return (
-      <View style={[styles.container, styles.loadingContainer]}>
-        <ActivityIndicator size="small" color={colors.primary[600]} />
-      </View>
-    );
-  }
-
+  // The editor (and its tentap WebView) is mounted ONCE and never unmounted.
+  // On macOS (New Arch / Fabric + react-native-webview) an unmounted WKWebView is
+  // recycled rather than destroyed, and remounting it strands the editor on the
+  // previously-loaded note's stale DOM — the note-switch bug. So note content is
+  // swapped via editor.setContent() on the live WebView (the load effect), and the
+  // select / loading / not-found states render as OVERLAYS on top of the editor
+  // rather than early-returns that would unmount it.
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
-        <View style={styles.titleRow}>
-          <TextInput
-            style={styles.titleInput}
-            value={title}
-            onChangeText={handleTitleChange}
-            placeholder="Untitled"
-            placeholderTextColor={semantic.fgSubtle}
-          />
-          {statusConfig && <Badge variant={statusConfig.variant} label={statusConfig.label} />}
-        </View>
+      {note && (
+        <View style={styles.header}>
+          <View style={styles.titleRow}>
+            <TextInput
+              style={styles.titleInput}
+              value={title}
+              onChangeText={handleTitleChange}
+              placeholder="Untitled"
+              placeholderTextColor={semantic.fgSubtle}
+            />
+            {statusConfig && <Badge variant={statusConfig.variant} label={statusConfig.label} />}
+          </View>
 
-        <View style={styles.metadataRow}>
-          <View style={styles.metadataItem}>
-            <CalendarIcon size={14} color={semantic.fgSubtle} />
-            <Text style={styles.metadataText}>Created {formatRelativeTime(note.createdAt)}</Text>
-          </View>
-          <View style={styles.metadataItem}>
-            <ClockIcon size={14} color={semantic.fgSubtle} />
-            <Text style={styles.metadataText}>Modified {formatRelativeTime(note.updatedAt)}</Text>
+          <View style={styles.metadataRow}>
+            <View style={styles.metadataItem}>
+              <CalendarIcon size={14} color={semantic.fgSubtle} />
+              <Text style={styles.metadataText}>Created {formatRelativeTime(note.createdAt)}</Text>
+            </View>
+            <View style={styles.metadataItem}>
+              <ClockIcon size={14} color={semantic.fgSubtle} />
+              <Text style={styles.metadataText}>Modified {formatRelativeTime(note.updatedAt)}</Text>
+            </View>
           </View>
         </View>
-      </View>
+      )}
 
       <View style={styles.editorContainer}>
         <NoteEditor editor={editor} />
       </View>
 
-      <AttachmentPicker noteId={noteId} onAttachmentReady={handleAttachmentReady} />
+      {note && <AttachmentPicker noteId={note.id} onAttachmentReady={handleAttachmentReady} />}
+
+      {!noteId && (
+        <View style={styles.overlay}>
+          <EmptyState
+            icon="✏️"
+            title="Select a note"
+            subtitle="Choose a note from the list to start editing"
+          />
+        </View>
+      )}
+
+      {noteId && (loading || !editorReady || contentLoading) && (
+        <View style={styles.overlay}>
+          <ActivityIndicator size="small" color={colors.primary[600]} />
+        </View>
+      )}
+
+      {noteId && !loading && !note && (
+        <View style={styles.overlay}>
+          <EmptyState icon="🔍" title="Note not found" subtitle="This note may have been deleted" />
+        </View>
+      )}
     </View>
   );
 }
@@ -470,6 +458,18 @@ const createStyles = (semantic: SemanticColors) =>
     loadingContainer: {
       alignItems: "center",
       justifyContent: "center",
+    },
+    // Covers the always-mounted editor for the select / loading / not-found
+    // states (the editor is never unmounted — see the render note).
+    overlay: {
+      position: "absolute",
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: semantic.bg,
     },
     header: {
       backgroundColor: semantic.bgSubtle,


### PR DESCRIPTION
<!-- drafto-factory-pr -->

Closes #551

## Summary

macOS notes opened blank in the editor even though their content was present and valid in the local DB. The content-load effect gated `setContent` on a hand-rolled poll of `editor.getJSON()` — but a resolved `getJSON()` only proves the WebView bridge can round-trip a message, not that the ProseMirror view is mounted and able to accept `setContent`. On macOS the gap between those two moments left the first `setContent` silently dropped, so the body rendered empty. This gates the load on tentap's real `isReady` editor-state signal instead. ([approved plan](https://github.com/JakubAnderwald/drafto/issues/551#issuecomment-4832408627))

## Parity report

Scoped to **desktop** per the issue's "Affected platforms" checkbox (web + mobile load content correctly today and are unchanged). The fix lives entirely in the desktop content-load path; the shared `contentToTiptap` / `resolveTipTapImageUrls` converters are unchanged, so there is no cross-platform blast radius.

- desktop — `apps/desktop/src/components/notes/note-editor-panel.tsx` + new `note-content-loader.ts` ✅
- web — no change (reference implementation for correct behaviour)
- mobile — no change (shares `db/` with desktop; loads correctly)

## Test plan

- [x] `pnpm --filter @drafto/desktop test` — 294 pass (13 new in `note-content-loader.test.ts`)
- [x] `pnpm --filter @drafto/desktop typecheck` — passed
- [x] `pnpm --filter @drafto/desktop lint` — passed
- [x] `prettier --check` — passed
- [ ] **On-device (In Test gate):** open a pre-existing note with real content on a macOS build and confirm the body renders. The desktop app has no automated E2E, and the approved plan defines "done" as on-device observation — **please verify this in the In Test preview before approving.**

## Diagnosis notes (what the static analysis changed)

- The plan's *secondary* hypothesis — "a single `getSignedUrl` rejection blanks the whole note" — is **refuted by the code**: `resolveTipTapImageUrls` already wraps every URL in `Promise.allSettled`, so a failed image URL keeps its `attachment://` src and cannot reject the load.
- The schema-mismatch hypothesis is **mostly refuted**: the tentap WebView bundle registers `image`/`table`/`taskList`/`heading`/lists. (`codeBlock` is genuinely absent from the bundle — a narrow edge intentionally **not** touched here, since stripping nodes would risk the data-loss invariant.)
- The remaining, strongest cause is the readiness gate, which this PR fixes.

## Data-loss invariant (preserved)

The gated `catch` in the load effect — which keeps the autosave gate (`loadedNoteIdRef`) **closed** on load failure so an empty bootstrap `onChange` can never overwrite real DB content (the 2026-04-24 / 2026-04-27 incidents) — is **unchanged**. The new image-resolution fallback only degrades images to a placeholder; `attachment://` is the canonical stored form, so the unresolved doc round-trips without corruption.

## Drift vs. approved plan

Matches the plan's "Files to touch" (`note-editor-panel.tsx`, with `resolve-urls.ts` inspected-only and left unedited). One addition beyond the listed files: a new pure helper `apps/desktop/src/components/notes/note-content-loader.ts`, extracted so the content-load branch is unit-testable without the WebView bridge (the plan explicitly anticipated a content-load-branch test). `note-editor.tsx` was inspected but needed no change — the readiness fix lives in the panel's gate, not the WebView mount.

🤖 Generated by the dark factory ([approved plan](https://github.com/JakubAnderwald/drafto/issues/551#issuecomment-4832408627))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note loading with centralized content classification to reliably display empty, plain-text, or structured editor content, even for malformed/ambiguous JSON.
  * Improved attachment image handling during note open: resolves `attachment://` URLs when possible, and safely falls back without blocking rendering on resolution errors or timeouts.
  * Strengthened editor readiness gating, loading overlays, and autosave/title behavior to reduce timing issues and prevent content loss.

* **Tests**
  * Added comprehensive unit tests for content classification, HTML escaping, and safe image URL resolution fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->