### PR TITLE
docs(desktop): document react-native-macos version lock + fossil workaround

### DIFF
--- a/apps/desktop/src/components/notes/note-content-loader.ts
+++ b/apps/desktop/src/components/notes/note-content-loader.ts
@@ -22,9 +22,7 @@ type UrlResolver = (filePath: string) => Promise<string>;
  * has content (the 2026-04-24 / 2026-04-27 incident class).
  */
 export type NoteContentLoad =
-  | { kind: "empty" }
-  | { kind: "html"; html: string }
-  | { kind: "structured"; value: unknown };
+  { kind: "empty" } | { kind: "html"; html: string } | { kind: "structured"; value: unknown };
 
 export function escapeHtml(text: string): string {
   return text

--- a/docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md
+++ b/docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md
@@ -1,0 +1,76 @@
+# 0027 — Desktop's React version is locked to react-native-macos; defer reproducibility to rnm 0.83
+
+- **Status**: Accepted
+- **Date**: 2026-07-02
+- **Authors**: Jakub Anderwald
+
+## Context
+
+The macOS desktop app builds on **`react-native-macos`** — Microsoft's macOS fork of React Native.
+The fork is actively maintained but **trails upstream React Native by a few versions**: its latest
+stable is `0.81.8` (shipped 2026-06-26) with `0.83` in progress, while mobile is on
+`react-native@0.86`.
+
+The version lag matters because each React Native release pins a specific **React** major/minor:
+
+| React Native  | requires React |
+| ------------- | -------------- |
+| 0.81, 0.82    | 19.1.x         |
+| **0.83**–0.86 | **19.2.x**     |
+
+RN 0.83 is the boundary where React moved 19.1 → 19.2. Desktop is on rnm **0.81** (React 19.1);
+mobile is on RN **0.86** (React 19.2.3).
+
+**React must be a single shared instance across the monorepo.** This was established the hard way
+(issue #558): forcing a per-app React split makes pnpm nest a separate React copy under each
+consuming package, and multiple React instances — even at the same version — break Context/hook
+identity and render the tree empty with no error. A Metro-level dedup could not reliably collapse
+them; only a single, uniform React works.
+
+Combining those two facts: **desktop's rnm 0.81 caps the shared React at 19.1**, which conflicts with
+mobile's RN 0.86 (needs 19.2). Today the working desktop build exists only as a "fossil" `node_modules`
+(React 19.1.4) that was installed before Dependabot bumped the declarations forward and never
+reinstalled; a clean `pnpm install` pulls React 19.2 and produces a crashing/blank desktop build. See
+`docs/operations/desktop-build-fossil.md`.
+
+## Decision
+
+1. **Do not force a monorepo-wide React downgrade** to 19.1.4. It would make desktop reproducible but
+   drag mobile/web back a React version (RN 0.86 genuinely needs React 19.2.3). Mobile and web stay
+   current (React 19.2 + RN 0.86).
+2. **Do not pin/materialise the desktop "fossil island"** in version control. Reproducing the old set
+   package-by-package is fragile and, because React can't be split, cannot be made to work cleanly
+   (the failed #558 investigation).
+3. **Interim:** ship desktop from the primary checkout's fossil `node_modules` (the documented
+   build-from-main workaround). Desktop clean-install reproducibility (#558) is **deferred**, not lost.
+4. **Real fix — adopt `react-native-macos@0.83`** (a fork of RN 0.83 → React 19.2) **when it is
+   published.** Bumping `apps/desktop` to it lets desktop run React 19.2, rejoin the shared React,
+   and a clean install works for all platforms — closing #558 with a one-line version bump.
+5. **Establish an upgrade cadence:** track rnm releases and keep desktop within ~1–2 versions of
+   upstream so it never lags far enough to fossilise again. Do **not** freeze the rnm/React pair from
+   Dependabot permanently; instead upgrade the pair deliberately, together, verified by a TestFlight
+   build that opens a note.
+6. **Do not migrate off `react-native-macos`.** It is maintained; a migration (Tauri/Electron over the
+   web app, or native) is a fallback to revisit only if the lag becomes untenable.
+
+## Consequences
+
+- **Positive**: Mobile and web stay on the current stack (React 19.2, RN 0.86). No risky migration.
+  The fix path is concrete and cheap — a version bump to rnm 0.83 when it ships. No monorepo-wide
+  dependency surgery lands now.
+- **Negative**: Desktop clean-install reproducibility (#558) is deferred until rnm 0.83. Until then,
+  desktop must be built from the primary checkout's `node_modules`, which must not be reinstalled
+  (see the fossil doc). Someone has to watch for the rnm 0.83 release.
+- **Neutral**: The desktop app intentionally lags a React Native (and React) version behind mobile
+  until rnm catches up — inherent to using an out-of-tree fork.
+
+## Alternatives Considered
+
+- **Uniform React 19.1.4 monorepo-wide + revert mobile RN to 0.83.2.** Proven to make desktop
+  reproducible (macOS build 42 launches and opens notes), but freezes mobile/web on the old React too.
+  Rejected: sacrifices mobile currency for a problem that rnm 0.83 resolves on its own.
+- **Pin/materialise the fossil island** (React 19.1.4 scoped + native-module pins + Metro React-dedup).
+  Rejected: the React split produces multiple React instances (empty screen); not cleanly fixable —
+  this is the failed core of the #558 investigation.
+- **Migrate the desktop app off `react-native-macos`** (Tauri/Electron over the web app, or native).
+  Rejected as premature: rnm is maintained and about to close the gap; kept as a fallback.

--- a/docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md
+++ b/docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md
@@ -19,7 +19,7 @@ The version lag matters because each React Native release pins a specific **Reac
 | **0.83**–0.86 | **19.2.x**     |
 
 RN 0.83 is the boundary where React moved 19.1 → 19.2. Desktop is on rnm **0.81** (React 19.1);
-mobile is on RN **0.86** (React 19.2.3).
+mobile is on RN **0.86** (React 19.2, currently pinned to 19.2.6; RN 0.86 peers `^19.2.3`).
 
 **React must be a single shared instance across the monorepo.** This was established the hard way
 (issue #558): forcing a per-app React split makes pnpm nest a separate React copy under each
@@ -36,7 +36,7 @@ reinstalled; a clean `pnpm install` pulls React 19.2 and produces a crashing/bla
 ## Decision
 
 1. **Do not force a monorepo-wide React downgrade** to 19.1.4. It would make desktop reproducible but
-   drag mobile/web back a React version (RN 0.86 genuinely needs React 19.2.3). Mobile and web stay
+   drag mobile/web back a React version (RN 0.86 genuinely needs React 19.2). Mobile and web stay
    current (React 19.2 + RN 0.86).
 2. **Do not pin/materialise the desktop "fossil island"** in version control. Reproducing the old set
    package-by-package is fragile and, because React can't be split, cannot be made to work cleanly

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,32 +30,33 @@ Every ADR follows the template in [0000-adr-template.md](./0000-adr-template.md)
 
 ## Index
 
-| #                                                        | Title                                          | Status             | Date       |
-| -------------------------------------------------------- | ---------------------------------------------- | ------------------ | ---------- |
-| [0000](./0000-adr-template.md)                           | ADR Template                                   | N/A                | 2026-02-24 |
-| [0001](./0001-data-model-and-rls-strategy.md)            | Data Model and RLS Strategy                    | Accepted           | 2026-02-24 |
-| [0002](./0002-api-route-conventions.md)                  | API Route Conventions                          | Accepted           | 2026-02-24 |
-| [0003](./0003-blocknote-editor-configuration.md)         | BlockNote Editor Configuration                 | Accepted           | 2026-02-25 |
-| [0004](./0004-design-system-css-variables.md)            | Design System with CSS Custom Properties       | Superseded by 0014 | 2026-03-03 |
-| [0005](./0005-dark-mode-implementation.md)               | Dark Mode Implementation                       | Accepted           | 2026-03-04 |
-| [0006](./0006-dev-prod-environment-separation.md)        | Dev/Prod Environment Separation                | Accepted           | 2026-03-04 |
-| [0007](./0007-evernote-import.md)                        | Evernote Import                                | Accepted           | 2026-03-04 |
-| [0008](./0008-production-data-safety-guardrails.md)      | Production Data Safety Guardrails              | Accepted           | 2026-03-07 |
-| [0009](./0009-mobile-app-technology-choices.md)          | Mobile App Technology Choices                  | Accepted           | 2026-03-07 |
-| [0010](./0010-offline-sync-strategy.md)                  | Offline Sync Strategy with WatermelonDB        | Accepted           | 2026-03-07 |
-| [0011](./0011-app-store-deployment-strategy.md)          | App Store Deployment Strategy                  | Superseded by 0016 | 2026-03-08 |
-| [0012](./0012-search-implementation.md)                  | Search Implementation                          | Accepted           | 2026-03-14 |
-| [0013](./0013-automated-support-pipeline.md)             | Automated Support Pipeline                     | Superseded by 0024 | 2026-03-14 |
-| [0014](./0014-digital-atelier-design-system.md)          | Digital Atelier Design System                  | Accepted           | 2026-03-19 |
-| [0015](./0015-desktop-app-technology-choice.md)          | Desktop App Technology Choice                  | Accepted           | 2026-03-29 |
-| [0016](./0016-local-fastlane-builds.md)                  | Local Fastlane Builds                          | Accepted           | 2026-03-31 |
-| [0017](./0017-mcp-server-for-claude-cowork.md)           | MCP Server for Claude Cowork                   | Accepted           | 2026-04-11 |
-| [0018](./0018-oauth-google-apple.md)                     | OAuth with Google and Apple                    | Accepted           | 2026-04-12 |
-| [0019](./0019-email-infrastructure-and-approval-flow.md) | Email Infrastructure and Account Approval Flow | Accepted           | 2026-04-20 |
-| [0020](./0020-email-design-tokens.md)                    | Email Design Tokens                            | Accepted           | 2026-04-21 |
-| [0021](./0021-shared-design-tokens.md)                   | Shared Design Tokens in `@drafto/shared`       | Accepted           | 2026-04-21 |
-| [0022](./0022-note-content-history.md)                   | Note Content History Table                     | Accepted           | 2026-04-25 |
-| [0023](./0023-per-request-client-tagging.md)             | Per-Request Client Tagging                     | Accepted           | 2026-04-27 |
-| [0024](./0024-realtime-support-agent.md)                 | Real-Time Support Agent                        | Accepted           | 2026-04-28 |
-| [0025](./0025-support-allowlist-from-zoho-sender.md)     | Support Allowlist Gate from Zoho Sender        | Accepted           | 2026-05-03 |
-| [0026](./0026-dark-factory-pipeline.md)                  | Dark Factory Unattended Development Pipeline   | Accepted           | 2026-05-06 |
+| #                                                                    | Title                                              | Status             | Date       |
+| -------------------------------------------------------------------- | -------------------------------------------------- | ------------------ | ---------- |
+| [0000](./0000-adr-template.md)                                       | ADR Template                                       | N/A                | 2026-02-24 |
+| [0001](./0001-data-model-and-rls-strategy.md)                        | Data Model and RLS Strategy                        | Accepted           | 2026-02-24 |
+| [0002](./0002-api-route-conventions.md)                              | API Route Conventions                              | Accepted           | 2026-02-24 |
+| [0003](./0003-blocknote-editor-configuration.md)                     | BlockNote Editor Configuration                     | Accepted           | 2026-02-25 |
+| [0004](./0004-design-system-css-variables.md)                        | Design System with CSS Custom Properties           | Superseded by 0014 | 2026-03-03 |
+| [0005](./0005-dark-mode-implementation.md)                           | Dark Mode Implementation                           | Accepted           | 2026-03-04 |
+| [0006](./0006-dev-prod-environment-separation.md)                    | Dev/Prod Environment Separation                    | Accepted           | 2026-03-04 |
+| [0007](./0007-evernote-import.md)                                    | Evernote Import                                    | Accepted           | 2026-03-04 |
+| [0008](./0008-production-data-safety-guardrails.md)                  | Production Data Safety Guardrails                  | Accepted           | 2026-03-07 |
+| [0009](./0009-mobile-app-technology-choices.md)                      | Mobile App Technology Choices                      | Accepted           | 2026-03-07 |
+| [0010](./0010-offline-sync-strategy.md)                              | Offline Sync Strategy with WatermelonDB            | Accepted           | 2026-03-07 |
+| [0011](./0011-app-store-deployment-strategy.md)                      | App Store Deployment Strategy                      | Superseded by 0016 | 2026-03-08 |
+| [0012](./0012-search-implementation.md)                              | Search Implementation                              | Accepted           | 2026-03-14 |
+| [0013](./0013-automated-support-pipeline.md)                         | Automated Support Pipeline                         | Superseded by 0024 | 2026-03-14 |
+| [0014](./0014-digital-atelier-design-system.md)                      | Digital Atelier Design System                      | Accepted           | 2026-03-19 |
+| [0015](./0015-desktop-app-technology-choice.md)                      | Desktop App Technology Choice                      | Accepted           | 2026-03-29 |
+| [0016](./0016-local-fastlane-builds.md)                              | Local Fastlane Builds                              | Accepted           | 2026-03-31 |
+| [0017](./0017-mcp-server-for-claude-cowork.md)                       | MCP Server for Claude Cowork                       | Accepted           | 2026-04-11 |
+| [0018](./0018-oauth-google-apple.md)                                 | OAuth with Google and Apple                        | Accepted           | 2026-04-12 |
+| [0019](./0019-email-infrastructure-and-approval-flow.md)             | Email Infrastructure and Account Approval Flow     | Accepted           | 2026-04-20 |
+| [0020](./0020-email-design-tokens.md)                                | Email Design Tokens                                | Accepted           | 2026-04-21 |
+| [0021](./0021-shared-design-tokens.md)                               | Shared Design Tokens in `@drafto/shared`           | Accepted           | 2026-04-21 |
+| [0022](./0022-note-content-history.md)                               | Note Content History Table                         | Accepted           | 2026-04-25 |
+| [0023](./0023-per-request-client-tagging.md)                         | Per-Request Client Tagging                         | Accepted           | 2026-04-27 |
+| [0024](./0024-realtime-support-agent.md)                             | Real-Time Support Agent                            | Accepted           | 2026-04-28 |
+| [0025](./0025-support-allowlist-from-zoho-sender.md)                 | Support Allowlist Gate from Zoho Sender            | Accepted           | 2026-05-03 |
+| [0026](./0026-dark-factory-pipeline.md)                              | Dark Factory Unattended Development Pipeline       | Accepted           | 2026-05-06 |
+| [0027](./0027-desktop-react-version-locked-to-react-native-macos.md) | Desktop React Version Locked to react-native-macos | Accepted           | 2026-07-02 |

--- a/docs/operations/desktop-build-fossil.md
+++ b/docs/operations/desktop-build-fossil.md
@@ -1,8 +1,9 @@
 # ⚠️ macOS desktop build — do NOT reinstall main's `node_modules`
 
 **Status:** the working macOS desktop build is a **fossil**. `apps/desktop` only builds and runs
-correctly from the `node_modules` already present in the primary checkout (`/Users/jakub/code/drafto`),
-which was installed months ago and **must not be reinstalled**. This is resolved for good by upgrading
+correctly from the `node_modules` already present in the build machine's primary checkout
+(`/Users/jakub/code/drafto` on the current release machine), which was installed months ago and
+**must not be reinstalled**. This is resolved for good by upgrading
 desktop to `react-native-macos@0.83` (React 19.2) once it ships — see
 [ADR-0027](../adr/0027-desktop-react-version-locked-to-react-native-macos.md) and
 [#558](https://github.com/JakubAnderwald/drafto/issues/558).
@@ -18,8 +19,9 @@ each layer is pinned). Full analysis: [#558](https://github.com/JakubAnderwald/d
 
 ## The rule
 
-- **Do NOT run `pnpm install` in `/Users/jakub/code/drafto`** (the primary checkout) until desktop is
-  upgraded to `react-native-macos@0.83`. It overwrites the working set and destroys the only shippable
+- **Do NOT run `pnpm install` in the build machine's primary checkout**
+  (`/Users/jakub/code/drafto` on the current release machine) until desktop is upgraded to
+  `react-native-macos@0.83`. It overwrites the working set and destroys the only shippable
   desktop build.
 - Build desktop releases from that checkout's existing `node_modules`:
   `cd apps/desktop && pnpm release:beta`.

--- a/docs/operations/desktop-build-fossil.md
+++ b/docs/operations/desktop-build-fossil.md
@@ -1,0 +1,44 @@
+# ⚠️ macOS desktop build — do NOT reinstall main's `node_modules`
+
+**Status:** the working macOS desktop build is a **fossil**. `apps/desktop` only builds and runs
+correctly from the `node_modules` already present in the primary checkout (`/Users/jakub/code/drafto`),
+which was installed months ago and **must not be reinstalled**. This is resolved for good by upgrading
+desktop to `react-native-macos@0.83` (React 19.2) once it ships — see
+[ADR-0027](../adr/0027-desktop-react-version-locked-to-react-native-macos.md) and
+[#558](https://github.com/JakubAnderwald/drafto/issues/558).
+
+## Why
+
+`react-native-macos@0.81.6` requires **React 19.1.x** and crashes at runtime on React **19.2.x**. The
+monorepo's _declared_ versions have since drifted forward (React 19.2.6, newer native modules — via
+Dependabot) because mobile's `react-native@0.86` needs React 19.2. Main's `node_modules` was never
+reinstalled, so it kept the working React-19.1.x set. A clean `pnpm install` pulls the current
+versions → **crashing / blank build** (crash on note-open, then crash on launch, then empty screen as
+each layer is pinned). Full analysis: [#558](https://github.com/JakubAnderwald/drafto/issues/558).
+
+## The rule
+
+- **Do NOT run `pnpm install` in `/Users/jakub/code/drafto`** (the primary checkout) until desktop is
+  upgraded to `react-native-macos@0.83`. It overwrites the working set and destroys the only shippable
+  desktop build.
+- Build desktop releases from that checkout's existing `node_modules`:
+  `cd apps/desktop && pnpm release:beta`.
+- The factory's automated desktop builds (clean checkout) are currently **broken** for the same
+  reason — ship desktop manually from the primary checkout until the rnm 0.83 upgrade lands.
+
+## The known-good version set (build 34 / build 40)
+
+If the fossil is ever lost, this is the working set to reconstruct:
+
+| package                                       | working version |
+| --------------------------------------------- | --------------- |
+| `react`                                       | `19.1.4`        |
+| `react-native` (`apps/desktop/node_modules/`) | `0.81.6`        |
+| `react-native-macos`                          | `0.81.6`        |
+| `react-native-safe-area-context`              | `5.7.0`         |
+| `react-native-svg`                            | `15.15.4`       |
+| `@react-native-async-storage/async-storage`   | `3.0.2`         |
+| `react-native-screens`                        | `4.24.0`        |
+
+Mobile and web use React `19.2.6` and newer native modules — that is correct and unaffected. Only the
+macOS desktop app is pinned to this older, `react-native-macos`-compatible set.


### PR DESCRIPTION
## What

Documents the root cause behind #558 (the macOS desktop build isn't reproducible from a clean
install) and the decision on how to resolve it. **Docs only — no dependency or code changes.**

## The finding

- Desktop builds on **react-native-macos**, which is maintained but lags upstream React Native
  (rnm `0.81` vs mobile's `0.86`).
- Each RN release pins a React version: **RN ≤ 0.82 → React 19.1; RN ≥ 0.83 → React 19.2.**
- React must be a **single shared instance** across the monorepo — splitting it produces multiple
  React copies that break Context/hook identity and render the desktop app blank (the long
  empty-screen investigation in #558).
- So desktop's rnm 0.81 **caps the shared React at 19.1**, conflicting with mobile's RN 0.86
  (needs 19.2). The working desktop build survives only as a "fossil" `node_modules` (React 19.1.4);
  a clean `pnpm install` pulls React 19.2 and breaks desktop.

## The decision (ADR-0027)

- Keep mobile/web **current** (React 19.2 + RN 0.86) — do not force a monorepo-wide React downgrade.
- Ship desktop from the primary checkout's fossil `node_modules` in the interim (documented +
  protected in `docs/operations/desktop-build-fossil.md` — do not `pnpm install` in the main checkout).
- **Real fix: bump `apps/desktop` to `react-native-macos@0.83`** (React 19.2) once published — a
  one-line upgrade that lets desktop rejoin the shared React and makes clean installs work. Closes
  #558 when it lands.
- Establish an upgrade cadence so desktop never lags far enough to fossilise again. Don't migrate off
  rnm (it's maintained); keep that as a fallback.

## Contents

- `docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md`
- `docs/operations/desktop-build-fossil.md` (protects the working fossil build machine)
- ADR index entry

Refs #558. Supersedes the "de-fossilize" investigation in #564 (which concluded: not abandoned, adopt
rnm 0.83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an ADR describing the current macOS desktop React/version alignment decision and the path forward.
  * Expanded the ADR index to include the new entry.
  * Added build guidance for macOS desktop using the existing pinned dependencies, including the recommended manual build steps and compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->