### PR TITLE
docs(desktop): guardrail so the macOS fossil build isn't missed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,19 @@ Note-taking app at drafto.eu. Monorepo with pnpm workspaces + Turborepo. Web (Ne
 
 ## Where to find things
 
-| Need                                              | Start at                                                                             |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| What a feature does and where it lives in code    | [`docs/features/`](./docs/features/)                                                 |
-| System shape, data flow, platform parity          | [`docs/architecture/`](./docs/architecture/)                                         |
-| Testing matrix (commands per platform)            | [`docs/architecture/testing.md`](./docs/architecture/testing.md)                     |
-| Environments, Supabase refs, migration workflow   | [`docs/architecture/environments.md`](./docs/architecture/environments.md)           |
-| Local machine setup                               | [`docs/operations/local-dev-setup.md`](./docs/operations/local-dev-setup.md)         |
-| Builds, Fastlane, App Store / Play / Mac releases | [`docs/operations/builds-and-releases.md`](./docs/operations/builds-and-releases.md) |
-| Supabase migration safety workflow                | [`docs/operations/migrations.md`](./docs/operations/migrations.md)                   |
-| Why a tech / pattern was chosen                   | [`docs/adr/`](./docs/adr/README.md)                                                  |
-| Dark factory pipeline (kanban-driven autopilot)   | [`docs/features/dark-factory.md`](./docs/features/dark-factory.md)                   |
-| Full index                                        | [`docs/README.md`](./docs/README.md)                                                 |
+| Need                                                                        | Start at                                                                                                                                      |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| What a feature does and where it lives in code                              | [`docs/features/`](./docs/features/)                                                                                                          |
+| System shape, data flow, platform parity                                    | [`docs/architecture/`](./docs/architecture/)                                                                                                  |
+| Testing matrix (commands per platform)                                      | [`docs/architecture/testing.md`](./docs/architecture/testing.md)                                                                              |
+| Environments, Supabase refs, migration workflow                             | [`docs/architecture/environments.md`](./docs/architecture/environments.md)                                                                    |
+| Local machine setup                                                         | [`docs/operations/local-dev-setup.md`](./docs/operations/local-dev-setup.md)                                                                  |
+| Builds, Fastlane, App Store / Play / Mac releases                           | [`docs/operations/builds-and-releases.md`](./docs/operations/builds-and-releases.md)                                                          |
+| ⚠️ Desktop build is a fossil — never `pnpm install` in the primary checkout | [`docs/operations/desktop-build-fossil.md`](./docs/operations/desktop-build-fossil.md) · [`apps/desktop/CLAUDE.md`](./apps/desktop/CLAUDE.md) |
+| Supabase migration safety workflow                                          | [`docs/operations/migrations.md`](./docs/operations/migrations.md)                                                                            |
+| Why a tech / pattern was chosen                                             | [`docs/adr/`](./docs/adr/README.md)                                                                                                           |
+| Dark factory pipeline (kanban-driven autopilot)                             | [`docs/features/dark-factory.md`](./docs/features/dark-factory.md)                                                                            |
+| Full index                                                                  | [`docs/README.md`](./docs/README.md)                                                                                                          |
 
 Historical plans live in [`docs/archive/`](./docs/archive/) — do not treat as source of truth.
 
@@ -37,7 +38,7 @@ If a feature genuinely requires paid infrastructure, surface that explicitly as 
 Never work directly on `main`. For every new task (feature, fix, chore, docs):
 
 1. Use the `/worktree` command to create an isolated branch and worktree
-2. **Immediately run `pnpm install`** in the new worktree — worktrees do not share `node_modules`, so all tooling (`turbo`, `tsc`, etc.) will fail without this step, then run `bash scripts/worktree-bootstrap.sh` to copy the gitignored env/config files (see below)
+2. **Immediately run `pnpm install`** in the new worktree — worktrees do not share `node_modules`, so all tooling (`turbo`, `tsc`, etc.) will fail without this step, then run `bash scripts/worktree-bootstrap.sh` to copy the gitignored env/config files (see below). **Exception — never build or release the macOS desktop app from a worktree:** a worktree's fresh install resolves React 19.2, which the `react-native-macos@0.81` fossil cannot run (it compiles, then crashes at runtime). Desktop releases run **only** from the primary checkout's fossil `node_modules` — see [Release Authorization](#release-authorization) and [`apps/desktop/CLAUDE.md`](./apps/desktop/CLAUDE.md).
 3. Do all work (commits, edits, tests) in that worktree
 4. Open a PR to merge into `main` — never push directly to `main`
 
@@ -107,7 +108,7 @@ When planning, fan out independent actions into a single batched message — don
 
 **Worktree gotcha**: `Edit`/`Write` require a prior `Read` of the _exact_ path. Reading `/Users/…/drafto/foo.ts` does NOT satisfy an edit against `/Users/…/drafto-worktree/foo.ts`. Pattern when starting work in a worktree: one batched `Read` for every worktree file you'll touch, then one batched `Edit`/`Write` for all the changes.
 
-**Plan structure**: Multi-PR or multi-step plans should also exploit parallelism — group independent work into "waves" (Wave 1 fully parallel, Wave 2 after Wave 1, etc.) and assign each independent unit to its own subagent. End any plan that ships a cross-platform release with the explicit per-platform release commands as a final wave: web (Vercel auto-deploys on merge), `cd apps/mobile && pnpm release:prod:android`, `pnpm release:prod:ios`, `cd apps/desktop && pnpm release:production`. The three store releases run concurrently in their own subagents. Note any required version bumps (`pnpm version:mobile|desktop patch|minor|major`) before the release wave.
+**Plan structure**: Multi-PR or multi-step plans should also exploit parallelism — group independent work into "waves" (Wave 1 fully parallel, Wave 2 after Wave 1, etc.) and assign each independent unit to its own subagent. End any plan that ships a cross-platform release with the explicit per-platform release commands as a final wave: web (Vercel auto-deploys on merge), `cd apps/mobile && pnpm release:prod:android`, `pnpm release:prod:ios`, `cd apps/desktop && pnpm release:production` (⚠️ desktop builds **only** from the primary checkout's fossil `node_modules` — never a worktree; see [Release Authorization](#release-authorization)). The three store releases run concurrently in their own subagents. Note any required version bumps (`pnpm version:mobile|desktop patch|minor|major`) before the release wave.
 
 ## SOLID Principles (Enforced)
 
@@ -176,6 +177,14 @@ Common CI failure patterns:
 Beta TestFlight builds (Mac App Store Connect, iOS, Android internal track) are **pre-authorized** — ship them without asking. Communicate what's going out (version + build number, what's in it) but don't gate on permission. A bad TestFlight build is reversible: the next build supersedes it, and old builds can be expired in App Store Connect.
 
 Production / public-store releases (`pnpm release:prod:*`, `pnpm release:production`, App Store / Play Store submission) still require explicit user approval — those affect non-tester users.
+
+### ⚠️ Desktop (macOS) builds ONLY from the primary checkout's fossil `node_modules`
+
+The macOS desktop app is a **fossil build**. `react-native-macos@0.81` needs **React 19.1.4**, but the monorepo's declared React is **19.2.6** (mobile needs it; React must be one shared instance). The only working desktop `node_modules` lives in the **primary checkout** (`/Users/jakub/code/drafto`), installed before the React bump and **never reinstalled**. A clean `pnpm install` — including any **fresh worktree** or CI checkout — pulls React 19.2 and produces a build that **compiles fine but crashes at runtime** (Hermes `EXC_BAD_ACCESS` / blank screen). **A green compile is not proof the app works — only a TestFlight build that opens a note is.**
+
+- **NEVER** `pnpm install` in the primary checkout, and **never build/release desktop from a worktree, fresh install, or CI.**
+- Build/ship desktop **only** from the primary checkout: `cd /Users/jakub/code/drafto && git pull && cd apps/desktop && pnpm release:beta` (source via `git pull`, **never** `pnpm install`).
+- Full rules: [`docs/operations/desktop-build-fossil.md`](./docs/operations/desktop-build-fossil.md) · [ADR-0027](./docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md) · [`apps/desktop/CLAUDE.md`](./apps/desktop/CLAUDE.md).
 
 ## Dark Factory
 

--- a/apps/desktop/CLAUDE.md
+++ b/apps/desktop/CLAUDE.md
@@ -1,0 +1,44 @@
+# Desktop (macOS) app — read before any build or release
+
+## ⚠️ The desktop build is a FOSSIL — do not reinstall, do not build from a worktree
+
+`react-native-macos@0.81` (the macOS RN fork this app uses) requires **React 19.1.x**. The monorepo's
+_declared_ React is **19.2.6** — mobile's `react-native@0.86` needs it, and React must be a single
+shared instance across the monorepo ([ADR-0027], [#558]). The **only** working desktop build is the
+**fossil `node_modules` in the primary checkout** (`/Users/jakub/code/drafto`), installed before the
+React bump and **never reinstalled**.
+
+A clean `pnpm install` — **including any fresh git worktree** — pulls React **19.2.6**, which the 0.81
+fork cannot run: the app **compiles green but crashes at runtime** (Hermes `EXC_BAD_ACCESS`, blank
+screen, crash-on-note-open). **A green native build is NOT proof it works — only a TestFlight build
+that opens a note is.**
+
+## Rules
+
+- **NEVER** run `pnpm install` in the primary checkout (`/Users/jakub/code/drafto`) — it overwrites
+  the fossil and destroys the only shippable desktop build.
+- **NEVER** build or release the desktop app from a worktree, a fresh install, or CI — all of them
+  resolve React 19.2 and produce the crashing build.
+- Build/ship desktop **only** from the primary checkout's existing fossil `node_modules`:
+
+  ```bash
+  cd /Users/jakub/code/drafto     # primary checkout — the fossil (React 19.1.4)
+  git pull                        # source only — NEVER `pnpm install`
+  cd apps/desktop && pnpm release:beta
+  ```
+
+- Doing desktop **code / unit-test / typecheck** work in a worktree is fine (JS tooling runs there);
+  just never treat a worktree's native build as shippable, and route the actual release through the
+  fossil.
+
+## Why not just fix it?
+
+React cannot be split per-app (multiple React instances break hooks/Context — the empty-screen
+failure in [#558]), and we will not drag mobile/web back to React 19.1. The real fix is a one-line
+bump to `react-native-macos@0.83` (React 19.2) **once it ships**. Until then, the fossil stands.
+
+Full detail: [`../../docs/operations/desktop-build-fossil.md`](../../docs/operations/desktop-build-fossil.md)
+· [ADR-0027](../../docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md).
+
+[ADR-0027]: ../../docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md
+[#558]: https://github.com/JakubAnderwald/drafto/issues/558


### PR DESCRIPTION
## Why

I recently shipped a broken macOS beta (build 44) by building the desktop app from a **fresh worktree install** — which resolves React 19.2 and crashes at runtime (Hermes `EXC_BAD_ACCESS`). The rule that would have prevented it (`docs/operations/desktop-build-fossil.md` + ADR-0027: *desktop builds only from the primary checkout's fossil `node_modules`*) existed but wasn't discoverable from the instructions an agent reads before a build/release.

## What

Make the fossil rule impossible to miss:

- **New `apps/desktop/CLAUDE.md`** — directory-scoped, so it loads in context for any desktop work. Leads with the rule: never `pnpm install` in the primary checkout; never build/release desktop from a worktree/fresh install/CI; build only from the fossil; **a green compile is not proof it works — only a TestFlight build that opens a note is.**
- **Root `CLAUDE.md`** — three pointers where an agent would trip:
  - a row in the "Where to find things" table,
  - an **Exception** on the worktree "run `pnpm install`" step (the exact place I went wrong),
  - a bold **Desktop builds ONLY from the fossil** callout under Release Authorization.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified desktop app build and release guidance for macOS.
  * Added instructions to use only the primary checkout’s existing dependencies and avoid fresh installs or worktree-based desktop builds.
  * Expanded release planning notes with clearer do/don’t guidance and links to relevant operational references.
  * Added a new desktop-specific section explaining the build constraint and recommended beta release flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->