### PR TITLE
fix(mobile): target TestFlight release notes at the exact iOS build

### DIFF
--- a/apps/mobile/fastlane/Fastfile
+++ b/apps/mobile/fastlane/Fastfile
@@ -61,10 +61,18 @@ def run_in_project(*args)
   end
 end
 
-def post_release_notes(platform:, max_chars:)
+# `build` is the iOS build number (nil for android). It is forwarded to
+# post-release-notes.mjs as --build so TestFlight notes target that exact iOS
+# build — macOS + iOS share one App Store Connect app, so "the newest build"
+# alone can resolve to a macOS (desktop) build.
+def post_release_notes(platform:, max_chars:, build: nil)
   Dir.chdir(PROJECT_ROOT) do
     notes = sh("bash", "scripts/generate-release-notes.sh", "--max-chars", max_chars.to_s).strip
-    sh("node", "scripts/post-release-notes.mjs", "--platform", platform, "--notes", notes) unless notes.empty?
+    next if notes.empty?
+
+    cmd = ["node", "scripts/post-release-notes.mjs", "--platform", platform, "--notes", notes]
+    cmd += ["--build", build.to_s] unless build.nil? || build.to_s.empty?
+    sh(*cmd)
   end
 rescue StandardError => e
   UI.important("Release notes posting failed (non-fatal): #{e.message}")
@@ -249,8 +257,10 @@ platform :ios do
       )
     end
 
-    # Post release notes
-    post_release_notes(platform: "ios", max_chars: 4000)
+    # Post release notes for THIS iOS build (not just the newest build in the
+    # shared macOS+iOS ASC app). post-release-notes.mjs polls until the build is
+    # indexed, so the upload above needn't block on full processing.
+    post_release_notes(platform: "ios", max_chars: 4000, build: new_build_number)
 
     # Phase G: comment "Now live" on closed support issues for this build.
     # TestFlight (beta) and the App Store (production) ship the same build

--- a/apps/mobile/scripts/post-release-notes.mjs
+++ b/apps/mobile/scripts/post-release-notes.mjs
@@ -29,14 +29,18 @@ import { pathToFileURL } from "node:url";
 
 const VALID_PLATFORMS = ["android", "ios", "all"];
 
-function parseArgs(argv) {
-  const platformIdx = argv.indexOf("--platform");
-  const notesIdx = argv.indexOf("--notes");
-  const buildIdx = argv.indexOf("--build");
+export function parseArgs(argv) {
+  // Return the token after `flag`, but treat a missing value or the next flag as
+  // absent — otherwise `--notes --build 29` would swallow `--build` as the notes.
+  const valueAfter = (flag) => {
+    const index = argv.indexOf(flag);
+    const value = index === -1 ? undefined : argv[index + 1];
+    return value && !value.startsWith("--") ? value : "";
+  };
   return {
-    platform: platformIdx !== -1 ? argv[platformIdx + 1] : "all",
-    notes: notesIdx !== -1 ? argv[notesIdx + 1] : "",
-    build: buildIdx !== -1 ? argv[buildIdx + 1] : "",
+    platform: valueAfter("--platform") || "all",
+    notes: valueAfter("--notes"),
+    build: valueAfter("--build"),
   };
 }
 
@@ -174,6 +178,12 @@ function generateAscJwt(keyId, issuerId, privateKeyP8) {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// Bound every App Store Connect request so a hung socket can't stall the release
+// step indefinitely (the retry cap only limits attempts, not a single request).
+const ASC_REQUEST_TIMEOUT_MS = 30_000;
+const ascFetch = (url, options = {}) =>
+  fetch(url, { ...options, signal: AbortSignal.timeout(ASC_REQUEST_TIMEOUT_MS) });
+
 /**
  * Flatten an App Store Connect `/builds` response (data + included) into
  * `{ id, version, uploadedDate, platform }` records. `platform` comes from the
@@ -291,7 +301,7 @@ async function postTestFlightNotes(releaseNotes, buildNumber) {
   const maxAttempts = buildNumber ? 15 : 1;
   let target = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const buildsRes = await fetch(buildsUrl, { headers });
+    const buildsRes = await ascFetch(buildsUrl, { headers });
     if (!buildsRes.ok) {
       throw new Error(`List builds failed: ${buildsRes.status} ${await buildsRes.text()}`);
     }
@@ -317,7 +327,7 @@ async function postTestFlightNotes(releaseNotes, buildNumber) {
   const buildId = target.id;
 
   // 2. Check if a betaBuildLocalization already exists for en-US
-  const locRes = await fetch(
+  const locRes = await ascFetch(
     `${baseUrl}/builds/${buildId}/betaBuildLocalizations?fields[betaBuildLocalizations]=locale,whatsNew`,
     { headers },
   );
@@ -331,7 +341,7 @@ async function postTestFlightNotes(releaseNotes, buildNumber) {
 
   if (existing) {
     // 3a. Update existing localization
-    const updateRes = await fetch(`${baseUrl}/betaBuildLocalizations/${existing.id}`, {
+    const updateRes = await ascFetch(`${baseUrl}/betaBuildLocalizations/${existing.id}`, {
       method: "PATCH",
       headers,
       body: JSON.stringify({
@@ -347,7 +357,7 @@ async function postTestFlightNotes(releaseNotes, buildNumber) {
     }
   } else {
     // 3b. Create new localization
-    const createRes = await fetch(`${baseUrl}/betaBuildLocalizations`, {
+    const createRes = await ascFetch(`${baseUrl}/betaBuildLocalizations`, {
       method: "POST",
       headers,
       body: JSON.stringify({
@@ -377,6 +387,12 @@ async function main() {
   }
   if (!VALID_PLATFORMS.includes(platform)) {
     console.error(`Error: --platform must be one of: ${VALID_PLATFORMS.join(", ")}`);
+    process.exit(1);
+  }
+  // Require an explicit build for TestFlight so notes target THAT iOS build; the
+  // newest-iOS fallback could otherwise update an unintended build's metadata.
+  if ((platform === "ios" || platform === "all") && !build) {
+    console.error("Error: --build is required when posting TestFlight (iOS) notes");
     process.exit(1);
   }
 

--- a/apps/mobile/scripts/post-release-notes.mjs
+++ b/apps/mobile/scripts/post-release-notes.mjs
@@ -3,7 +3,12 @@
  * Post release notes to Google Play and/or App Store Connect (TestFlight).
  *
  * Usage:
- *   node post-release-notes.mjs --platform android|ios|all --notes "Release notes text"
+ *   node post-release-notes.mjs --platform android|ios|all --notes "Release notes text" [--build N]
+ *
+ * --build is the iOS build number just uploaded. It is REQUIRED for correct
+ * TestFlight targeting: macOS (desktop) and iOS ship under the same App Store
+ * Connect app (eu.drafto.mobile), so without an exact build match the "newest
+ * uploaded build" can be a macOS build and the iOS notes land on the wrong build.
  *
  * Environment variables:
  *   Google Play (android):
@@ -20,22 +25,19 @@
 
 import { createSign } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
-const args = process.argv.slice(2);
-const platformIdx = args.indexOf("--platform");
-const notesIdx = args.indexOf("--notes");
-const platform = platformIdx !== -1 ? args[platformIdx + 1] : "all";
-const notes = notesIdx !== -1 ? args[notesIdx + 1] : "";
+const VALID_PLATFORMS = ["android", "ios", "all"];
 
-if (!notes) {
-  console.error("Error: --notes is required");
-  process.exit(1);
-}
-
-const validPlatforms = ["android", "ios", "all"];
-if (!validPlatforms.includes(platform)) {
-  console.error(`Error: --platform must be one of: ${validPlatforms.join(", ")}`);
-  process.exit(1);
+function parseArgs(argv) {
+  const platformIdx = argv.indexOf("--platform");
+  const notesIdx = argv.indexOf("--notes");
+  const buildIdx = argv.indexOf("--build");
+  return {
+    platform: platformIdx !== -1 ? argv[platformIdx + 1] : "all",
+    notes: notesIdx !== -1 ? argv[notesIdx + 1] : "",
+    build: buildIdx !== -1 ? argv[buildIdx + 1] : "",
+  };
 }
 
 // --- Google Play ---
@@ -170,7 +172,70 @@ function generateAscJwt(keyId, issuerId, privateKeyP8) {
   return `${header}.${payload}.${signature}`;
 }
 
-async function postTestFlightNotes(releaseNotes) {
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Flatten an App Store Connect `/builds` response (data + included) into
+ * `{ id, version, uploadedDate, platform }` records. `platform` comes from the
+ * build's preReleaseVersion ("IOS" | "MAC_OS") — the query MUST list
+ * `preReleaseVersion` in `fields[builds]` for that relationship linkage to be
+ * present. As a defensive fallback (linkage absent) we use the macOS-only build
+ * fields (computedMinMacOsVersion / lsMinimumSystemVersion) whose presence
+ * identifies a macOS build.
+ */
+export function normalizeBuilds(buildsResponse) {
+  const preReleaseById = new Map(
+    (buildsResponse.included || [])
+      .filter((item) => item.type === "preReleaseVersions")
+      .map((item) => [item.id, item.attributes]),
+  );
+  return (buildsResponse.data || []).map((build) => {
+    const attrs = build.attributes || {};
+    const preReleaseId = build.relationships?.preReleaseVersion?.data?.id;
+    const preReleasePlatform = preReleaseId
+      ? preReleaseById.get(preReleaseId)?.platform
+      : undefined;
+    const hasMacFields = Boolean(attrs.computedMinMacOsVersion || attrs.lsMinimumSystemVersion);
+    return {
+      id: build.id,
+      version: attrs.version,
+      uploadedDate: attrs.uploadedDate,
+      platform: preReleasePlatform || (hasMacFields ? "MAC_OS" : "IOS"),
+    };
+  });
+}
+
+/**
+ * Pick the iOS TestFlight build to attach "What to Test" notes to.
+ *
+ * macOS (desktop) and iOS ship under the SAME App Store Connect app, so "the
+ * newest uploaded build" can be a macOS build — which is exactly how iOS notes
+ * once overwrote a desktop build's notes. Always restrict to iOS.
+ *
+ * Build numbers are NOT unique: macOS and iOS increment independently, so the same
+ * number exists on both platforms (e.g. an old macOS build 29 alongside the new
+ * iOS build 29). When a build number is known we filter to iOS builds with that
+ * exact number; among the survivors (and in the no-number fallback) we pick the
+ * most recently uploaded so a reused number can't resolve to a stale build.
+ *
+ * @param {{id: string, version: string, uploadedDate?: string, platform: string}[]} builds
+ * @param {{buildNumber?: string|number}} [opts]
+ */
+export function selectTestFlightBuild(builds, { buildNumber } = {}) {
+  let candidates = builds.filter((build) => build.platform === "IOS");
+  if (buildNumber !== undefined && buildNumber !== null && String(buildNumber) !== "") {
+    candidates = candidates.filter((build) => String(build.version) === String(buildNumber));
+  }
+  if (candidates.length === 0) {
+    return null;
+  }
+  const uploadedAt = (build) => (build.uploadedDate ? Date.parse(build.uploadedDate) : 0);
+  return candidates.reduce((newest, build) =>
+    uploadedAt(build) > uploadedAt(newest) ? build : newest,
+  );
+}
+
+async function postTestFlightNotes(releaseNotes, buildNumber) {
   const keyId = process.env.ASC_API_KEY_ID;
   const issuerId = process.env.ASC_API_ISSUER_ID;
   const privateKeyP8 =
@@ -203,24 +268,53 @@ async function postTestFlightNotes(releaseNotes) {
     "Content-Type": "application/json",
   };
 
-  // 1. Find the latest build (most recent preReleaseVersion).
-  // Uses the top-level /v1/builds endpoint because the relationship endpoint /v1/apps/{id}/builds
-  // no longer accepts the `sort` query parameter.
-  const buildsRes = await fetch(
-    `${baseUrl}/builds?filter[app]=${appId}&sort=-uploadedDate&limit=1&fields[builds]=version,processingState`,
-    { headers },
-  );
-  if (!buildsRes.ok) {
-    throw new Error(`List builds failed: ${buildsRes.status} ${await buildsRes.text()}`);
+  // 1. Find the iOS build to attach notes to. macOS + iOS share this ASC app, so
+  // we filter to iOS and match the exact build number. A freshly uploaded build
+  // may still be processing / not yet indexed (the lane uploads with
+  // skip_waiting_for_build_processing), so poll until it appears.
+  //
+  // When the build number is known, filter by it directly (`filter[version]`)
+  // rather than sorting by uploadedDate: a still-processing build has a null
+  // uploadedDate and sorts LAST, so with many historical builds it could fall off
+  // a paged newest-first list entirely. Uses the top-level /v1/builds endpoint
+  // because the relationship endpoint /v1/apps/{id}/builds no longer accepts these
+  // query params; include preReleaseVersion so we can read each build's platform.
+  // `preReleaseVersion` MUST be in fields[builds] or ASC omits the relationship
+  // linkage and platform can't be resolved from the include; uploadedDate breaks
+  // ties when a build number is reused; the macOS-only fields are a fallback.
+  const commonFields =
+    `&fields[builds]=version,uploadedDate,processingState,preReleaseVersion,computedMinMacOsVersion,lsMinimumSystemVersion` +
+    `&include=preReleaseVersion&fields[preReleaseVersions]=platform`;
+  const buildsUrl = buildNumber
+    ? `${baseUrl}/builds?filter[app]=${appId}&filter[version]=${encodeURIComponent(buildNumber)}${commonFields}`
+    : `${baseUrl}/builds?filter[app]=${appId}&sort=-uploadedDate&limit=20${commonFields}`;
+  const maxAttempts = buildNumber ? 15 : 1;
+  let target = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const buildsRes = await fetch(buildsUrl, { headers });
+    if (!buildsRes.ok) {
+      throw new Error(`List builds failed: ${buildsRes.status} ${await buildsRes.text()}`);
+    }
+    target = selectTestFlightBuild(normalizeBuilds(await buildsRes.json()), { buildNumber });
+    if (target || attempt === maxAttempts) {
+      break;
+    }
+    console.log(
+      `TestFlight: iOS build ${buildNumber} not indexed yet (attempt ${attempt}/${maxAttempts}); retrying in 20s…`,
+    );
+    await sleep(20_000);
   }
-  const buildsData = await buildsRes.json();
 
-  if (!buildsData.data || buildsData.data.length === 0) {
-    console.error("Skipping TestFlight: no builds found");
+  if (!target) {
+    console.error(
+      buildNumber
+        ? `Skipping TestFlight: iOS build ${buildNumber} not found for app ${appId} after ${maxAttempts} attempts`
+        : "Skipping TestFlight: no iOS builds found",
+    );
     return;
   }
 
-  const buildId = buildsData.data[0].id;
+  const buildId = target.id;
 
   // 2. Check if a betaBuildLocalization already exists for en-US
   const locRes = await fetch(
@@ -269,14 +363,23 @@ async function postTestFlightNotes(releaseNotes) {
     }
   }
 
-  console.log(
-    `TestFlight: "What to Test" updated for build ${buildsData.data[0].attributes.version}`,
-  );
+  console.log(`TestFlight: "What to Test" updated for iOS build ${target.version}`);
 }
 
 // --- Main ---
 
 async function main() {
+  const { platform, notes, build } = parseArgs(process.argv.slice(2));
+
+  if (!notes) {
+    console.error("Error: --notes is required");
+    process.exit(1);
+  }
+  if (!VALID_PLATFORMS.includes(platform)) {
+    console.error(`Error: --platform must be one of: ${VALID_PLATFORMS.join(", ")}`);
+    process.exit(1);
+  }
+
   const errors = [];
 
   if (platform === "android" || platform === "all") {
@@ -290,7 +393,7 @@ async function main() {
 
   if (platform === "ios" || platform === "all") {
     try {
-      await postTestFlightNotes(notes);
+      await postTestFlightNotes(notes, build);
     } catch (err) {
       console.error(`TestFlight error: ${err.message}`);
       errors.push(err);
@@ -302,4 +405,7 @@ async function main() {
   }
 }
 
-main();
+// Only run when invoked directly (not when imported by tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/__tests__/post-release-notes-select.test.mjs
+++ b/scripts/__tests__/post-release-notes-select.test.mjs
@@ -1,0 +1,181 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeBuilds,
+  selectTestFlightBuild,
+} from "../../apps/mobile/scripts/post-release-notes.mjs";
+
+// Newest-builds fixture (the `sort=-uploadedDate` query): macOS (desktop) and iOS
+// builds coexist under ONE shared App Store Connect app (eu.drafto.mobile). This
+// is the exact shape the bug hinged on — a macOS build sorted newest while an iOS
+// build was the one actually being released.
+const sharedAppBuilds = {
+  data: [
+    {
+      id: "build-mac-47",
+      attributes: {
+        version: "47",
+        uploadedDate: "2026-07-14T14:09:33-07:00",
+        computedMinMacOsVersion: "12.0",
+      },
+      relationships: { preReleaseVersion: { data: { id: "pr-mac" } } },
+    },
+    {
+      id: "build-ios-29",
+      attributes: { version: "29", uploadedDate: "2026-07-15T09:41:44-07:00" },
+      relationships: { preReleaseVersion: { data: { id: "pr-ios" } } },
+    },
+    {
+      id: "build-ios-28",
+      attributes: { version: "28", uploadedDate: "2026-06-30T10:00:00-07:00" },
+      relationships: { preReleaseVersion: { data: { id: "pr-ios" } } },
+    },
+  ],
+  included: [
+    { type: "preReleaseVersions", id: "pr-mac", attributes: { platform: "MAC_OS" } },
+    { type: "preReleaseVersions", id: "pr-ios", attributes: { platform: "IOS" } },
+  ],
+};
+
+// `filter[version]=29` fixture — mirrors the LIVE ASC response: build number 29
+// exists on BOTH platforms (macOS passed through 29 months ago), so an exact
+// build-number filter returns two builds and platform must disambiguate.
+const buildNumber29 = {
+  data: [
+    {
+      id: "build-ios-29",
+      attributes: { version: "29", uploadedDate: "2026-07-15T09:41:44-07:00" },
+      relationships: { preReleaseVersion: { data: { id: "pr-ios" } } },
+    },
+    {
+      id: "build-mac-29-old",
+      attributes: {
+        version: "29",
+        uploadedDate: "2026-06-22T13:42:57-07:00",
+        computedMinMacOsVersion: "12.0",
+      },
+      relationships: { preReleaseVersion: { data: { id: "pr-mac" } } },
+    },
+  ],
+  included: [
+    { type: "preReleaseVersions", id: "pr-ios", attributes: { platform: "IOS" } },
+    { type: "preReleaseVersions", id: "pr-mac", attributes: { platform: "MAC_OS" } },
+  ],
+};
+
+describe("normalizeBuilds", () => {
+  it("reads platform from the preReleaseVersion include", () => {
+    const builds = normalizeBuilds(sharedAppBuilds);
+    assert.deepEqual(builds, [
+      {
+        id: "build-mac-47",
+        version: "47",
+        uploadedDate: "2026-07-14T14:09:33-07:00",
+        platform: "MAC_OS",
+      },
+      {
+        id: "build-ios-29",
+        version: "29",
+        uploadedDate: "2026-07-15T09:41:44-07:00",
+        platform: "IOS",
+      },
+      {
+        id: "build-ios-28",
+        version: "28",
+        uploadedDate: "2026-06-30T10:00:00-07:00",
+        platform: "IOS",
+      },
+    ]);
+  });
+
+  it("falls back to macOS-only build fields when the include linkage is absent", () => {
+    const builds = normalizeBuilds({
+      data: [
+        {
+          id: "m",
+          attributes: { version: "50", lsMinimumSystemVersion: "12.0" },
+          relationships: {},
+        },
+        { id: "i", attributes: { version: "51" }, relationships: {} },
+      ],
+      included: [],
+    });
+    assert.equal(builds.find((b) => b.id === "m").platform, "MAC_OS");
+    assert.equal(builds.find((b) => b.id === "i").platform, "IOS");
+  });
+
+  it("tolerates a missing data/included array", () => {
+    assert.deepEqual(normalizeBuilds({}), []);
+  });
+});
+
+describe("selectTestFlightBuild", () => {
+  it("regression: targets the iOS build by number, never the newer macOS build", () => {
+    // Before the fix, the script took the newest uploaded build (macOS 47) and
+    // wrote the iOS notes onto it, leaving the iOS build with none.
+    const target = selectTestFlightBuild(normalizeBuilds(sharedAppBuilds), { buildNumber: "29" });
+    assert.equal(target.id, "build-ios-29");
+    assert.equal(target.platform, "IOS");
+    assert.equal(target.version, "29");
+  });
+
+  it("picks the iOS build when the same build number exists on macOS (live-data shape)", () => {
+    // filter[version]=29 returns iOS 29 AND an old macOS 29; must pick iOS.
+    const target = selectTestFlightBuild(normalizeBuilds(buildNumber29), { buildNumber: "29" });
+    assert.equal(target.id, "build-ios-29");
+    assert.equal(target.platform, "IOS");
+  });
+
+  it("accepts a numeric build number", () => {
+    assert.equal(
+      selectTestFlightBuild(normalizeBuilds(sharedAppBuilds), { buildNumber: 28 }).id,
+      "build-ios-28",
+    );
+  });
+
+  it("never crosses to a macOS build even when its number matches", () => {
+    // "47" is a macOS build number; there is no iOS 47 → no target (safe skip),
+    // rather than silently writing to the macOS build.
+    assert.equal(
+      selectTestFlightBuild(normalizeBuilds(sharedAppBuilds), { buildNumber: "47" }),
+      null,
+    );
+  });
+
+  it("breaks ties on a reused iOS build number by newest upload", () => {
+    const dupes = [
+      {
+        id: "ios-29-old",
+        version: "29",
+        platform: "IOS",
+        uploadedDate: "2026-05-01T00:00:00-07:00",
+      },
+      {
+        id: "ios-29-new",
+        version: "29",
+        platform: "IOS",
+        uploadedDate: "2026-07-15T09:41:44-07:00",
+      },
+    ];
+    assert.equal(selectTestFlightBuild(dupes, { buildNumber: "29" }).id, "ios-29-new");
+  });
+
+  it("falls back to the newest iOS build when no number is given", () => {
+    // Newest overall is macOS 47; newest IOS is 29 (uploaded after 28).
+    assert.equal(selectTestFlightBuild(normalizeBuilds(sharedAppBuilds), {}).id, "build-ios-29");
+  });
+
+  it("returns null when there are no iOS builds", () => {
+    const macOnly = normalizeBuilds({
+      data: [
+        {
+          id: "build-mac-47",
+          attributes: { version: "47", computedMinMacOsVersion: "12.0" },
+          relationships: { preReleaseVersion: { data: { id: "pr-mac" } } },
+        },
+      ],
+      included: [{ type: "preReleaseVersions", id: "pr-mac", attributes: { platform: "MAC_OS" } }],
+    });
+    assert.equal(selectTestFlightBuild(macOnly, { buildNumber: "29" }), null);
+  });
+});

--- a/scripts/__tests__/post-release-notes-select.test.mjs
+++ b/scripts/__tests__/post-release-notes-select.test.mjs
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   normalizeBuilds,
+  parseArgs,
   selectTestFlightBuild,
 } from "../../apps/mobile/scripts/post-release-notes.mjs";
 
@@ -62,6 +63,31 @@ const buildNumber29 = {
     { type: "preReleaseVersions", id: "pr-mac", attributes: { platform: "MAC_OS" } },
   ],
 };
+
+describe("parseArgs", () => {
+  it("parses a full invocation", () => {
+    assert.deepEqual(parseArgs(["--platform", "ios", "--notes", "Fixed things", "--build", "29"]), {
+      platform: "ios",
+      notes: "Fixed things",
+      build: "29",
+    });
+  });
+
+  it("does not consume the next flag as a value", () => {
+    // `--notes --build 29` must NOT treat "--build" as the notes text.
+    const parsed = parseArgs(["--platform", "ios", "--notes", "--build", "29"]);
+    assert.equal(parsed.notes, "");
+    assert.equal(parsed.build, "29");
+  });
+
+  it("defaults platform to all and leaves notes/build empty when absent", () => {
+    assert.deepEqual(parseArgs([]), { platform: "all", notes: "", build: "" });
+  });
+
+  it("treats a trailing flag with no value as empty", () => {
+    assert.equal(parseArgs(["--notes"]).notes, "");
+  });
+});
 
 describe("normalizeBuilds", () => {
   it("reads platform from the preReleaseVersion include", () => {


### PR DESCRIPTION
## What & why

The macOS desktop TestFlight build 47 showed a giant whole-history "What to Test" that even listed **mobile-only** commits (`#582 "pin react-native"`, `#300 "mobile: add primitives"`) — commits a desktop-scoped generator can't emit. Investigation ([diagnosis](https://github.com/JakubAnderwald/drafto/issues/474)) showed why:

macOS (desktop) and iOS ship under **one** App Store Connect app (`eu.drafto.mobile`). `apps/mobile/scripts/post-release-notes.mjs` chose the build to attach iOS notes to with:

```js
`/builds?filter[app]=${appId}&sort=-uploadedDate&limit=1`   // newest build — ANY platform
const buildId = buildsData.data[0].id;
```

No platform filter. The iOS lane uploads with `skip_waiting_for_build_processing: true`, so the just-uploaded iOS build 29 was still processing (no `uploadedDate`) and the "newest uploaded build" resolved to the **macOS build 47**. The mobile-generated notes were written onto build 47, and **iOS build 29 shipped with empty notes**.

## Fix

- **Fastfile** (`apps/mobile/fastlane/Fastfile`): the ios lane passes the build number just uploaded (`--build new_build_number`); `post_release_notes` gains an optional `build:` param. Android is unchanged (no `--build`).
- **Script** (`apps/mobile/scripts/post-release-notes.mjs`): when a build number is known, query ASC by `filter[version]`, resolve platform from the `preReleaseVersion` include, filter to **iOS**, and pick the **newest iOS match**. Poll until the build is indexed (handles the `skip_waiting_for_build_processing` upload without blocking it on full processing). Extracted pure `normalizeBuilds` / `selectTestFlightBuild`; guarded `main()` so the module is import-safe.

Two facts the live App Store Connect API forced into the design (both covered by tests):
1. **Build numbers repeat** — an old macOS build 29 coexists with the new iOS build 29, so `filter[version]` returns both; the iOS filter + newest-upload tiebreak disambiguate.
2. `preReleaseVersion` **must** be listed in `fields[builds]` or ASC drops the relationship linkage and platform can't be resolved.

## Verification

- New unit tests (`scripts/__tests__/post-release-notes-select.test.mjs`, run by the Scripts Tests job): 10 cases incl. the exact shared-app / duplicate-build-number shape. Full scripts suite: 524 pass.
- **Live end-to-end** against App Store Connect (read-only): the exact query the script now issues resolves `--build 29` → the real **iOS** build 29 (`ef6e4df7`), and `--build 47` (a macOS number) → `null` (safe skip, never clobbers a macOS build).

## Scope

Code-only, per request — no live "What to Test" was rewritten. macOS build 47 / iOS build 29 keep their current (swapped) beta notes; this stops it recurring on the next release. Desktop's own `post-release-notes.mjs` is unaffected — it already filters to macOS builds, so it can't cross-contaminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - iOS release notes now target the exact TestFlight build that was uploaded.
  - Build selection correctly distinguishes iOS builds from shared macOS/iOS app builds.
  - Release-note posting waits for the requested build to become available.

- **Bug Fixes**
  - Prevented iOS notes from being applied to the wrong platform or build.
  - Improved handling when build information is incomplete or unavailable.

- **Tests**
  - Added coverage for platform detection, build matching, fallback behavior, and reused build numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->