### PR TITLE
feat(dark-factory): add a 'None' platform option to flag infra-only issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/factory-feature.yml
+++ b/.github/ISSUE_TEMPLATE/factory-feature.yml
@@ -41,13 +41,15 @@ body:
         Drives the parity check. The factory's plan-vs-diff post-check fails the
         card if a checked platform has no corresponding code changes. Use one of
         the parity:*-only labels to override for legitimate single-platform work.
-        A change that touches no app platform at all (factory internals under
-        scripts/, docs, CI) is filed via the CLI with the parity:infra-only
-        label and no boxes ticked — the spec gate skips this requirement for it.
+        For a change that touches no app platform (factory internals under
+        scripts/, docs, CI), tick **None** — that flags the issue infra-only,
+        with no separate label needed. None is mutually exclusive with the
+        platform boxes.
       options:
         - label: web (`apps/web`)
         - label: iOS / Android (`apps/mobile`)
         - label: macOS (`apps/desktop`)
+        - label: None — factory internals / docs / CI (no app platform)
     validations:
       required: true
   - type: dropdown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ gh issue create --project "Drafto Factory" \
 
 **Kill switches**: per-card via `factory-pause` label or dragging to **Blocked**; global via `node scripts/lib/state-cli.mjs factory:pause`; emergency via `launchctl unload ~/Library/LaunchAgents/eu.drafto.factory.plist`.
 
-**Parity-mandate enforcement**: the factory's `--implement` post-check diffs the PR against the issue's "Affected platforms" checkboxes and blocks the card if a claimed platform has no code changes. To run a legitimate single-platform feature, apply `parity:web-only` / `parity:mobile-only` / `parity:desktop-only` to the issue. For a factory-internal change that touches no app platform (under `scripts/`, docs, CI), apply `parity:infra-only` with no platform boxes ticked — the spec gate skips the "Affected platforms" requirement and the parity check passes as long as the PR stays out of `apps/` and `packages/shared/`.
+**Parity-mandate enforcement**: the factory's `--implement` post-check diffs the PR against the issue's "Affected platforms" checkboxes and blocks the card if a claimed platform has no code changes. To run a legitimate single-platform feature, apply `parity:web-only` / `parity:mobile-only` / `parity:desktop-only` to the issue. For a factory-internal change that touches no app platform (under `scripts/`, docs, CI), tick the **None** box in the issue form (or apply the `parity:infra-only` label) — the spec gate skips the "Affected platforms" requirement and the parity check passes as long as the PR stays out of `apps/` and `packages/shared/`.
 
 ## Cross-Platform Feature Workflow
 

--- a/docs/features/dark-factory.md
+++ b/docs/features/dark-factory.md
@@ -69,7 +69,7 @@ Use the **Factory feature spec** template (`.github/ISSUE_TEMPLATE/factory-featu
 
 1. **What** — one paragraph user-facing description.
 2. **Acceptance criteria** — bulleted, testable.
-3. **Affected platforms** — checkboxes (web / iOS+Android / macOS).
+3. **Affected platforms** — checkboxes (web / iOS+Android / macOS), or **None** for a factory-internal / docs / CI change that touches no app platform.
 4. **Schema changes?** — yes/no. If yes, the factory adds `needs-migration-review`.
 5. **UI?** — screenshot / Figma URL if applicable.
 6. **Out of scope** — explicit non-goals.

--- a/scripts/__tests__/factory-agent-infra-only.test.mjs
+++ b/scripts/__tests__/factory-agent-infra-only.test.mjs
@@ -34,6 +34,7 @@ const noPlatformSpec = JSON.stringify({
   what: "internal change",
   acceptance: "tests pass",
   affectedPlatforms: [],
+  infraOnly: false,
   schemaChanges: false,
   ui: "",
   outOfScope: "nothing",
@@ -44,6 +45,29 @@ const webSpec = JSON.stringify({
   what: "web change",
   acceptance: "tests pass",
   affectedPlatforms: ["web"],
+  infraOnly: false,
+  schemaChanges: false,
+  ui: "",
+  outOfScope: "nothing",
+});
+
+// A spec from a ticked "None" box (parseSpec sets infraOnly true).
+const infraOnlyBoxSpec = JSON.stringify({
+  what: "scripts change",
+  acceptance: "tests pass",
+  affectedPlatforms: [],
+  infraOnly: true,
+  schemaChanges: false,
+  ui: "",
+  outOfScope: "nothing",
+});
+
+// Contradiction: the None box ticked AND a platform box ticked.
+const infraOnlyBoxWithPlatformSpec = JSON.stringify({
+  what: "scripts change",
+  acceptance: "tests pass",
+  affectedPlatforms: ["web"],
+  infraOnly: true,
   schemaChanges: false,
   ui: "",
   outOfScope: "nothing",
@@ -74,13 +98,43 @@ describe("spec_missing_section + parity:infra-only", () => {
     );
   });
 
-  it("blocks infra-only combined with a ticked platform (contradiction)", () => {
+  it("blocks the parity:infra-only label combined with a ticked platform box", () => {
     assert.equal(
       withFn(
         "spec_missing_section",
         `spec_missing_section ${JSON.stringify(webSpec)} "infra-only"`,
       ),
-      "Affected platforms (infra-only can't be combined with a platform box)",
+      "Affected platforms (None / infra-only can't be combined with a platform box)",
+    );
+  });
+
+  it("blocks a ticked None box combined with a ticked platform box", () => {
+    assert.equal(
+      withFn(
+        "spec_missing_section",
+        `spec_missing_section ${JSON.stringify(infraOnlyBoxWithPlatformSpec)} "infra-only"`,
+      ),
+      "Affected platforms (None / infra-only can't be combined with a platform box)",
+    );
+  });
+
+  it("accepts a ticked None box with no platform (infra-only resolved)", () => {
+    assert.equal(
+      withFn(
+        "spec_missing_section",
+        `spec_missing_section ${JSON.stringify(infraOnlyBoxSpec)} "infra-only"`,
+      ),
+      "",
+    );
+  });
+
+  it("blocks a ticked None box combined with a single-platform parity label", () => {
+    assert.equal(
+      withFn(
+        "spec_missing_section",
+        `spec_missing_section ${JSON.stringify(infraOnlyBoxSpec)} "web-only"`,
+      ),
+      "Affected platforms (None box conflicts with the web-only label)",
     );
   });
 });

--- a/scripts/__tests__/factory-agent-infra-only.test.mjs
+++ b/scripts/__tests__/factory-agent-infra-only.test.mjs
@@ -73,6 +73,16 @@ describe("spec_missing_section + parity:infra-only", () => {
       "",
     );
   });
+
+  it("blocks infra-only combined with a ticked platform (contradiction)", () => {
+    assert.equal(
+      withFn(
+        "spec_missing_section",
+        `spec_missing_section ${JSON.stringify(webSpec)} "infra-only"`,
+      ),
+      "Affected platforms (infra-only can't be combined with a platform box)",
+    );
+  });
 });
 
 describe("parity_violation + parity:infra-only", () => {

--- a/scripts/__tests__/factory-bundle.test.mjs
+++ b/scripts/__tests__/factory-bundle.test.mjs
@@ -11,7 +11,9 @@ import {
   buildFactoryWatchBundle,
   parseSpec,
   parsePlatformCheckboxes,
+  parseInfraOnlyCheckbox,
   parityOverrideFrom,
+  effectiveParityOverride,
   reporterFromBody,
   extractScreenshots,
 } from "../lib/factory-bundle.mjs";
@@ -62,6 +64,7 @@ describe("parseSpec", () => {
     assert.equal(spec.schemaChanges, false);
     assert.match(spec.ui, /figma\.com/);
     assert.match(spec.outOfScope, /bulk-duplicate/);
+    assert.equal(spec.infraOnly, false);
   });
 
   it("returns empty defaults for a body with no headings", () => {
@@ -69,6 +72,13 @@ describe("parseSpec", () => {
     assert.equal(spec.what, "");
     assert.deepEqual(spec.affectedPlatforms, []);
     assert.equal(spec.schemaChanges, null);
+  });
+
+  it("flags infraOnly when the 'None' box is ticked", () => {
+    const body = `### Affected platforms\n\n- [ ] web (\`apps/web\`)\n- [x] None — factory internals / docs / CI (no app platform)`;
+    const spec = parseSpec(body);
+    assert.equal(spec.infraOnly, true);
+    assert.deepEqual(spec.affectedPlatforms, []);
   });
 
   it("accepts 'UI' as a synonym for 'UI design (if applicable)'", () => {
@@ -103,6 +113,15 @@ describe("parsePlatformCheckboxes", () => {
   });
 });
 
+describe("parseInfraOnlyCheckbox", () => {
+  it("returns true only when a ticked box starts with 'None'", () => {
+    assert.equal(parseInfraOnlyCheckbox("- [x] None — factory internals / docs / CI"), true);
+    assert.equal(parseInfraOnlyCheckbox("- [ ] None — factory internals"), false);
+    assert.equal(parseInfraOnlyCheckbox("- [x] web (`apps/web`)"), false);
+    assert.equal(parseInfraOnlyCheckbox(""), false);
+  });
+});
+
 describe("parityOverrideFrom", () => {
   it("returns the override kind when a parity:* label is present", () => {
     assert.equal(parityOverrideFrom(["parity:web-only", "status:ready"]), "web-only");
@@ -115,6 +134,19 @@ describe("parityOverrideFrom", () => {
     assert.equal(parityOverrideFrom(["status:ready"]), null);
     assert.equal(parityOverrideFrom([]), null);
     assert.equal(parityOverrideFrom(null), null);
+  });
+});
+
+describe("effectiveParityOverride", () => {
+  it("prefers an explicit parity:* label over the None box", () => {
+    assert.equal(effectiveParityOverride(["parity:web-only"], { infraOnly: true }), "web-only");
+  });
+  it("falls back to infra-only when the None box is ticked", () => {
+    assert.equal(effectiveParityOverride([], { infraOnly: true }), "infra-only");
+  });
+  it("returns null when neither a label nor the None box is present", () => {
+    assert.equal(effectiveParityOverride([], { infraOnly: false }), null);
+    assert.equal(effectiveParityOverride(null, null), null);
   });
 });
 

--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -409,18 +409,27 @@ spec_missing_section() {
   fi
   # Affected platforms requires at least one checkbox — UNLESS this is an
   # infra-only change (factory internals under scripts/, docs, CI) that touches
-  # no app platform. infra-only is signalled by the parity:infra-only label OR a
-  # ticked "None" box; both surface as parityOverride="infra-only" in the bundle.
+  # no app platform. infra-only is signalled by a ticked "None" box
+  # (spec.infraOnly) OR the parity:infra-only label (both surface as
+  # parityOverride="infra-only"). None / infra-only is mutually exclusive with
+  # the platform boxes AND with a single-platform parity:<x>-only label.
   local parity_override="${2:-}"
-  local platforms_count
+  local platforms_count infra_box
   platforms_count=$(echo "$spec_json" | jq '.affectedPlatforms | length')
-  if [[ "$parity_override" == "infra-only" ]]; then
-    # Mutually exclusive with the platform boxes — a ticked platform contradicts it.
+  infra_box=$(echo "$spec_json" | jq -r '.infraOnly')
+  if [[ "$infra_box" == "true" || "$parity_override" == "infra-only" ]]; then
+    # None / infra-only with a ticked platform box is contradictory.
     if [[ "$platforms_count" != "0" ]]; then
-      echo "Affected platforms (infra-only can't be combined with a platform box)"
+      echo "Affected platforms (None / infra-only can't be combined with a platform box)"
       return 0
     fi
-  elif [[ "$platforms_count" == "0" ]]; then
+  fi
+  if [[ "$infra_box" == "true" && -n "$parity_override" && "$parity_override" != "infra-only" ]]; then
+    # A ticked None box plus a single-platform parity:<x>-only label conflicts.
+    echo "Affected platforms (None box conflicts with the $parity_override label)"
+    return 0
+  fi
+  if [[ "$infra_box" != "true" && "$parity_override" != "infra-only" && "$platforms_count" == "0" ]]; then
     echo "Affected platforms"
     return 0
   fi
@@ -1157,9 +1166,9 @@ card back to **Ready**.
       log "Issue #$ISSUE_NUM: spec incomplete (missing: $MISSING)"
       if [[ "$DRY_RUN" -eq 0 ]]; then
         gh issue comment "$ISSUE_NUM" --repo JakubAnderwald/drafto \
-          --body "🏭 **Spec incomplete: \`$MISSING\` is empty.**
+          --body "🏭 **Spec problem: \`$MISSING\`.**
 
-Please fill in the missing section using the [factory-feature template]\
+Please fix it using the [factory-feature template]\
 (https://github.com/JakubAnderwald/drafto/issues/new?template=factory-feature.yml) \
 and drag the card back to **Ready**.
 

--- a/scripts/factory-agent.sh
+++ b/scripts/factory-agent.sh
@@ -409,15 +409,20 @@ spec_missing_section() {
   fi
   # Affected platforms requires at least one checkbox — UNLESS this is an
   # infra-only change (factory internals under scripts/, docs, CI) that touches
-  # no app platform, declared via the parity:infra-only override label.
+  # no app platform. infra-only is signalled by the parity:infra-only label OR a
+  # ticked "None" box; both surface as parityOverride="infra-only" in the bundle.
   local parity_override="${2:-}"
-  if [[ "$parity_override" != "infra-only" ]]; then
-    local platforms_count
-    platforms_count=$(echo "$spec_json" | jq '.affectedPlatforms | length')
-    if [[ "$platforms_count" == "0" ]]; then
-      echo "Affected platforms"
+  local platforms_count
+  platforms_count=$(echo "$spec_json" | jq '.affectedPlatforms | length')
+  if [[ "$parity_override" == "infra-only" ]]; then
+    # Mutually exclusive with the platform boxes — a ticked platform contradicts it.
+    if [[ "$platforms_count" != "0" ]]; then
+      echo "Affected platforms (infra-only can't be combined with a platform box)"
       return 0
     fi
+  elif [[ "$platforms_count" == "0" ]]; then
+    echo "Affected platforms"
+    return 0
   fi
   echo ""
 }

--- a/scripts/factory-plan-prompt.md
+++ b/scripts/factory-plan-prompt.md
@@ -49,11 +49,12 @@ last fenced ` ```json ` block). It has shape:
     "what": "...",
     "acceptance": "...",
     "affectedPlatforms": ["web", "mobile", "desktop"],
+    "infraOnly": true | false,
     "schemaChanges": true | false | null,
     "ui": "...",
     "outOfScope": "..."
   },
-  "parityOverride": "web-only" | "mobile-only" | "desktop-only" | null,
+  "parityOverride": "web-only" | "mobile-only" | "desktop-only" | "infra-only" | null,
   // GitHub-hosted image URLs pulled from the issue body + comments (host-
   // validated in code — only github.com/user-attachments and *.githubusercontent.com
   // ever appear here). These are the screenshots referenced by the spec. You may
@@ -207,7 +208,11 @@ here let the operator catch issues before approval rather than after.>
 
 <For each platform in `spec.affectedPlatforms`, list the specific code path
 that needs to change on that platform. If `parityOverride` is set, note it
-and limit the checklist to the allowed platform. Name the actual path on each
+and limit the checklist to the allowed platform. When `parityOverride` is
+`"infra-only"` (a ticked "None" box / `parity:infra-only` label) the change
+touches NO app platform — `spec.affectedPlatforms` is legitimately empty; list
+the `scripts/` / docs / CI paths instead and keep the plan out of `apps/**` and
+`packages/shared/**`. Name the actual path on each
 platform — never assert behavioural parity from shared `db/`. `apps/desktop`
 and `apps/mobile` share `src/db/` (schema, models, sync), but their editors,
 screens, and render paths are SEPARATE files that can and do diverge; verify
@@ -259,7 +264,10 @@ Constraints:
 2. **Check phase scope.** Compare `spec.affectedPlatforms` (modulated by
    `parityOverride`) against the table above for `config.phase`. If the work
    exceeds the phase, emit `action=blocked` and explain in the plan body's
-   "Risks" section.
+   "Risks" section. A `parityOverride` of `"infra-only"` with an empty
+   `spec.affectedPlatforms` is a VALID no-app-platform change (factory internals
+   under `scripts/`, docs, CI) — do NOT block it for "no affected platforms";
+   just confirm the plan stays out of `apps/**` and `packages/shared/**`.
 
 3. **Ground the plan.** Skim enough to ground "Files to touch" in reality — a
    plan that names non-existent files is worse than no plan. Specifically:

--- a/scripts/factory-plan-prompt.md
+++ b/scripts/factory-plan-prompt.md
@@ -18,12 +18,12 @@ The bundle's `config.phase` tells you which actions are enabled in this run.
 `--plan` mode itself runs in every phase — but the **content** of your plan
 must respect the phase contract:
 
-| Phase | Plans you may produce                                                                                                                                                        |
-| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `A`   | Any plan is fine — implementation will be skipped at the next stage regardless. Treat this as observation-quality runs.                                                      |
-| `B`   | Plan must touch only `apps/web/**`, `packages/shared/**`, `supabase/**`, root-level configs. If the spec requires mobile/desktop changes, mark the plan as **out-of-phase**. |
-| `C`   | Plan may touch every app and shared package end-to-end.                                                                                                                      |
-| `D`   | Same as Phase C — Phase D unlocks beta-channel auto-dispatch but doesn't change planning scope.                                                                              |
+| Phase | Plans you may produce                                                                                                                                                                                                           |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `A`   | Any plan is fine — implementation will be skipped at the next stage regardless. Treat this as observation-quality runs.                                                                                                         |
+| `B`   | Plan must touch only `apps/web/**`, `packages/shared/**`, `supabase/**`, root-level configs, or infra-only paths (`scripts/**`, `docs/**`, CI). If the spec requires mobile/desktop changes, mark the plan as **out-of-phase**. |
+| `C`   | Plan may touch every app and shared package end-to-end.                                                                                                                                                                         |
+| `D`   | Same as Phase C — Phase D unlocks beta-channel auto-dispatch but doesn't change planning scope.                                                                                                                                 |
 
 If the requested work exceeds the current phase's scope, **still post a plan**
 — the operator wants to see what the work would look like — but mark

--- a/scripts/factory-prompt.md
+++ b/scripts/factory-prompt.md
@@ -42,7 +42,7 @@ last fenced ` ```json ` block). It has shape:
     "bodyEnveloped": "<issue-body>...</issue-body>"
   },
   "spec": { /* same shape as factory_plan */ },
-  "parityOverride": "web-only" | "mobile-only" | "desktop-only" | null,
+  "parityOverride": "web-only" | "mobile-only" | "desktop-only" | "infra-only" | null,
   "approvedPlan": {
     "commentId": "...",
     "url": "https://github.com/...#issuecomment-...",
@@ -275,7 +275,11 @@ When the plan's "Affected platforms" lists more than one platform, every
 platform must see actual code changes — the bash post-check diffs the PR
 against the platform set and fails the run if anything is missing.
 `parity:<x>-only` labels override this for legitimate single-platform
-work; the bundle surfaces these via `parityOverride`.
+work; the bundle surfaces these via `parityOverride`. When `parityOverride`
+is `"infra-only"` (a ticked "None" box / `parity:infra-only` label) the change
+touches NO app platform — keep the diff entirely within `scripts/`, docs, or
+CI; the post-check blocks the run if it touches `apps/**` or
+`packages/shared/**`.
 
 The `apps/mobile/src/db/` and `apps/desktop/src/db/` directories share
 schema + migrations + models. If the plan touches either, edit both in

--- a/scripts/factory-watch-prompt.md
+++ b/scripts/factory-watch-prompt.md
@@ -33,7 +33,7 @@ You will receive a single JSON bundle (last fenced ` ```json ` block). Shape:
   "kind": "factory_watch",
   "issue": { "number": 412, "title": "...", "labels": [...], "bodyEnveloped": "<issue-body>...</issue-body>" },
   "spec": { /* parsed factory-feature sections */ },
-  "parityOverride": "web-only" | null,
+  "parityOverride": "web-only" | "mobile-only" | "desktop-only" | "infra-only" | null,
   "approvedPlan": { "commentId", "url", "createdAt", "bodyEnveloped": "<factory-plan>...</factory-plan>" },
   "priorPr": { "number", "url", "headRef", "state" },
   "ciSummaryEnveloped": "<ci-summary>...failing checks, newest first...</ci-summary>",

--- a/scripts/lib/factory-bundle.mjs
+++ b/scripts/lib/factory-bundle.mjs
@@ -187,16 +187,19 @@ export function parseSpec(body) {
     what: "",
     acceptance: "",
     affectedPlatforms: [],
+    infraOnly: false,
     schemaChanges: null,
     ui: "",
     outOfScope: "",
   };
   if (typeof body !== "string" || body.length === 0) return empty;
   const sections = splitSections(body);
+  const platformsSection = pickSection(sections, ["Affected platforms"]);
   return {
     what: pickSection(sections, ["What"]),
     acceptance: pickSection(sections, ["Acceptance criteria"]),
-    affectedPlatforms: parsePlatformCheckboxes(pickSection(sections, ["Affected platforms"])),
+    affectedPlatforms: parsePlatformCheckboxes(platformsSection),
+    infraOnly: parseInfraOnlyCheckbox(platformsSection),
     schemaChanges: parseSchemaAnswer(pickSection(sections, ["Schema changes?"])),
     ui: pickSection(sections, ["UI design (if applicable)", "UI"]),
     outOfScope: pickSection(sections, ["Out of scope"]),
@@ -262,6 +265,19 @@ export function parsePlatformCheckboxes(section) {
   return [...new Set(out)].sort();
 }
 
+// Pure: was the "None — no app platform" box ticked in the Affected platforms
+// section? A ticked None box marks the issue infra-only (factory internals,
+// docs, CI) — the form-native equivalent of the parity:infra-only label.
+export function parseInfraOnlyCheckbox(section) {
+  if (typeof section !== "string" || section.length === 0) return false;
+  for (const line of section.split(/\r?\n/)) {
+    const m = line.match(/^\s*[-*]\s*\[([ xX])\]\s*(.+?)\s*$/);
+    if (!m || m[1] === " ") continue;
+    if (m[2].toLowerCase().startsWith("none")) return true;
+  }
+  return false;
+}
+
 function parseSchemaAnswer(section) {
   if (typeof section !== "string" || section.length === 0) return null;
   const s = section.toLowerCase().trim();
@@ -285,6 +301,13 @@ export function parityOverrideFrom(labels) {
     if (name === "parity:infra-only") return "infra-only";
   }
   return null;
+}
+
+// Pure: the effective parity override for an issue — an explicit parity:* label
+// wins; otherwise a ticked "None" box in the Affected platforms section implies
+// infra-only. Same return vocabulary as parityOverrideFrom (plus null).
+export function effectiveParityOverride(labels, spec) {
+  return parityOverrideFrom(labels) ?? (spec?.infraOnly ? "infra-only" : null);
 }
 
 // Pure: distil the support-agent footer into the fields the factory needs.
@@ -384,11 +407,12 @@ export function buildFactoryPlanBundle({
   if (!issue || !Number.isInteger(issue.number)) {
     throw new Error("buildFactoryPlanBundle: issue.number is required");
   }
+  const spec = parseSpec(issue.body ?? "");
   const bundle = {
     kind: "factory_plan",
     issue: shapeIssue(issue),
-    spec: parseSpec(issue.body ?? ""),
-    parityOverride: parityOverrideFrom(issue.labels),
+    spec,
+    parityOverride: effectiveParityOverride(issue.labels, spec),
     // GitHub-hosted image URLs (host-validated) pulled from the body + comments
     // so the planner can fetch and actually look at screenshot-driven specs.
     screenshots: extractScreenshots(issue.body ?? "", comments),
@@ -421,11 +445,12 @@ export function buildFactoryImplementBundle({
   // need to see it, and downstream forwarding (if any) shouldn't surface it.
   const planBody = typeof approvedPlan?.body === "string" ? approvedPlan.body : "";
   const planClean = planBody.split(FACTORY_PLAN_MARKER).join("").trim();
+  const spec = parseSpec(issue.body ?? "");
   return {
     kind: "factory_implement",
     issue: shapeIssue(issue),
-    spec: parseSpec(issue.body ?? ""),
-    parityOverride: parityOverrideFrom(issue.labels),
+    spec,
+    parityOverride: effectiveParityOverride(issue.labels, spec),
     approvedPlan: approvedPlan
       ? {
           commentId: approvedPlan.commentId ?? approvedPlan.id ?? null,
@@ -475,11 +500,12 @@ export function buildFactoryWatchBundle({
   }
   const planBody = typeof approvedPlan?.body === "string" ? approvedPlan.body : "";
   const planClean = planBody.split(FACTORY_PLAN_MARKER).join("").trim();
+  const spec = parseSpec(issue.body ?? "");
   return {
     kind: "factory_watch",
     issue: shapeIssue(issue),
-    spec: parseSpec(issue.body ?? ""),
-    parityOverride: parityOverrideFrom(issue.labels),
+    spec,
+    parityOverride: effectiveParityOverride(issue.labels, spec),
     approvedPlan: approvedPlan
       ? {
           commentId: approvedPlan.commentId ?? approvedPlan.id ?? null,


### PR DESCRIPTION
## What

Follow-up to #559. Infra-only issues (factory internals under `scripts/`, docs, CI) still *looked* like incomplete specs in the issue form — all platform boxes empty, with intent carried only by an off-screen `parity:infra-only` label. This adds a fourth checkbox that self-documents the intent **and** drives the gate, so no separate label is needed:

```
- [ ] web (apps/web)
- [ ] iOS / Android (apps/mobile)
- [ ] macOS (apps/desktop)
- [x] None — factory internals / docs / CI (no app platform)
```

## Changes

- **`scripts/lib/factory-bundle.mjs`**
  - `parseSpec` now exposes **`infraOnly`** (via new `parseInfraOnlyCheckbox` — true when a ticked box starts with "None").
  - new **`effectiveParityOverride(labels, spec)`** = explicit `parity:*` label **OR** (`spec.infraOnly` → `"infra-only"`). All three bundle builders use it, so the box flows through `bundle.parityOverride` to **both** the spec gate and the implement-time parity check.
- **`scripts/factory-agent.sh`** — `spec_missing_section` also blocks the **contradiction** of infra-only combined with a ticked platform box (mutually exclusive).
- **`.github/ISSUE_TEMPLATE/factory-feature.yml`** — the `None` option + updated description. With `required: true`, the infra-only flow is now satisfiable via the web form too (tick None).
- **`docs/features/dark-factory.md`, `CLAUDE.md`** — document the None box (the `parity:infra-only` label still works for CLI / non-form issues).

## Tests

- `parseInfraOnlyCheckbox`, `effectiveParityOverride` (label-vs-box precedence, null handling), `parseSpec.infraOnly`, and the new spec-gate contradiction case.
- Full `drafto-scripts` suite green (488).

## Relationship to the label
Explicit `parity:*` labels still win over the box, and `parity:infra-only` remains the path for issues created outside the form. The box is the form-native, self-documenting equivalent. #555 has been updated to use the ticked None box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit **“None — factory internals / docs / CI (no app platform)”** option for selecting infra-only changes.
  * Updated factory planning prompts and context to support an **infra-only** parity mode end-to-end.
* **Bug Fixes**
  * Improved validation and error messaging for contradictory combinations (e.g., **None** with platform selections or conflicting parity overrides).
* **Documentation**
  * Refreshed “How to file an issue” guidance to reflect the expanded “Affected platforms” behavior.
* **Tests**
  * Expanded unit tests for infra-only parsing, parity override precedence, and invalid/valid spec combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->