### PR TITLE
fix(nightly-audit): stop false-positive CI-failure issues; ignore Expo major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,21 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Expo-SDK-aligned packages must track the pinned Expo SDK (~55); the SDK is bumped
+      # deliberately as one coordinated step. Major bumps ahead of the SDK break the React
+      # Native / Expo build and can never merge, so Dependabot retries them forever — the
+      # dominant source of nightly-audit false positives. Suppress semver-major bumps for the
+      # whole Expo family: bare `expo`, `expo-*`, scoped `@expo/*` (e.g. @expo/vector-icons),
+      # and the Expo tooling packages that lack an `expo` prefix. Minor/patch updates still
+      # flow through the minor-and-patch group above.
+      - dependency-name: "expo"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "expo-*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@expo/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-expo"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jest-expo"
+        update-types: ["version-update:semver-major"]

--- a/scripts/nightly-audit.sh
+++ b/scripts/nightly-audit.sh
@@ -203,7 +203,14 @@ fi
 # `cancelled` is treated as healthy on purpose: ci.yml sets concurrency cancel-in-progress, so a
 # superseded run is expected, not a breakage. `none` (no CI run in the window, or the workflow was
 # renamed away from "CI") is logged rather than flagged, to avoid false positives in quiet periods.
-WORKFLOW_RUNS=$(gh run list --repo "$REPO" --branch main --limit 30 --status completed --json conclusion,workflowName,createdAt 2>/dev/null) || WORKFLOW_RUNS="[]"
+# Distinguish a genuine "no CI run in the window" (LATEST_CI_CONCLUSION="none", treated as healthy)
+# from a failure of `gh run list` itself (auth expiry, rate limit, network blip on the Mac mini):
+# the latter gets its own WARNING so a breakage of the audit's own tooling is visible in the log
+# rather than silently folded into the healthy "none" path.
+if ! WORKFLOW_RUNS=$(gh run list --repo "$REPO" --branch main --limit 30 --status completed --json conclusion,workflowName,createdAt 2>/dev/null); then
+  log "WARNING: 'gh run list --branch main' failed; CI health on main could not be determined this run"
+  WORKFLOW_RUNS="[]"
+fi
 LATEST_CI_CONCLUSION=$(echo "$WORKFLOW_RUNS" | jq -r '[.[] | select(.workflowName == "CI")] | (max_by(.createdAt).conclusion) // "none"' 2>/dev/null) || LATEST_CI_CONCLUSION="none"
 case "$LATEST_CI_CONCLUSION" in
   failure | timed_out | startup_failure)

--- a/scripts/nightly-audit.sh
+++ b/scripts/nightly-audit.sh
@@ -187,17 +187,33 @@ else
   log "drafto.eu health check: OK (HTTP $HTTP_CODE)"
 fi
 
-# GitHub Actions CI on main
-WORKFLOW_RUNS=$(gh run list --repo "$REPO" --branch main --limit 5 --json conclusion,name 2>/dev/null) || WORKFLOW_RUNS="[]"
-FAILED_RUNS=$(echo "$WORKFLOW_RUNS" | jq '[.[] | select(.conclusion == "failure")]')
-FAILED_RUN_COUNT=$(echo "$FAILED_RUNS" | jq 'length')
-if [[ "$FAILED_RUN_COUNT" -gt 0 ]]; then
-  FAILED_NAMES=$(echo "$FAILED_RUNS" | jq -r '[.[].name] | unique | join(", ")')
-  PROBLEMS+=("### App: Failed CI workflows on main"$'\n\n'"Failing: $FAILED_NAMES")
-  log "WARNING: $FAILED_RUN_COUNT failed workflows on main"
-else
-  log "GitHub Actions on main: all passing"
-fi
+# GitHub Actions CI on main. Report only when the latest completed run of the app's own `CI`
+# workflow ended in a red state. Two bugs in the old check produced daily false-positive audit
+# issues:
+#   1. `gh run list --branch main` also returns Dependabot's background "Dependabot Updates"
+#      runs (event=dynamic) and other push-triggered workflows — their failures are not main-CI
+#      health. Selecting workflowName == "CI" is both sound (excludes Dependabot + unrelated or
+#      since-deleted workflows) and complete (CI runs are named "CI" whether triggered by push,
+#      pull_request, or workflow_dispatch).
+#   2. Counting "any failure in the window" kept flagging main after an older failure had already
+#      been fixed by a newer green run. We take the most recent CI run by createdAt (max_by, so
+#      correctness doesn't rely on gh's default ordering) and check only that run. --limit 30
+#      keeps a CI run in the window even when a burst of same-second Dependabot runs floods the
+#      top; --status completed skips in-progress runs whose conclusion is still null.
+# `cancelled` is treated as healthy on purpose: ci.yml sets concurrency cancel-in-progress, so a
+# superseded run is expected, not a breakage. `none` (no CI run in the window, or the workflow was
+# renamed away from "CI") is logged rather than flagged, to avoid false positives in quiet periods.
+WORKFLOW_RUNS=$(gh run list --repo "$REPO" --branch main --limit 30 --status completed --json conclusion,workflowName,createdAt 2>/dev/null) || WORKFLOW_RUNS="[]"
+LATEST_CI_CONCLUSION=$(echo "$WORKFLOW_RUNS" | jq -r '[.[] | select(.workflowName == "CI")] | (max_by(.createdAt).conclusion) // "none"' 2>/dev/null) || LATEST_CI_CONCLUSION="none"
+case "$LATEST_CI_CONCLUSION" in
+  failure | timed_out | startup_failure)
+    PROBLEMS+=("### App: Failed CI workflows on main"$'\n\n'"The latest \`CI\` run on \`main\` ended in \`$LATEST_CI_CONCLUSION\`.")
+    log "WARNING: latest CI run on main ended in '$LATEST_CI_CONCLUSION'"
+    ;;
+  *)
+    log "GitHub Actions on main: latest CI run is '$LATEST_CI_CONCLUSION'"
+    ;;
+esac
 
 # ── Report ──
 log "=== Audit complete ==="


### PR DESCRIPTION
## Context

The 05:00 nightly audit (`scripts/nightly-audit.sh`) filed a `nightly-audit` issue almost daily for **"Failed CI workflows on main"** even though main CI was green — accumulating 17 open audit issues. This PR fixes the root causes. (Diagnosis of every open `nightly-audit` issue and why each is stale/resolved is tracked separately; this PR ships the two code fixes.)

## Root causes

1. **Section E false positive.** It counted *any* failed run from `gh run list --branch main`, which includes Dependabot's background **"Dependabot Updates"** jobs (`event=dynamic`) — e.g. the Expo major-bump update runs — and *stale* failures already fixed by a newer green run. Proof: PR #533's actual CI was all-green, yet the audit reported `expo-document-picker` as "failing" (it was reading the Dependabot updater job).
2. **Expo major bumps that never merge.** Dependabot kept opening major-version PRs for Expo-SDK-aligned packages (expo-haptics/eslint-config-expo/jest-expo 55→57, expo-document-picker 55→56). These are pinned to Expo SDK `~55`, fail CI, never merge, and Dependabot retries them forever — the source of the recurring noise.

## Changes

- **`scripts/nightly-audit.sh`** — Section E now checks only the **latest completed `CI` run** (`workflowName == "CI"`, selected via `max_by(.createdAt)` so it doesn't rely on `gh`'s default ordering) and flags a genuine red state (`failure` / `timed_out` / `startup_failure`). `cancelled` is treated as healthy on purpose (`ci.yml` uses concurrency `cancel-in-progress`); `none` is logged, not flagged. This also stabilises the audit signature — the volatile `Update #NNN` run names no longer enter the problem set — ending the duplicate-issue churn.
- **`.github/dependabot.yml`** — ignore `version-update:semver-major` for the Expo family: `expo`, `expo-*`, `@expo/*`, `eslint-config-expo`, `jest-expo`. Minor/patch updates still flow through the existing `minor-and-patch` group. (The 4 open Expo major PRs #530-#533 will be closed after merge — `ignore` only prevents *future* re-creation.)

## Verification

- Live dry-run of the new Section E against current main → `latest CI run is 'success'` (no problem filed). The old logic would have counted 6 failures (5 Dependabot + 1 stale CI).
- `bash -n` clean; edge cases checked (empty window, no-CI-in-window, out-of-order runs, `timed_out`).
- `dependabot.yml` prettier-clean, valid YAML, glob coverage confirmed against every Expo-family direct dependency in `apps/mobile`.
- Reviewed via `/code-review` (high); findings on failure-state coverage, explicit ordering, and defensive guarding were folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false-positive health alerts by tightening the CI status check for the main branch.
  * Improved handling of recent workflow results so only genuine CI failures are reported.

* **Chores**
  * Updated dependency update rules to avoid unwanted major-version upgrade prompts for Expo-related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->