### PR TITLE
fix(mobile): iOS modular-headers config plugin for Google Sign-In (unblock pod install)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -80,5 +80,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     "./plugins/with-android-optimizations",
     "./plugins/with-android-signing",
     "./plugins/with-ios-swift-concurrency",
+    "./plugins/with-ios-modular-headers",
   ],
 });

--- a/apps/mobile/plugins/with-ios-modular-headers.js
+++ b/apps/mobile/plugins/with-ios-modular-headers.js
@@ -1,0 +1,61 @@
+const { withDangerousMod } = require("expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Expo config plugin: opt the Google Sign-In transitive pods into modular headers.
+ *
+ * `@react-native-google-signin/google-signin` pulls in `AppCheckCore` (a Swift pod)
+ * which depends on `GoogleUtilities` and `RecaptchaInterop`. Those two do not define
+ * Clang modules, so CocoaPods cannot integrate them into the Swift `AppCheckCore`
+ * target as static libraries and `pod install` fails:
+ *
+ *   The Swift pod `AppCheckCore` depends upon `GoogleUtilities` and
+ *   `RecaptchaInterop`, which do not define modules.
+ *
+ * Declaring those two with `:modular_headers => true` generates the module maps they
+ * need, without flipping the whole project to `use_modular_headers!` (which would
+ * force modular headers on every pod, including React Native's).
+ *
+ * The `ios/` project is regenerated on every `expo prebuild`, so this fix must live
+ * as a config plugin rather than a hand edit to the generated Podfile.
+ *
+ * Remove if a future @react-native-google-signin / AppCheckCore release defines the
+ * modules itself, or after adopting a setup that vendors these as frameworks.
+ */
+function withIosModularHeaders(config) {
+  return withDangerousMod(config, [
+    "ios",
+    (config) => {
+      const podfilePath = path.join(config.modRequest.platformProjectRoot, "Podfile");
+      if (!fs.existsSync(podfilePath)) {
+        return config;
+      }
+
+      let contents = fs.readFileSync(podfilePath, "utf-8");
+      if (contents.includes(":modular_headers => true")) {
+        return config; // already patched
+      }
+
+      const modularPods = [
+        "  # Google Sign-In's AppCheckCore (Swift) requires these to expose Clang modules.",
+        "  pod 'GoogleUtilities', :modular_headers => true",
+        "  pod 'RecaptchaInterop', :modular_headers => true",
+      ].join("\n");
+
+      // Insert just after `use_expo_modules!` inside the app target.
+      const anchor = /^(\s*use_expo_modules!.*)$/m;
+      if (!anchor.test(contents)) {
+        throw new Error(
+          "with-ios-modular-headers: could not find the `use_expo_modules!` anchor in the Podfile",
+        );
+      }
+      contents = contents.replace(anchor, `$1\n${modularPods}`);
+
+      fs.writeFileSync(podfilePath, contents);
+      return config;
+    },
+  ]);
+}
+
+module.exports = withIosModularHeaders;

--- a/apps/mobile/plugins/with-ios-modular-headers.js
+++ b/apps/mobile/plugins/with-ios-modular-headers.js
@@ -33,14 +33,24 @@ function withIosModularHeaders(config) {
       }
 
       let contents = fs.readFileSync(podfilePath, "utf-8");
-      if (contents.includes(":modular_headers => true")) {
+
+      // Check for the exact declarations we need — not any `:modular_headers => true`
+      // entry — so an unrelated modular-headers pod can't make us skip the fix, and a
+      // partially-patched Podfile still gets the missing pod(s) added.
+      const requiredPods = [
+        "pod 'GoogleUtilities', :modular_headers => true",
+        "pod 'RecaptchaInterop', :modular_headers => true",
+      ];
+      const missingPods = requiredPods.filter((declaration) => !contents.includes(declaration));
+      if (missingPods.length === 0) {
         return config; // already patched
       }
 
       const modularPods = [
-        "  # Google Sign-In's AppCheckCore (Swift) requires these to expose Clang modules.",
-        "  pod 'GoogleUtilities', :modular_headers => true",
-        "  pod 'RecaptchaInterop', :modular_headers => true",
+        ...(missingPods.length === requiredPods.length
+          ? ["  # Google Sign-In's AppCheckCore (Swift) requires these to expose Clang modules."]
+          : []),
+        ...missingPods.map((declaration) => `  ${declaration}`),
       ].join("\n");
 
       // Insert just after `use_expo_modules!` inside the app target.


### PR DESCRIPTION
## Problem

Every iOS release build failed at `pod install` on a clean prebuild:

```
The Swift pod `AppCheckCore` depends upon `GoogleUtilities` and `RecaptchaInterop`,
which do not define modules.
bundle exec pod install --repo-update --ansi exited with non-zero code: 1
```

`@react-native-google-signin/google-signin` pulls in `AppCheckCore` (a Swift pod); its transitive deps `GoogleUtilities` and `RecaptchaInterop` don't define Clang modules, so CocoaPods can't integrate them into the Swift target as static libraries. This is a **pre-existing** iOS blocker (the RN-codegen failure fixed in #582 was surfacing first and masking it) — it's unrelated to app code.

## Fix

Add a local Expo config plugin `apps/mobile/plugins/with-ios-modular-headers.js` (mirroring the existing `with-ios-swift-concurrency` plugin) that patches the generated Podfile to declare the two offending transitive pods with `:modular_headers => true`:

```ruby
pod 'GoogleUtilities', :modular_headers => true
pod 'RecaptchaInterop', :modular_headers => true
```

This generates the module maps `AppCheckCore` needs, **without** forcing `use_modular_headers!` across the whole project (which would apply modular headers to every pod, including React Native's). The `ios/` project is regenerated on every `expo prebuild`, so this has to be a config plugin, not a Podfile edit.

## Verification

- `pod install` now completes: **"Pod installation complete! 121 total pods"** (was exit 1).
- A full `fastlane ios beta` build signs the IPA and **uploads to TestFlight** (v1.3.0, build 29) — validated end-to-end before this PR.

With this + #582, all three betas are shipped: macOS build 47, Android internal build 38, iOS TestFlight build 29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS build compatibility by configuring required CocoaPods dependencies with modular headers.
  * Prevented duplicate Podfile configuration during repeated prebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->