### PR TITLE
feat(dark-factory): add parity:infra-only override for no-platform changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/factory-feature.yml
+++ b/.github/ISSUE_TEMPLATE/factory-feature.yml
@@ -39,8 +39,11 @@ body:
       label: Affected platforms
       description: |
         Drives the parity check. The factory's plan-vs-diff post-check fails the
-        card if a checked platform has no corresponding code changes. Use one
-        of the parity:* labels to override for legitimate single-platform work.
+        card if a checked platform has no corresponding code changes. Use one of
+        the parity:*-only labels to override for legitimate single-platform work.
+        A change that touches no app platform at all (factory internals under
+        scripts/, docs, CI) is filed via the CLI with the parity:infra-only
+        label and no boxes ticked — the spec gate skips this requirement for it.
       options:
         - label: web (`apps/web`)
         - label: iOS / Android (`apps/mobile`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ gh issue create --project "Drafto Factory" \
 
 **Kill switches**: per-card via `factory-pause` label or dragging to **Blocked**; global via `node scripts/lib/state-cli.mjs factory:pause`; emergency via `launchctl unload ~/Library/LaunchAgents/eu.drafto.factory.plist`.
 
-**Parity-mandate enforcement**: the factory's `--implement` post-check diffs the PR against the issue's "Affected platforms" checkboxes and blocks the card if a claimed platform has no code changes. To run a legitimate single-platform feature, apply `parity:web-only` / `parity:mobile-only` / `parity:desktop-only` to the issue. For a factory-internal change that touches no app platform (under `scripts/`, docs, CI), apply `parity:infra-only` with no platform boxes ticked — the spec gate skips the "Affected platforms" requirement and the parity check passes as long as the PR stays out of `apps/`.
+**Parity-mandate enforcement**: the factory's `--implement` post-check diffs the PR against the issue's "Affected platforms" checkboxes and blocks the card if a claimed platform has no code changes. To run a legitimate single-platform feature, apply `parity:web-only` / `parity:mobile-only` / `parity:desktop-only` to the issue. For a factory-internal change that touches no app platform (under `scripts/`, docs, CI), apply `parity:infra-only` with no platform boxes ticked — the spec gate skips the "Affected platforms" requirement and the parity check passes as long as the PR stays out of `apps/` and `packages/shared/`.
 
 ## Cross-Platform Feature Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ gh issue create --project "Drafto Factory" \
 
 **Kill switches**: per-card via `factory-pause` label or dragging to **Blocked**; global via `node scripts/lib/state-cli.mjs factory:pause`; emergency via `launchctl unload ~/Library/LaunchAgents/eu.drafto.factory.plist`.
 
-**Parity-mandate enforcement**: the factory's `--implement` post-check diffs the PR against the issue's "Affected platforms" checkboxes and blocks the card if a claimed platform has no code changes. To run a legitimate single-platform feature, apply `parity:web-only` / `parity:mobile-only` / `parity:desktop-only` to the issue.
+**Parity-mandate enforcement**: the factory's `--implement` post-check diffs the PR against the issue's "Affected platforms" checkboxes and blocks the card if a claimed platform has no code changes. To run a legitimate single-platform feature, apply `parity:web-only` / `parity:mobile-only` / `parity:desktop-only` to the issue. For a factory-internal change that touches no app platform (under `scripts/`, docs, CI), apply `parity:infra-only` with no platform boxes ticked — the spec gate skips the "Affected platforms" requirement and the parity check passes as long as the PR stays out of `apps/`.
 
 ## Cross-Platform Feature Workflow
 

--- a/docs/features/dark-factory.md
+++ b/docs/features/dark-factory.md
@@ -43,24 +43,25 @@ The factory agent reads the Status field directly via the GitHub GraphQL API on 
 
 The full set is created idempotently by `scripts/setup-factory-labels.sh`. Reference:
 
-| Label                 | Set by               | Meaning                                                          |
-| --------------------- | -------------------- | ---------------------------------------------------------------- |
-| `status:ready`        | human (via board)    | Spec accepted; factory may plan.                                 |
-| `status:planning`     | factory              | Plan in progress.                                                |
-| `status:plan-review`  | factory              | Awaiting plan approval.                                          |
-| `status:in-progress`  | human / factory      | Implementation in progress.                                      |
-| `status:in-review`    | factory              | PR open, CI / review comments active.                            |
-| `status:in-test`      | factory              | Vercel preview ready, awaiting ship approval.                    |
-| `status:approved`     | human / factory      | Approved for release; merge + dispatch authorised.               |
-| `status:released`     | factory              | Merged + beta dispatched.                                        |
-| `status:done`         | human / support      | Final acceptance.                                                |
-| `status:blocked`      | factory              | Hard stop — see comment on issue.                                |
-| `factory-pause`       | operator             | Global kill switch on this issue (factory ignores).              |
-| `migration-approved`  | operator             | Authorises factory to merge a PR with `supabase/migrations` SQL. |
-| `factory-failure`     | factory failure trap | Filed by `cleanup()` when a factory run errors out.              |
-| `parity:web-only`     | operator             | Skip cross-platform parity check (legitimate web-only work).     |
-| `parity:mobile-only`  | operator             | Skip cross-platform parity check (legitimate mobile-only work).  |
-| `parity:desktop-only` | operator             | Skip cross-platform parity check (legitimate desktop-only work). |
+| Label                 | Set by               | Meaning                                                              |
+| --------------------- | -------------------- | -------------------------------------------------------------------- |
+| `status:ready`        | human (via board)    | Spec accepted; factory may plan.                                     |
+| `status:planning`     | factory              | Plan in progress.                                                    |
+| `status:plan-review`  | factory              | Awaiting plan approval.                                              |
+| `status:in-progress`  | human / factory      | Implementation in progress.                                          |
+| `status:in-review`    | factory              | PR open, CI / review comments active.                                |
+| `status:in-test`      | factory              | Vercel preview ready, awaiting ship approval.                        |
+| `status:approved`     | human / factory      | Approved for release; merge + dispatch authorised.                   |
+| `status:released`     | factory              | Merged + beta dispatched.                                            |
+| `status:done`         | human / support      | Final acceptance.                                                    |
+| `status:blocked`      | factory              | Hard stop — see comment on issue.                                    |
+| `factory-pause`       | operator             | Global kill switch on this issue (factory ignores).                  |
+| `migration-approved`  | operator             | Authorises factory to merge a PR with `supabase/migrations` SQL.     |
+| `factory-failure`     | factory failure trap | Filed by `cleanup()` when a factory run errors out.                  |
+| `parity:web-only`     | operator             | Skip cross-platform parity check (legitimate web-only work).         |
+| `parity:mobile-only`  | operator             | Skip cross-platform parity check (legitimate mobile-only work).      |
+| `parity:desktop-only` | operator             | Skip cross-platform parity check (legitimate desktop-only work).     |
+| `parity:infra-only`   | operator             | Skip parity check; change touches no app platform (scripts/docs/CI). |
 
 ## How to file an issue for the factory
 

--- a/scripts/__tests__/factory-agent-infra-only.test.mjs
+++ b/scripts/__tests__/factory-agent-infra-only.test.mjs
@@ -90,7 +90,17 @@ docs/features/dark-factory.md"`,
   it("blocks when an infra-only PR sneaks in apps/** changes", () => {
     assert.equal(
       withFn("parity_violation", `PHASE=C; parity_violation "" "infra-only" "apps/web/src/x.ts"`),
-      "parity:infra-only but the PR changes files under apps/",
+      "parity:infra-only but the PR changes app code (apps/ or packages/shared/)",
+    );
+  });
+
+  it("blocks when an infra-only PR touches packages/shared (compiled into all platforms)", () => {
+    assert.equal(
+      withFn(
+        "parity_violation",
+        `PHASE=C; parity_violation "" "infra-only" "packages/shared/src/editor/markdown-converter.ts"`,
+      ),
+      "parity:infra-only but the PR changes app code (apps/ or packages/shared/)",
     );
   });
 

--- a/scripts/__tests__/factory-agent-infra-only.test.mjs
+++ b/scripts/__tests__/factory-agent-infra-only.test.mjs
@@ -1,0 +1,114 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Coverage for the parity:infra-only override — a change that touches no app
+// platform (factory internals under scripts/, docs, CI). It must (a) let an
+// empty-"Affected platforms" spec through the structural gate and (b) pass the
+// parity post-check, while still blocking if the PR sneaks in apps/** edits.
+// The two bash helpers are exercised behaviourally by extracting their real
+// definitions from factory-agent.sh (same harness as factory-intest-iteration).
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const agentPath = resolve(HERE, "..", "factory-agent.sh");
+const script = readFileSync(agentPath, "utf8");
+
+// Run a bash snippet that extracts a function definition from the real script
+// (start of `name()` through its first column-0 `}`) and exercises it.
+function withFn(fn, body) {
+  const snippet = `
+set -euo pipefail
+eval "$(awk '/^${fn}\\(\\)/{f=1} f{print} f&&/^}/{exit}' "${agentPath}")"
+${body}
+`;
+  const r = spawnSync("bash", ["-c", snippet], { encoding: "utf8" });
+  assert.equal(r.status, 0, `bash failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+// A fully-specced bundle .spec with NO platform boxes ticked.
+const noPlatformSpec = JSON.stringify({
+  what: "internal change",
+  acceptance: "tests pass",
+  affectedPlatforms: [],
+  schemaChanges: false,
+  ui: "",
+  outOfScope: "nothing",
+});
+
+// Same, but with a platform ticked (the normal case).
+const webSpec = JSON.stringify({
+  what: "web change",
+  acceptance: "tests pass",
+  affectedPlatforms: ["web"],
+  schemaChanges: false,
+  ui: "",
+  outOfScope: "nothing",
+});
+
+describe("spec_missing_section + parity:infra-only", () => {
+  it("blocks an empty-platform spec with no override", () => {
+    assert.equal(
+      withFn("spec_missing_section", `spec_missing_section ${JSON.stringify(noPlatformSpec)} ""`),
+      "Affected platforms",
+    );
+  });
+
+  it("accepts an empty-platform spec when the override is infra-only", () => {
+    assert.equal(
+      withFn(
+        "spec_missing_section",
+        `spec_missing_section ${JSON.stringify(noPlatformSpec)} "infra-only"`,
+      ),
+      "",
+    );
+  });
+
+  it("still accepts a normal spec with a platform ticked", () => {
+    assert.equal(
+      withFn("spec_missing_section", `spec_missing_section ${JSON.stringify(webSpec)} ""`),
+      "",
+    );
+  });
+});
+
+describe("parity_violation + parity:infra-only", () => {
+  it("passes when an infra-only PR touches only scripts/docs", () => {
+    assert.equal(
+      withFn(
+        "parity_violation",
+        `PHASE=C; parity_violation "" "infra-only" "scripts/factory-agent.sh
+docs/features/dark-factory.md"`,
+      ),
+      "",
+    );
+  });
+
+  it("blocks when an infra-only PR sneaks in apps/** changes", () => {
+    assert.equal(
+      withFn("parity_violation", `PHASE=C; parity_violation "" "infra-only" "apps/web/src/x.ts"`),
+      "parity:infra-only but the PR changes files under apps/",
+    );
+  });
+
+  it("leaves the existing single-platform override behaviour intact", () => {
+    assert.equal(
+      withFn("parity_violation", `PHASE=C; parity_violation "web" "web-only" "scripts/x.mjs"`),
+      "",
+    );
+  });
+});
+
+describe("structural wiring", () => {
+  it("passes bash -n", () => {
+    const r = spawnSync("bash", ["-n", agentPath], { encoding: "utf8" });
+    assert.equal(r.status, 0, r.stderr);
+  });
+
+  it("threads the parity override into the spec gate", () => {
+    assert.match(script, /spec_missing_section "\$SPEC" "\$SPEC_PARITY_OVERRIDE"/);
+  });
+});

--- a/scripts/__tests__/factory-bundle.test.mjs
+++ b/scripts/__tests__/factory-bundle.test.mjs
@@ -108,6 +108,7 @@ describe("parityOverrideFrom", () => {
     assert.equal(parityOverrideFrom(["parity:web-only", "status:ready"]), "web-only");
     assert.equal(parityOverrideFrom([{ name: "parity:mobile-only" }]), "mobile-only");
     assert.equal(parityOverrideFrom(["parity:desktop-only"]), "desktop-only");
+    assert.equal(parityOverrideFrom(["parity:infra-only"]), "infra-only");
   });
 
   it("returns null when no parity:* label is present", () => {

--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -818,12 +818,13 @@ parity_violation() {
     echo "Phase B is web-only but the PR changes files under apps/mobile or apps/desktop"
     return 0
   fi
-  # parity:infra-only authorises a change that touches NO app platform (factory
-  # internals under scripts/, docs, CI). If it changes apps/**, the label is
+  # parity:infra-only authorises a change that touches NO app runtime (factory
+  # internals under scripts/, docs, CI). App code under apps/** OR the shared
+  # package packages/shared/** (compiled into every platform) means the label is
   # wrong — block so non-infra work can't masquerade as infra-only.
   if [[ "$override" == "infra-only" ]]; then
-    if echo "$diff_files" | grep -qE '^apps/(web|mobile|desktop)/'; then
-      echo "parity:infra-only but the PR changes files under apps/"
+    if echo "$diff_files" | grep -qE '^(apps/|packages/shared/)'; then
+      echo "parity:infra-only but the PR changes app code (apps/ or packages/shared/)"
       return 0
     fi
     echo ""; return 0

--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -407,12 +407,17 @@ spec_missing_section() {
     echo "Schema changes?"
     return 0
   fi
-  # Affected platforms requires at least one checkbox.
-  local platforms_count
-  platforms_count=$(echo "$spec_json" | jq '.affectedPlatforms | length')
-  if [[ "$platforms_count" == "0" ]]; then
-    echo "Affected platforms"
-    return 0
+  # Affected platforms requires at least one checkbox — UNLESS this is an
+  # infra-only change (factory internals under scripts/, docs, CI) that touches
+  # no app platform, declared via the parity:infra-only override label.
+  local parity_override="${2:-}"
+  if [[ "$parity_override" != "infra-only" ]]; then
+    local platforms_count
+    platforms_count=$(echo "$spec_json" | jq '.affectedPlatforms | length')
+    if [[ "$platforms_count" == "0" ]]; then
+      echo "Affected platforms"
+      return 0
+    fi
   fi
   echo ""
 }
@@ -813,6 +818,16 @@ parity_violation() {
     echo "Phase B is web-only but the PR changes files under apps/mobile or apps/desktop"
     return 0
   fi
+  # parity:infra-only authorises a change that touches NO app platform (factory
+  # internals under scripts/, docs, CI). If it changes apps/**, the label is
+  # wrong — block so non-infra work can't masquerade as infra-only.
+  if [[ "$override" == "infra-only" ]]; then
+    if echo "$diff_files" | grep -qE '^apps/(web|mobile|desktop)/'; then
+      echo "parity:infra-only but the PR changes files under apps/"
+      return 0
+    fi
+    echo ""; return 0
+  fi
   # A parity:*-only override authorises a single-platform PR — skip the
   # cross-platform mandate entirely.
   if [[ -n "$override" ]]; then echo ""; return 0; fi
@@ -1126,9 +1141,12 @@ card back to **Ready**.
       continue
     fi
 
-    # Structural spec check before mutating board state.
+    # Structural spec check before mutating board state. The parity override
+    # (parity:infra-only) lets a no-app-platform change skip the
+    # Affected-platforms requirement.
     SPEC=$(echo "$BUNDLE" | jq '.spec')
-    MISSING=$(spec_missing_section "$SPEC")
+    SPEC_PARITY_OVERRIDE=$(echo "$BUNDLE" | jq -r '.parityOverride // ""')
+    MISSING=$(spec_missing_section "$SPEC" "$SPEC_PARITY_OVERRIDE")
     if [[ -n "$MISSING" ]]; then
       log "Issue #$ISSUE_NUM: spec incomplete (missing: $MISSING)"
       if [[ "$DRY_RUN" -eq 0 ]]; then

--- a/scripts/lib/factory-bundle.mjs
+++ b/scripts/lib/factory-bundle.mjs
@@ -271,7 +271,9 @@ function parseSchemaAnswer(section) {
 }
 
 // Pure: which parity:* override label is present on the issue (if any).
-// Returns "web-only" | "mobile-only" | "desktop-only" | null.
+// Returns "web-only" | "mobile-only" | "desktop-only" | "infra-only" | null.
+// "infra-only" marks a change that touches no app platform (factory internals
+// under scripts/, docs, CI); the others authorise single-platform app work.
 export function parityOverrideFrom(labels) {
   const list = Array.isArray(labels) ? labels : [];
   for (const lbl of list) {
@@ -280,6 +282,7 @@ export function parityOverrideFrom(labels) {
     if (name === "parity:web-only") return "web-only";
     if (name === "parity:mobile-only") return "mobile-only";
     if (name === "parity:desktop-only") return "desktop-only";
+    if (name === "parity:infra-only") return "infra-only";
   }
   return null;
 }

--- a/scripts/setup-factory-labels.sh
+++ b/scripts/setup-factory-labels.sh
@@ -64,6 +64,7 @@ LABELS=(
   "parity:web-only|C5DEF5|Skip cross-platform parity check (web-only feature)."
   "parity:mobile-only|C5DEF5|Skip cross-platform parity check (mobile-only feature)."
   "parity:desktop-only|C5DEF5|Skip cross-platform parity check (desktop-only feature)."
+  "parity:infra-only|C5DEF5|Skip parity check; change touches no app platform (scripts/docs/CI)."
 )
 
 echo "Bootstrapping factory labels on $REPO ($(date '+%Y-%m-%d %H:%M:%S'))"


### PR DESCRIPTION
## What

Factory-internal issues that touch **no app platform** (changes under `scripts/`, docs, CI) had no clean path through the pipeline:

- The spec gate (`spec_missing_section`) requires ≥1 **Affected platforms** checkbox, so a `scripts/`-only card is always blocked as *"spec incomplete"* (this is exactly what happened to #555).
- Checking a box to get past it would then **fail the parity post-check** (`claimed platform 'web' has no apps/web changes`).

This adds a first-class `parity:infra-only` override.

## Changes

- **`scripts/lib/factory-bundle.mjs`** — `parityOverrideFrom` recognises `parity:infra-only`.
- **`scripts/factory-agent.sh`**:
  - `spec_missing_section` skips the Affected-platforms requirement **only** when the override is `infra-only` (the override is threaded in from `bundle.parityOverride` at the call site).
  - `parity_violation` passes an infra-only PR, but **blocks** one that sneaks in `apps/**` changes — so non-infra work can't masquerade as infra-only.
- **`.github/ISSUE_TEMPLATE/factory-feature.yml`, `docs/features/dark-factory.md`, `CLAUDE.md`, `scripts/setup-factory-labels.sh`** — document and create the label.

## Tests

- `scripts/__tests__/factory-agent-infra-only.test.mjs` (new) — behavioural coverage of **both** bash gates, extracted from the real `factory-agent.sh` (same harness as `factory-intest-iteration`), covering: empty-platform spec blocked w/o override, accepted w/ infra-only; parity passes for scripts/docs, blocks for `apps/**`; existing single-platform override behaviour intact.
- `scripts/__tests__/factory-bundle.test.mjs` — adds the `parity:infra-only` → `infra-only` case.
- Full `drafto-scripts` suite green (481 tests).

## Why this design

Generalises the existing `parity:*-only` mechanism rather than special-casing docs/infra issues. The spec gate (not the web form's `required: true`) is the real enforcer, and it still blocks a *normal* empty-platform issue — only `infra-only` is exempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)