### PR TITLE
fix(desktop): tag each release so notes scope to the delta, not full history

### DIFF
--- a/apps/desktop/fastlane/Fastfile
+++ b/apps/desktop/fastlane/Fastfile
@@ -286,5 +286,26 @@ platform :mac do
     track_label =
       destination == "appstore" ? "the macOS App Store (build #{new_build_number})" : "TestFlight macOS (build #{new_build_number})"
     comment_released_issues(build: new_build_number, track: track_label)
+
+    # Tag this release (e.g. desktop@0.3.2+45) so generate-release-notes.sh scopes
+    # the NEXT build's "What to Test" to the delta since this build, instead of
+    # dumping the whole history. There were no desktop@ tags at all because
+    # desktop ships manually from the primary-checkout fossil (see
+    # docs/operations/desktop-build-fossil.md), so the desktop-*-release.yml CI
+    # tag job never runs — tag here instead. `-v:refname` orders the +build suffix
+    # numerically (verified). Non-fatal: a tag/push failure must not fail an
+    # already-shipped release.
+    begin
+      release_tag = "desktop@#{version}+#{new_build_number}"
+      if `git tag -l "#{release_tag}"`.strip.empty?
+        sh("git", "tag", release_tag)
+        sh("git", "push", "origin", release_tag)
+        UI.success("Tagged release #{release_tag}")
+      else
+        UI.message("Release tag #{release_tag} already exists — skipping")
+      end
+    rescue StandardError => e
+      UI.important("Release tagging failed (non-fatal): #{e.message}")
+    end
   end
 end


### PR DESCRIPTION
## Why

Desktop TestFlight "What to Test" dumps the **entire repo history** on every build (screenshotted on build 45 — "What's new" starts at #452 and scrolls back years, with the actual new fix buried under it). Root cause: `apps/desktop/scripts/generate-release-notes.sh` scopes to `git log <last desktop@ tag>..HEAD`, but **there are zero `desktop@` tags** — so it falls back to `RANGE=HEAD` (all history).

Tags are created by the `desktop-*-release.yml` CI workflow, which **never runs** because desktop can't build in CI (the React-19.1.4 fossil — `docs/operations/desktop-build-fossil.md`); desktop ships **manually from the primary checkout**, and that path (the Fastfile) never tagged. Same latent bug affects mobile (its `mobile@` tags are stale CI-era artifacts, last `mobile@1.1.7` while current version is 1.3.0).

## What

Tag each successful desktop release at the end of the `mac` beta/production lane:

```ruby
release_tag = "desktop@#{version}+#{new_build_number}"   # e.g. desktop@0.3.2+46
# create if missing, push, non-fatal on error
```

- Created **after** notes/comment steps, so this build's notes still use the previous tag; the **next** build's notes then cover only the delta since this build.
- `--sort=-v:refname` already orders the `+build` suffix numerically (verified: `+100 > +45 > +44 > +10 > +9`), so **no change to the generator or the shared `comment-released-issues.mjs` is needed.**
- Non-fatal: a tag/push failure can't fail an already-shipped release.

The first release after this merges still dumps once (no prior tag to anchor); every release after is scoped.

Fastfile-only (Ruby) — no code/JS surface. Mobile's identical gap is left as a follow-up (its android+ios dual-lane needs slightly different handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
