### PR TITLE
fix(notebooks): block deleting notebooks with non-trashed notes on mobile + desktop

### DIFF
--- a/apps/desktop/__tests__/components/notebooks-sidebar.test.tsx
+++ b/apps/desktop/__tests__/components/notebooks-sidebar.test.tsx
@@ -103,11 +103,24 @@ describe("NotebooksSidebar — delete guard", () => {
   it("requires confirmation, then cascades trashed notes and deletes the notebook", async () => {
     const markAsDeleted = jest.fn();
     const trashedNoteMarkAsDeleted = jest.fn();
+    const attachmentMarkAsDeleted = jest.fn();
     mockNotebooks.push({ id: "nb-1", name: "Empty NB", markAsDeleted });
     mockNoteFetchCount.mockResolvedValue(0);
     mockNoteFetch.mockResolvedValue([
       { id: "t1", isTrashed: true, markAsDeleted: trashedNoteMarkAsDeleted },
     ]);
+    mockGet.mockImplementation((table: string) => {
+      if (table === "notes") return { query: mockNotesQuery };
+      if (table === "attachments")
+        return {
+          query: () => ({
+            fetch: jest
+              .fn()
+              .mockResolvedValue([{ id: "a1", markAsDeleted: attachmentMarkAsDeleted }]),
+          }),
+        };
+      return {};
+    });
 
     const { UNSAFE_root } = render(<NotebooksSidebar {...defaultProps} />);
     await findDeleteButton(UNSAFE_root).props.onPress();
@@ -129,6 +142,7 @@ describe("NotebooksSidebar — delete guard", () => {
     await waitFor(() => expect(markAsDeleted).toHaveBeenCalled());
     expect(mockWrite).toHaveBeenCalled();
     expect(trashedNoteMarkAsDeleted).toHaveBeenCalled();
+    expect(attachmentMarkAsDeleted).toHaveBeenCalled();
   });
 
   it("aborts at confirm time if a note raced into the notebook after the guard passed", async () => {

--- a/apps/desktop/__tests__/components/notebooks-sidebar.test.tsx
+++ b/apps/desktop/__tests__/components/notebooks-sidebar.test.tsx
@@ -1,0 +1,154 @@
+import { Alert } from "react-native";
+import { Q } from "@nozbe/watermelondb";
+
+import { render, waitFor } from "../helpers/test-utils";
+import { NotebooksSidebar } from "@/components/sidebar/notebooks-sidebar";
+
+// SyncStatus pulls in useDatabase/useNetworkStatus providers we don't render here.
+jest.mock("@/components/sync-status", () => ({ SyncStatus: () => null }));
+
+jest.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "user-1", email: "user@example.com" }, signOut: jest.fn() }),
+}));
+
+const mockNotebooks: Array<{ id: string; name: string; markAsDeleted: jest.Mock }> = [];
+let mockLoading = false;
+jest.mock("@/hooks/use-notebooks", () => ({
+  useNotebooks: () => ({ notebooks: mockNotebooks, loading: mockLoading }),
+}));
+
+const mockGet = jest.fn();
+const mockWrite = jest.fn(async (fn: () => Promise<void>) => {
+  await fn();
+});
+jest.mock("@/db", () => ({
+  database: {
+    get: (...args: unknown[]) => mockGet(...args),
+    write: (...args: unknown[]) => mockWrite(...args),
+  },
+}));
+
+const mockNoteFetchCount = jest.fn();
+const mockNoteFetch = jest.fn();
+// A real jest.fn so we can assert the guard queries with the is_trashed=false predicate.
+const mockNotesQuery = jest.fn(() => ({ fetchCount: mockNoteFetchCount, fetch: mockNoteFetch }));
+
+const defaultProps = {
+  selectedNotebookId: undefined,
+  onSelectNotebook: jest.fn(),
+  showTrash: false,
+  onToggleTrash: jest.fn(),
+  onOpenSearch: jest.fn(),
+};
+
+type PressableNode = { props: { onPress: () => void | Promise<void> } };
+
+// The delete "×" is a hover-revealed Pressable (disabled until hovered); grab the
+// composite element that carries both the accessibility label and the onPress
+// handler and invoke it directly — that is exactly what a click wires up.
+function findDeleteButton(root: ReturnType<typeof render>["UNSAFE_root"]): PressableNode {
+  const matches = root.findAll(
+    (node) =>
+      node.props?.accessibilityLabel === "Delete notebook" &&
+      typeof node.props?.onPress === "function",
+  );
+  return matches[0] as unknown as PressableNode;
+}
+
+function confirmDelete() {
+  const buttons = (Alert.alert as jest.Mock).mock.calls.at(-1)?.[2] as Array<{
+    text: string;
+    onPress?: () => void | Promise<void>;
+  }>;
+  return buttons.find((b) => b.text === "Delete")?.onPress?.();
+}
+
+describe("NotebooksSidebar — delete guard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNotebooks.length = 0;
+    mockLoading = false;
+    mockNoteFetch.mockResolvedValue([]);
+    mockGet.mockImplementation((table: string) => {
+      if (table === "notes") return { query: mockNotesQuery };
+      if (table === "attachments")
+        return { query: () => ({ fetch: jest.fn().mockResolvedValue([]) }) };
+      return {};
+    });
+    jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  it("blocks deletion (filtering on non-trashed notes) and never writes", async () => {
+    mockNotebooks.push({ id: "nb-1", name: "Work Notes", markAsDeleted: jest.fn() });
+    mockNoteFetchCount.mockResolvedValue(3);
+
+    const { UNSAFE_root } = render(<NotebooksSidebar {...defaultProps} />);
+    await findDeleteButton(UNSAFE_root).props.onPress();
+
+    await waitFor(() =>
+      expect(Alert.alert).toHaveBeenCalledWith(
+        "Cannot Delete Notebook",
+        "Cannot delete notebook with notes. Move or delete notes first.",
+      ),
+    );
+    // The guard must count NON-trashed notes only, not all notes.
+    expect(mockNotesQuery).toHaveBeenCalledWith(
+      Q.where("notebook_id", "nb-1"),
+      Q.where("is_trashed", false),
+    );
+    expect(mockWrite).not.toHaveBeenCalled();
+    expect(mockNotebooks[0].markAsDeleted).not.toHaveBeenCalled();
+  });
+
+  it("requires confirmation, then cascades trashed notes and deletes the notebook", async () => {
+    const markAsDeleted = jest.fn();
+    const trashedNoteMarkAsDeleted = jest.fn();
+    mockNotebooks.push({ id: "nb-1", name: "Empty NB", markAsDeleted });
+    mockNoteFetchCount.mockResolvedValue(0);
+    mockNoteFetch.mockResolvedValue([
+      { id: "t1", isTrashed: true, markAsDeleted: trashedNoteMarkAsDeleted },
+    ]);
+
+    const { UNSAFE_root } = render(<NotebooksSidebar {...defaultProps} />);
+    await findDeleteButton(UNSAFE_root).props.onPress();
+
+    await waitFor(() =>
+      expect(Alert.alert).toHaveBeenCalledWith(
+        "Delete Notebook",
+        expect.stringContaining("permanently deleted"),
+        expect.any(Array),
+      ),
+    );
+    // Regression guard: the old code deleted immediately on click; nothing may be
+    // written until the user confirms.
+    expect(mockWrite).not.toHaveBeenCalled();
+    expect(markAsDeleted).not.toHaveBeenCalled();
+
+    await confirmDelete();
+
+    await waitFor(() => expect(markAsDeleted).toHaveBeenCalled());
+    expect(mockWrite).toHaveBeenCalled();
+    expect(trashedNoteMarkAsDeleted).toHaveBeenCalled();
+  });
+
+  it("aborts at confirm time if a note raced into the notebook after the guard passed", async () => {
+    const markAsDeleted = jest.fn();
+    mockNotebooks.push({ id: "nb-1", name: "Empty NB", markAsDeleted });
+    mockNoteFetchCount.mockResolvedValue(0); // guard passes...
+    mockNoteFetch.mockResolvedValue([{ id: "n1", isTrashed: false, markAsDeleted: jest.fn() }]); // ...but a note raced in
+
+    const { UNSAFE_root } = render(<NotebooksSidebar {...defaultProps} />);
+    await findDeleteButton(UNSAFE_root).props.onPress();
+    await waitFor(() => expect(Alert.alert).toHaveBeenCalled());
+    await confirmDelete();
+
+    await waitFor(() =>
+      expect(Alert.alert).toHaveBeenCalledWith(
+        "Cannot Delete Notebook",
+        "Cannot delete notebook with notes. Move or delete notes first.",
+      ),
+    );
+    expect(mockWrite).not.toHaveBeenCalled();
+    expect(markAsDeleted).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/components/sidebar/notebooks-sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/notebooks-sidebar.tsx
@@ -160,6 +160,10 @@ export function NotebooksSidebar({
                 });
               } catch (err) {
                 console.error("Failed to delete notebook:", err);
+                Alert.alert(
+                  "Error",
+                  err instanceof Error ? err.message : "Failed to delete notebook",
+                );
               }
             },
           },
@@ -167,6 +171,7 @@ export function NotebooksSidebar({
       );
     } catch (err) {
       console.error("Failed to delete notebook:", err);
+      Alert.alert("Error", err instanceof Error ? err.message : "Failed to delete notebook");
     }
   }, []);
 

--- a/apps/desktop/src/components/sidebar/notebooks-sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/notebooks-sidebar.tsx
@@ -1,10 +1,19 @@
 import { useState, useMemo, useCallback, useEffect } from "react";
-import { View, Text, Pressable, TextInput, StyleSheet, ActivityIndicator } from "react-native";
+import {
+  View,
+  Text,
+  Pressable,
+  TextInput,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+import { Q } from "@nozbe/watermelondb";
 
 import { useNotebooks } from "@/hooks/use-notebooks";
 import { useAuth } from "@/providers/auth-provider";
 import { useTheme } from "@/providers/theme-provider";
-import { database, Notebook } from "@/db";
+import { database, Notebook, Note, Attachment } from "@/db";
 import { generateId } from "@/lib/generate-id";
 import { colors, fontFamily, fontSizes, radii, spacing } from "@/theme/tokens";
 import type { SemanticColors } from "@/theme/tokens";
@@ -95,9 +104,67 @@ export function NotebooksSidebar({
 
   const handleDelete = useCallback(async (notebook: Notebook) => {
     try {
-      await database.write(async () => {
-        await notebook.markAsDeleted();
-      });
+      // Fast pre-check: don't even offer deletion while non-trashed notes remain.
+      // Mirrors the web API's 409 guard (apps/web/src/app/api/notebooks/[id]/route.ts),
+      // which mobile/desktop bypass by writing straight to WatermelonDB + sync.
+      const activeNoteCount = await database
+        .get<Note>("notes")
+        .query(Q.where("notebook_id", notebook.id), Q.where("is_trashed", false))
+        .fetchCount();
+
+      if (activeNoteCount > 0) {
+        Alert.alert(
+          "Cannot Delete Notebook",
+          "Cannot delete notebook with notes. Move or delete notes first.",
+        );
+        return;
+      }
+
+      Alert.alert(
+        "Delete Notebook",
+        `Delete notebook "${notebook.name}"? Trashed notes inside will be permanently deleted.`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Delete",
+            style: "destructive",
+            onPress: async () => {
+              try {
+                // Re-read atomically at delete time: a background sync could have pulled
+                // a note into this notebook between the guard check and this confirmation.
+                const notes = await database
+                  .get<Note>("notes")
+                  .query(Q.where("notebook_id", notebook.id))
+                  .fetch();
+                if (notes.some((note) => !note.isTrashed)) {
+                  Alert.alert(
+                    "Cannot Delete Notebook",
+                    "Cannot delete notebook with notes. Move or delete notes first.",
+                  );
+                  return;
+                }
+                // Cascade the remaining (all trashed) notes and their attachments locally so
+                // the WatermelonDB state matches the server FK `on delete cascade` after sync.
+                await database.write(async () => {
+                  for (const note of notes) {
+                    const attachments = await database
+                      .get<Attachment>("attachments")
+                      .query(Q.where("note_id", note.id))
+                      .fetch();
+                    for (const attachment of attachments) {
+                      await attachment.markAsDeleted();
+                    }
+                    await note.markAsDeleted();
+                  }
+                  await notebook.markAsDeleted();
+                });
+              } catch (err) {
+                console.error("Failed to delete notebook:", err);
+              }
+            },
+          },
+        ],
+      );
     } catch (err) {
       console.error("Failed to delete notebook:", err);
     }

--- a/apps/mobile/__tests__/screens/notebooks.test.tsx
+++ b/apps/mobile/__tests__/screens/notebooks.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Alert } from "react-native";
+import { Q } from "@nozbe/watermelondb";
 
 import { render, fireEvent, waitFor } from "../helpers/test-utils";
 import NotebooksScreen from "../../app/(tabs)/index";
@@ -139,5 +140,132 @@ describe("NotebooksScreen", () => {
     await waitFor(() => {
       expect(mockDatabaseWrite).toHaveBeenCalled();
     });
+  });
+
+  it("blocks deleting a notebook with non-trashed notes (filtered) and writes nothing", async () => {
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    mockNotebooks.push({ id: "nb-1", name: "Work Notes", updatedAt: new Date() });
+    const notesQuery = jest.fn(() => ({
+      fetchCount: jest.fn().mockResolvedValue(2),
+      fetch: jest.fn().mockResolvedValue([]),
+    }));
+    mockDatabaseGet.mockImplementation((table: string) => {
+      if (table === "notes") return { query: notesQuery };
+      return {};
+    });
+
+    const { getByTestId } = render(<NotebooksScreen />);
+    fireEvent.press(getByTestId("action-trash"));
+
+    await waitFor(() =>
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Cannot Delete Notebook",
+        "Cannot delete notebook with notes. Move or delete notes first.",
+      ),
+    );
+    // The guard must count NON-trashed notes only, not all notes.
+    expect(notesQuery).toHaveBeenCalledWith(
+      Q.where("notebook_id", "nb-1"),
+      Q.where("is_trashed", false),
+    );
+    expect(mockDatabaseWrite).not.toHaveBeenCalled();
+  });
+
+  it("deletes an empty notebook and cascades its trashed notes after the user confirms", async () => {
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    const notebookMarkAsDeleted = jest.fn();
+    const trashedNoteMarkAsDeleted = jest.fn();
+    mockNotebooks.push({ id: "nb-1", name: "Empty NB", updatedAt: new Date() });
+    mockDatabaseWrite.mockImplementation(async (fn: () => Promise<void>) => {
+      await fn();
+    });
+    mockDatabaseGet.mockImplementation((table: string) => {
+      if (table === "notes") {
+        return {
+          query: () => ({
+            fetchCount: jest.fn().mockResolvedValue(0),
+            fetch: jest
+              .fn()
+              .mockResolvedValue([
+                { id: "t1", isTrashed: true, markAsDeleted: trashedNoteMarkAsDeleted },
+              ]),
+          }),
+        };
+      }
+      if (table === "notebooks") {
+        return { find: jest.fn().mockResolvedValue({ markAsDeleted: notebookMarkAsDeleted }) };
+      }
+      if (table === "attachments") {
+        return { query: () => ({ fetch: jest.fn().mockResolvedValue([]) }) };
+      }
+      return {};
+    });
+
+    const { getByTestId } = render(<NotebooksScreen />);
+    fireEvent.press(getByTestId("action-trash"));
+
+    await waitFor(() =>
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Delete Notebook",
+        expect.stringContaining("permanently deleted"),
+        expect.any(Array),
+      ),
+    );
+    // Nothing is deleted until the user confirms.
+    expect(mockDatabaseWrite).not.toHaveBeenCalled();
+
+    const buttons = alertSpy.mock.calls.at(-1)?.[2] as Array<{
+      text: string;
+      onPress?: () => void | Promise<void>;
+    }>;
+    await buttons.find((b) => b.text === "Delete")?.onPress?.();
+
+    await waitFor(() => expect(notebookMarkAsDeleted).toHaveBeenCalled());
+    expect(trashedNoteMarkAsDeleted).toHaveBeenCalled();
+    expect(mockDatabaseWrite).toHaveBeenCalled();
+  });
+
+  it("aborts at confirm time if a note raced into the notebook after the guard passed", async () => {
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    const notebookMarkAsDeleted = jest.fn();
+    mockNotebooks.push({ id: "nb-1", name: "Empty NB", updatedAt: new Date() });
+    mockDatabaseWrite.mockImplementation(async (fn: () => Promise<void>) => {
+      await fn();
+    });
+    mockDatabaseGet.mockImplementation((table: string) => {
+      if (table === "notes") {
+        return {
+          query: () => ({
+            fetchCount: jest.fn().mockResolvedValue(0), // guard passes...
+            fetch: jest
+              .fn()
+              .mockResolvedValue([{ id: "n1", isTrashed: false, markAsDeleted: jest.fn() }]), // ...but a note raced in
+          }),
+        };
+      }
+      if (table === "notebooks") {
+        return { find: jest.fn().mockResolvedValue({ markAsDeleted: notebookMarkAsDeleted }) };
+      }
+      return {};
+    });
+
+    const { getByTestId } = render(<NotebooksScreen />);
+    fireEvent.press(getByTestId("action-trash"));
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+
+    const buttons = alertSpy.mock.calls.at(-1)?.[2] as Array<{
+      text: string;
+      onPress?: () => void | Promise<void>;
+    }>;
+    await buttons.find((b) => b.text === "Delete")?.onPress?.();
+
+    await waitFor(() =>
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Cannot Delete Notebook",
+        "Cannot delete notebook with notes. Move or delete notes first.",
+      ),
+    );
+    expect(mockDatabaseWrite).not.toHaveBeenCalled();
+    expect(notebookMarkAsDeleted).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/__tests__/screens/notebooks.test.tsx
+++ b/apps/mobile/__tests__/screens/notebooks.test.tsx
@@ -175,6 +175,7 @@ describe("NotebooksScreen", () => {
     const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     const notebookMarkAsDeleted = jest.fn();
     const trashedNoteMarkAsDeleted = jest.fn();
+    const attachmentMarkAsDeleted = jest.fn();
     mockNotebooks.push({ id: "nb-1", name: "Empty NB", updatedAt: new Date() });
     mockDatabaseWrite.mockImplementation(async (fn: () => Promise<void>) => {
       await fn();
@@ -196,7 +197,13 @@ describe("NotebooksScreen", () => {
         return { find: jest.fn().mockResolvedValue({ markAsDeleted: notebookMarkAsDeleted }) };
       }
       if (table === "attachments") {
-        return { query: () => ({ fetch: jest.fn().mockResolvedValue([]) }) };
+        return {
+          query: () => ({
+            fetch: jest
+              .fn()
+              .mockResolvedValue([{ id: "a1", markAsDeleted: attachmentMarkAsDeleted }]),
+          }),
+        };
       }
       return {};
     });
@@ -222,6 +229,7 @@ describe("NotebooksScreen", () => {
 
     await waitFor(() => expect(notebookMarkAsDeleted).toHaveBeenCalled());
     expect(trashedNoteMarkAsDeleted).toHaveBeenCalled();
+    expect(attachmentMarkAsDeleted).toHaveBeenCalled();
     expect(mockDatabaseWrite).toHaveBeenCalled();
   });
 

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -92,42 +92,79 @@ export default function NotebooksScreen() {
   };
 
   const handleDelete = useCallback(
-    (id: string, name: string) => {
-      Alert.alert("Delete Notebook", `Are you sure you want to delete "${name}"?`, [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: async () => {
-            try {
-              const notebook = await database.get<Notebook>("notebooks").find(id);
-              const notes = await database
-                .get<Note>("notes")
-                .query(Q.where("notebook_id", id))
-                .fetch();
-              await database.write(async () => {
-                for (const note of notes) {
-                  const attachments = await database
-                    .get<Attachment>("attachments")
-                    .query(Q.where("note_id", note.id))
-                    .fetch();
-                  for (const attachment of attachments) {
-                    await attachment.markAsDeleted();
-                  }
-                  await note.markAsDeleted();
+    async (id: string, name: string) => {
+      // Fast pre-check: don't even offer deletion while non-trashed notes remain.
+      // Mirrors the web API's 409 guard (apps/web/src/app/api/notebooks/[id]/route.ts),
+      // which mobile/desktop bypass by writing straight to WatermelonDB + sync.
+      let activeNoteCount: number;
+      try {
+        activeNoteCount = await database
+          .get<Note>("notes")
+          .query(Q.where("notebook_id", id), Q.where("is_trashed", false))
+          .fetchCount();
+      } catch (err) {
+        Alert.alert("Error", err instanceof Error ? err.message : "Failed to delete notebook");
+        return;
+      }
+
+      if (activeNoteCount > 0) {
+        Alert.alert(
+          "Cannot Delete Notebook",
+          "Cannot delete notebook with notes. Move or delete notes first.",
+        );
+        return;
+      }
+
+      Alert.alert(
+        "Delete Notebook",
+        `Delete notebook "${name}"? Trashed notes inside will be permanently deleted.`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Delete",
+            style: "destructive",
+            onPress: async () => {
+              try {
+                const notebook = await database.get<Notebook>("notebooks").find(id);
+                // Re-read atomically at delete time: a background sync could have pulled
+                // a note into this notebook between the guard check and this confirmation.
+                const notes = await database
+                  .get<Note>("notes")
+                  .query(Q.where("notebook_id", id))
+                  .fetch();
+                if (notes.some((note) => !note.isTrashed)) {
+                  Alert.alert(
+                    "Cannot Delete Notebook",
+                    "Cannot delete notebook with notes. Move or delete notes first.",
+                  );
+                  return;
                 }
-                await notebook.markAsDeleted();
-              });
-              sync();
-            } catch (err) {
-              Alert.alert(
-                "Error",
-                err instanceof Error ? err.message : "Failed to delete notebook",
-              );
-            }
+                // Cascade the remaining (all trashed) notes and their attachments locally so
+                // the WatermelonDB state matches the server FK `on delete cascade` after sync.
+                await database.write(async () => {
+                  for (const note of notes) {
+                    const attachments = await database
+                      .get<Attachment>("attachments")
+                      .query(Q.where("note_id", note.id))
+                      .fetch();
+                    for (const attachment of attachments) {
+                      await attachment.markAsDeleted();
+                    }
+                    await note.markAsDeleted();
+                  }
+                  await notebook.markAsDeleted();
+                });
+                sync();
+              } catch (err) {
+                Alert.alert(
+                  "Error",
+                  err instanceof Error ? err.message : "Failed to delete notebook",
+                );
+              }
+            },
           },
-        },
-      ]);
+        ],
+      );
     },
     [database, sync],
   );

--- a/docs/features/notes-and-notebooks.md
+++ b/docs/features/notes-and-notebooks.md
@@ -13,7 +13,7 @@ Shipped on all four platforms: web, iOS, Android, macOS.
 - Notebooks are a single flat level (no nesting). Each note belongs to exactly one notebook.
 - Soft delete: `DELETE /api/notes/:id` sets `is_trashed = true` and stamps `trashed_at`. Trashed notes live in a dedicated trash view and are permanently purged after 30 days by a `pg_cron` job.
 - Permanent delete is available from trash via `DELETE /api/notes/:id/permanent`.
-- Deleting a notebook is blocked while it holds non-trashed notes. Web enforces this in the API (`DELETE /api/notebooks/:id` → 409 "Cannot delete notebook with notes. Move or delete notes first."); mobile and desktop enforce the same rule client-side before their WatermelonDB delete syncs (they never hit the API route). When an eligible notebook is deleted, its remaining trashed notes and attachments are cascade-removed locally so the client matches the server-side `on delete cascade` after sync.
+- Deleting a notebook is blocked while it holds non-trashed notes. Web enforces this in the API (`DELETE /api/notebooks/:id` → 409 "Cannot delete notebook with notes. Move or delete notes first."); mobile and desktop enforce the same rule client-side before their WatermelonDB delete syncs (they never hit the API route). When an eligible notebook is deleted, its remaining trashed notes and attachments are cascade-removed locally so the client matches the server-side `on delete cascade` after sync. The client guard is a point-in-time check against the local copy, so a note synced from another device between the check and the delete can still slip past it (unlike the web API's DB-backed 409); mobile additionally lacks server-deletion self-heal to clean up the resulting orphan row ([#462](https://github.com/JakubAnderwald/drafto/issues/462)).
 - The default notebook is provisioned server-side in the App Router layout if the user has zero notebooks.
 - Mobile and desktop hold a full local copy in WatermelonDB and sync via pull/push against Supabase; web reads/writes directly through the API.
 
@@ -64,7 +64,7 @@ Shipped on all four platforms: web, iOS, Android, macOS.
   - RLS requires `profiles.is_approved = true` for all reads/writes on notebooks, notes, attachments — unapproved users see nothing.
   - `notes.user_id` and `notes.notebook_id → notebooks.user_id` must match the authenticated user; enforced in RLS `WITH CHECK`.
   - Soft delete is the default for `DELETE /api/notes/:id`. Hard delete only goes through `/api/notes/:id/permanent`.
-  - `notebooks` delete rejects non-trashed children: web via a 409 in the API route, mobile/desktop via a client-side guard before the sync push issues the hard delete.
+  - `notebooks` delete rejects non-trashed children: web via a 409 in the API route, mobile/desktop via a client-side guard before the sync push issues the hard delete. Only the web 409 is race-free; the client guard is a point-in-time local check a cross-device sync can still race (#462).
   - `updated_at` is maintained by the `handle_updated_at` trigger; do not set it manually.
 - Tests that catch regressions:
   - `apps/web/__tests__/unit/notebooks-api.test.ts`, `notes-api.test.ts`, `trash-api.test.ts`, `trash-cleanup.test.ts`.

--- a/docs/features/notes-and-notebooks.md
+++ b/docs/features/notes-and-notebooks.md
@@ -13,7 +13,7 @@ Shipped on all four platforms: web, iOS, Android, macOS.
 - Notebooks are a single flat level (no nesting). Each note belongs to exactly one notebook.
 - Soft delete: `DELETE /api/notes/:id` sets `is_trashed = true` and stamps `trashed_at`. Trashed notes live in a dedicated trash view and are permanently purged after 30 days by a `pg_cron` job.
 - Permanent delete is available from trash via `DELETE /api/notes/:id/permanent`.
-- Deleting a notebook is blocked if it contains non-trashed notes (409 with message to move or delete notes first).
+- Deleting a notebook is blocked while it holds non-trashed notes. Web enforces this in the API (`DELETE /api/notebooks/:id` → 409 "Cannot delete notebook with notes. Move or delete notes first."); mobile and desktop enforce the same rule client-side before their WatermelonDB delete syncs (they never hit the API route). When an eligible notebook is deleted, its remaining trashed notes and attachments are cascade-removed locally so the client matches the server-side `on delete cascade` after sync.
 - The default notebook is provisioned server-side in the App Router layout if the user has zero notebooks.
 - Mobile and desktop hold a full local copy in WatermelonDB and sync via pull/push against Supabase; web reads/writes directly through the API.
 
@@ -64,7 +64,7 @@ Shipped on all four platforms: web, iOS, Android, macOS.
   - RLS requires `profiles.is_approved = true` for all reads/writes on notebooks, notes, attachments — unapproved users see nothing.
   - `notes.user_id` and `notes.notebook_id → notebooks.user_id` must match the authenticated user; enforced in RLS `WITH CHECK`.
   - Soft delete is the default for `DELETE /api/notes/:id`. Hard delete only goes through `/api/notes/:id/permanent`.
-  - `notebooks` delete rejects non-trashed children with 409.
+  - `notebooks` delete rejects non-trashed children: web via a 409 in the API route, mobile/desktop via a client-side guard before the sync push issues the hard delete.
   - `updated_at` is maintained by the `handle_updated_at` trigger; do not set it manually.
 - Tests that catch regressions:
   - `apps/web/__tests__/unit/notebooks-api.test.ts`, `notes-api.test.ts`, `trash-api.test.ts`, `trash-cleanup.test.ts`.


### PR DESCRIPTION
## What & why

Deleting a notebook on macOS (and mobile) could **permanently destroy its notes**. The sidebar delete ran `notebook.markAsDeleted()`, which syncs a `DELETE FROM notebooks`; the server FK `notebook_id … on delete cascade` then obliterated every note in it — bypassing Trash **and** the 30-day grace entirely. On desktop there was no confirmation at all (a single hover-click). Web + the MCP tool already block this with a 409, but mobile/desktop write straight to WatermelonDB and never hit that route.

Reported after a user deleted a non-empty "Notes" notebook and lost its notes.

## Change

Mobile (`apps/mobile/app/(tabs)/index.tsx`) and desktop (`apps/desktop/src/components/sidebar/notebooks-sidebar.tsx`) now enforce the same contract client-side, before sync pushes a hard delete:

- **Block** deletion while the notebook holds any **non-trashed** note, with the same message the web API returns (*"Cannot delete notebook with notes. Move or delete notes first."*).
- **Require explicit confirmation** for eligible (no non-trashed notes) deletes. On confirm, cascade the remaining **trashed** notes + attachments locally so the WatermelonDB state matches the server FK cascade after sync (the confirm text warns those trashed notes are permanently deleted).
- **Atomic re-check**: re-read the notebook's notes inside the confirm handler and abort if a note raced in between the guard check and confirmation.

Also:
- `docs/features/notes-and-notebooks.md` — corrected to describe web-API-409 vs client-side (mobile/desktop) enforcement + the local trashed-note cascade.
- New desktop sidebar test suite; extended mobile notebooks screen tests (asserts the `is_trashed=false` predicate, exercises the trashed cascade, and covers the race abort).

No web/MCP/schema/migration changes.

## Verification

- `pnpm lint` (0 errors), `pnpm typecheck` (4/4), `pnpm format:check`, `pnpm test` (desktop 320, mobile 122, web + shared) — all green.
- Web's `notebooks-id-api.test.ts` (the 409 contract) unchanged and passing.

## Known limitation (out of scope)

The guard is **local-only**: a non-trashed note created on another device but not yet pulled is invisible to it, so a cross-device delete can still cascade that note server-side — and mobile lacks the server-deletion self-heal desktop has, so an orphan row can persist. This is inherent to offline-first (server-side enforcement is explicitly out of scope for #474) and the mobile self-heal gap is tracked by **#462**.

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented notebook deletion when active, non-trashed notes remain.
  - Added a final safety check before deletion to handle notes added during confirmation.
  - Deleting eligible notebooks now also removes their trashed notes and attachments locally before synchronization.
  - Added clearer alerts for blocked deletions and deletion errors.

- **Documentation**
  - Updated notebook deletion behavior and safety constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->