### PR TITLE
docs: require --project flag when creating factory issues via gh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,15 @@ Production / public-store releases (`pnpm release:prod:*`, `pnpm release:product
 
 Drafto runs an unattended development pipeline on the Mac mini ("dark factory") that watches a GitHub Projects v2 board and drives issues through plan → implement → preview → ship. State lives in `status:*` labels mirrored from the board's Status field, plus `logs/factory-state.json`. See [`docs/features/dark-factory.md`](./docs/features/dark-factory.md) for the operator manual, [`docs/operations/factory-runbook.md`](./docs/operations/factory-runbook.md) for phase promotion + rollback, and [ADR-0026](./docs/adr/0026-dark-factory-pipeline.md) for the decision.
 
+**Creating factory issues:** Issues are **not** auto-added to the board — neither `gh issue create` nor the web issue form adds them. Always pass `--project "Drafto Factory"` when creating one via the CLI so the card lands on the [board](https://github.com/users/JakubAnderwald/projects/1) and the factory can pick it up:
+
+```bash
+gh issue create --project "Drafto Factory" \
+  --template factory-feature.yml --title "feat: ..." --body "..."
+```
+
+(Requires the `gh` token to carry `project` scope — run `gh auth refresh -s project` once if `--project` errors with a missing-scope message.)
+
 **Two human gates** the factory will never bypass: Plan Review → In Progress (plan-approval) and In Test → Approved (merge + ship). Both are reachable via the kanban board for any reporter, and via email reply for allowlisted reporters (Jakub + his wife). The migration gate (`migration-approved` label required when a PR touches `supabase/migrations/**`) is a hard stop on the Approved transition for everyone.
 
 **Kill switches**: per-card via `factory-pause` label or dragging to **Blocked**; global via `node scripts/lib/state-cli.mjs factory:pause`; emergency via `launchctl unload ~/Library/LaunchAgents/eu.drafto.factory.plist`.


### PR DESCRIPTION
## What

CLI-created issues (`gh issue create`) and the web issue form do **not** auto-add to the **Drafto Factory** Projects v2 board (https://github.com/users/JakubAnderwald/projects/1). Cards silently never enter the pipeline.

This documents the fix in `CLAUDE.md` (Dark Factory section): always pass `--project "Drafto Factory"` when creating a factory issue via the CLI, plus the one-time `gh auth refresh -s project` scope requirement.

## Why this approach

We considered the issue-template `projects:` key and an `actions/add-to-project` workflow. The template key only fires for web-form creation (not the CLI), and the workflow requires a `project`-scoped PAT secret. Since these issues are created via the CLI, the `--project` flag is the lowest-friction, no-secret path — baking it into `CLAUDE.md` makes it the default behavior.

## Note

No code change — docs only. The flag requires the local `gh` token to carry `project` scope (`gh auth refresh -s project`), which is a one-time operator step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating factory issues so they appear on the correct project board.
  * Clarified that issues created through the web form or basic CLI command are not automatically added to the board.
  * Documented the need to include the project option when creating issues and how to refresh access if the required permission is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->