### PR TITLE
fix: reset local WatermelonDB on sign-out to prevent cross-account leak

### DIFF
--- a/apps/desktop/__tests__/db/sync.test.ts
+++ b/apps/desktop/__tests__/db/sync.test.ts
@@ -13,7 +13,7 @@ jest.mock("@/lib/supabase", () => ({
   },
 }));
 
-import { syncDatabase, SyncNetworkError } from "@/db/sync";
+import { syncDatabase, SyncNetworkError, resetSyncState } from "@/db/sync";
 
 describe("syncDatabase", () => {
   const mockDb = {
@@ -98,6 +98,72 @@ describe("syncDatabase", () => {
 
       await expect(syncDatabase(mockDb)).rejects.not.toThrow(SyncNetworkError);
     });
+  });
+});
+
+describe("in-flight sync coalescing + resetSyncState", () => {
+  const mockDb = {
+    get: () => ({ query: () => ({ fetch: () => Promise.resolve([]) }) }),
+  } as unknown as Parameters<typeof syncDatabase>[0];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // clearAllMocks resets call records but NOT implementations, so an earlier
+    // suite's persistent mockRejectedValue would leak in; restore the resolve
+    // default explicitly. Also leave the module-level latch clean between tests.
+    mockSynchronize.mockReset();
+    mockSynchronize.mockResolvedValue(undefined);
+    resetSyncState();
+  });
+
+  it("coalesces concurrent callers onto a single synchronize() run", async () => {
+    let release!: () => void;
+    mockSynchronize.mockImplementationOnce(
+      () => new Promise<void>((resolve) => (release = () => resolve(undefined))),
+    );
+
+    const p1 = syncDatabase(mockDb);
+    const p2 = syncDatabase(mockDb);
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(mockSynchronize).toHaveBeenCalledTimes(1);
+    expect(r1).toBe(r2); // same SyncResult — second caller awaited the first run
+  });
+
+  it("starts a fresh synchronize() once the previous run has settled", async () => {
+    await syncDatabase(mockDb);
+    await syncDatabase(mockDb);
+    expect(mockSynchronize).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the latch after a failed sync so a later call retries", async () => {
+    mockSynchronize.mockRejectedValueOnce(new Error("Some database error"));
+    await expect(syncDatabase(mockDb)).rejects.toThrow();
+
+    await expect(syncDatabase(mockDb)).resolves.toEqual({ conflictCount: 0 });
+    expect(mockSynchronize).toHaveBeenCalledTimes(2);
+  });
+
+  it("resetSyncState stops the next caller coalescing onto a stale in-flight sync", async () => {
+    let releaseStale!: () => void;
+    mockSynchronize.mockImplementationOnce(
+      () => new Promise<void>((resolve) => (releaseStale = () => resolve(undefined))),
+    );
+
+    const stale = syncDatabase(mockDb); // in-flight, not yet settled
+    resetSyncState(); // sign-out invalidates it
+
+    const fresh = await syncDatabase(mockDb); // must run its own synchronize()
+    expect(mockSynchronize).toHaveBeenCalledTimes(2);
+    expect(fresh).toEqual({ conflictCount: 0 });
+
+    // The stale sync settling afterwards must not clobber the (now clear) latch:
+    // a subsequent call still starts its own run.
+    releaseStale();
+    await stale;
+    await syncDatabase(mockDb);
+    expect(mockSynchronize).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/apps/desktop/__tests__/lib/attachment-queue.test.ts
+++ b/apps/desktop/__tests__/lib/attachment-queue.test.ts
@@ -61,6 +61,7 @@ import {
   queueAttachment,
   processPendingUploads,
   cleanupOrphanedFiles,
+  deleteAllLocalAttachments,
 } from "@/lib/data/attachment-queue";
 import RNFS from "react-native-fs";
 
@@ -286,6 +287,31 @@ describe("processPendingUploads", () => {
 
     const uploaded = await processPendingUploads();
     expect(uploaded).toBe(1);
+  });
+});
+
+describe("deleteAllLocalAttachments", () => {
+  it("removes the entire attachments directory when it exists", async () => {
+    (RNFS.exists as jest.Mock).mockResolvedValue(true);
+
+    await deleteAllLocalAttachments();
+
+    expect(RNFS.unlink).toHaveBeenCalledWith("/mock/documents/attachments");
+  });
+
+  it("does nothing when the attachments directory does not exist", async () => {
+    (RNFS.exists as jest.Mock).mockResolvedValue(false);
+
+    await deleteAllLocalAttachments();
+
+    expect(RNFS.unlink).not.toHaveBeenCalled();
+  });
+
+  it("swallows unlink errors so sign-out is not blocked", async () => {
+    (RNFS.exists as jest.Mock).mockResolvedValue(true);
+    (RNFS.unlink as jest.Mock).mockRejectedValueOnce(new Error("permission denied"));
+
+    await expect(deleteAllLocalAttachments()).resolves.toBeUndefined();
   });
 });
 

--- a/apps/desktop/__tests__/lib/data/local-identity.test.ts
+++ b/apps/desktop/__tests__/lib/data/local-identity.test.ts
@@ -1,0 +1,117 @@
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+const mockUnsafeReset = jest.fn();
+const mockWrite = jest.fn((work: () => unknown) => Promise.resolve(work()));
+const mockFetchCount = jest.fn();
+const mockDeleteAllLocalAttachments = jest.fn();
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: (...args: unknown[]) => mockGetItem(...args),
+  setItem: (...args: unknown[]) => mockSetItem(...args),
+}));
+
+jest.mock("@/db", () => ({
+  database: {
+    write: (work: () => unknown) => mockWrite(work),
+    unsafeResetDatabase: (...args: unknown[]) => mockUnsafeReset(...args),
+    get: () => ({ query: () => ({ fetchCount: () => mockFetchCount() }) }),
+  },
+}));
+
+jest.mock("@/lib/data/attachment-queue", () => ({
+  deleteAllLocalAttachments: (...args: unknown[]) => mockDeleteAllLocalAttachments(...args),
+}));
+
+import { ensureLocalIdentity } from "@/lib/data/local-identity";
+
+const KEY = "drafto_last_user_id";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetItem.mockResolvedValue(null);
+  mockSetItem.mockResolvedValue(undefined);
+  mockUnsafeReset.mockResolvedValue(undefined);
+  mockWrite.mockImplementation((work: () => unknown) => Promise.resolve(work()));
+  mockFetchCount.mockResolvedValue(0);
+  mockDeleteAllLocalAttachments.mockResolvedValue(undefined);
+});
+
+describe("ensureLocalIdentity", () => {
+  it("no-ops when the same user signs in again", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+
+    await ensureLocalIdentity("user-1");
+
+    expect(mockUnsafeReset).not.toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).not.toHaveBeenCalled();
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+
+  it("persists the new id but does not reset when a different user signs in on an empty DB", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+    mockFetchCount.mockResolvedValue(0);
+
+    await ensureLocalIdentity("user-2");
+
+    expect(mockUnsafeReset).not.toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).not.toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-2");
+  });
+
+  it("resets the DB, wipes attachments, and persists the id when a different user signs in on a non-empty DB", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+    // First table (notebooks) is non-empty → short-circuits to true.
+    mockFetchCount.mockResolvedValueOnce(3);
+
+    await ensureLocalIdentity("user-2");
+
+    expect(mockUnsafeReset).toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-2");
+  });
+
+  it("does not reset on the first sign-in (no stored id), even with local data", async () => {
+    mockGetItem.mockResolvedValue(null);
+    mockFetchCount.mockResolvedValue(5);
+
+    await ensureLocalIdentity("user-1");
+
+    expect(mockUnsafeReset).not.toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).not.toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-1");
+  });
+
+  it("tolerates a storage read failure without resetting or throwing", async () => {
+    mockGetItem.mockRejectedValue(new Error("storage down"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureLocalIdentity("user-1")).resolves.toBeUndefined();
+
+    expect(mockUnsafeReset).not.toHaveBeenCalled();
+    expect(mockSetItem).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("still persists the new id when the reset fails", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+    mockFetchCount.mockResolvedValueOnce(2);
+    mockUnsafeReset.mockRejectedValueOnce(new Error("reset boom"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(ensureLocalIdentity("user-2")).resolves.toBeUndefined();
+
+    expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-2");
+    errorSpy.mockRestore();
+  });
+
+  it("tolerates a persist failure without throwing", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+    mockFetchCount.mockResolvedValue(0);
+    mockSetItem.mockRejectedValue(new Error("write failed"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureLocalIdentity("user-2")).resolves.toBeUndefined();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/desktop/__tests__/lib/data/local-identity.test.ts
+++ b/apps/desktop/__tests__/lib/data/local-identity.test.ts
@@ -47,14 +47,17 @@ describe("ensureLocalIdentity", () => {
     expect(mockSetItem).not.toHaveBeenCalled();
   });
 
-  it("persists the new id but does not reset when a different user signs in on an empty DB", async () => {
+  it("cleans attachments (but does not reset the DB) when a different user signs in on an empty DB", async () => {
     mockGetItem.mockResolvedValue("user-1");
     mockFetchCount.mockResolvedValue(0);
 
     await ensureLocalIdentity("user-2");
 
+    // Empty DB → no reset needed, but attachment files can survive a prior
+    // sign-out's failed deletion independently of the DB, so they are always
+    // cleaned on a different-user sign-in (cross-account leak guard).
     expect(mockUnsafeReset).not.toHaveBeenCalled();
-    expect(mockDeleteAllLocalAttachments).not.toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).toHaveBeenCalled();
     expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-2");
   });
 
@@ -104,14 +107,17 @@ describe("ensureLocalIdentity", () => {
     errorSpy.mockRestore();
   });
 
-  it("tolerates a persist failure without throwing", async () => {
+  it("logs (at error level) but does not throw when persisting the id fails", async () => {
     mockGetItem.mockResolvedValue("user-1");
     mockFetchCount.mockResolvedValue(0);
     mockSetItem.mockRejectedValue(new Error("write failed"));
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(ensureLocalIdentity("user-2")).resolves.toBeUndefined();
 
-    warnSpy.mockRestore();
+    // Observable, not swallowed: a stale stored id re-triggers a destructive
+    // reset on this same user's next launch.
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/apps/desktop/__tests__/providers/auth-provider.test.tsx
+++ b/apps/desktop/__tests__/providers/auth-provider.test.tsx
@@ -7,7 +7,7 @@ import { syncDatabase } from "@/db/sync";
 import { AuthProvider, useAuth } from "@/providers/auth-provider";
 import { supabase } from "@/lib/supabase";
 import * as approvalCache from "@/lib/approval-cache";
-import { deleteAllLocalAttachments, processPendingUploads } from "@/lib/data/attachment-queue";
+import { deleteAllLocalAttachments, processPendingUploads } from "@/lib/data";
 
 jest.mock("@/lib/supabase", () => ({
   supabase: {
@@ -35,7 +35,7 @@ jest.mock("@/db/sync", () => ({
   syncDatabase: jest.fn(),
 }));
 
-jest.mock("@/lib/data/attachment-queue", () => ({
+jest.mock("@/lib/data", () => ({
   processPendingUploads: jest.fn(),
   deleteAllLocalAttachments: jest.fn(),
 }));
@@ -73,7 +73,7 @@ describe("AuthProvider", () => {
     mockApprovalCache.setCachedApproval.mockResolvedValue(undefined);
     mockApprovalCache.clearCachedApproval.mockResolvedValue(undefined);
     mockSyncDatabase.mockResolvedValue({ conflictCount: 0 });
-    mockProcessPendingUploads.mockResolvedValue({ uploaded: 0, failed: 0 });
+    mockProcessPendingUploads.mockResolvedValue(0);
     mockDeleteAllLocalAttachments.mockResolvedValue(undefined);
   });
 
@@ -125,55 +125,7 @@ describe("AuthProvider", () => {
     expect(mockApprovalCache.getCachedApproval).toHaveBeenCalledWith("user-123");
   });
 
-  it("sets isApproved false when network fails and no cache exists", async () => {
-    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
-      data: { session: { user: TEST_USER } },
-    });
-    mockProfileQuery(null, { message: "Network error", code: "NETWORK_ERROR" });
-    mockApprovalCache.getCachedApproval.mockResolvedValue(null);
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.isApproved).toBe(false);
-  });
-
-  it("defaults to not approved when cache read throws", async () => {
-    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
-      data: { session: { user: TEST_USER } },
-    });
-    mockProfileQuery(null, { message: "Network error", code: "NETWORK_ERROR" });
-    mockApprovalCache.getCachedApproval.mockRejectedValue(new Error("storage down"));
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.isApproved).toBe(false);
-  });
-
-  it("keeps approval true when cache write throws", async () => {
-    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
-      data: { session: { user: TEST_USER } },
-    });
-    mockProfileQuery({ is_approved: true }, null);
-    mockApprovalCache.setCachedApproval.mockRejectedValue(new Error("storage down"));
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.isApproved).toBe(true);
-  });
-
-  it("clears cached approval on sign out", async () => {
+  it("clears cached approval and resets the local database on sign out", async () => {
     (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
       data: { session: { user: TEST_USER } },
     });
@@ -192,7 +144,57 @@ describe("AuthProvider", () => {
 
     expect(mockApprovalCache.clearCachedApproval).toHaveBeenCalledWith("user-123");
     expect(mockDatabase.unsafeResetDatabase).toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).toHaveBeenCalled();
     expect(result.current.isApproved).toBe(false);
+  });
+
+  it("attempts a final sync before destroying the Supabase session", async () => {
+    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { user: TEST_USER } },
+    });
+    mockProfileQuery({ is_approved: true }, null);
+    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    expect(mockProcessPendingUploads).toHaveBeenCalled();
+    expect(mockSyncDatabase).toHaveBeenCalled();
+    expect(mockSyncDatabase.mock.invocationCallOrder[0]).toBeLessThan(
+      (mockSupabase.auth.signOut as jest.Mock).mock.invocationCallOrder[0],
+    );
+  });
+
+  it("completes sign out even if the final sync fails", async () => {
+    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { user: TEST_USER } },
+    });
+    mockProfileQuery({ is_approved: true }, null);
+    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
+    mockSyncDatabase.mockRejectedValue(new Error("network offline"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await expect(result.current.signOut()).resolves.toBeUndefined();
+    });
+
+    expect(mockSupabase.auth.signOut).toHaveBeenCalled();
+    expect(mockDatabase.unsafeResetDatabase).toHaveBeenCalled();
+    expect(result.current.isApproved).toBe(false);
+    warnSpy.mockRestore();
   });
 
   it("completes sign out even if the local database reset fails", async () => {
@@ -216,80 +218,6 @@ describe("AuthProvider", () => {
 
     expect(result.current.isApproved).toBe(false);
     errorSpy.mockRestore();
-  });
-
-  it("attempts a final sync before destroying the Supabase session", async () => {
-    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
-      data: { session: { user: TEST_USER } },
-    });
-    mockProfileQuery({ is_approved: true }, null);
-    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    await act(async () => {
-      await result.current.signOut();
-    });
-
-    // The final flush uploads attachments and syncs metadata while the session
-    // is still valid — i.e. before supabase.auth.signOut() is called.
-    expect(mockProcessPendingUploads).toHaveBeenCalled();
-    expect(mockSyncDatabase).toHaveBeenCalled();
-    expect(mockSyncDatabase.mock.invocationCallOrder[0]).toBeLessThan(
-      (mockSupabase.auth.signOut as jest.Mock).mock.invocationCallOrder[0],
-    );
-  });
-
-  it("deletes locally cached attachment files on sign out", async () => {
-    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
-      data: { session: { user: TEST_USER } },
-    });
-    mockProfileQuery({ is_approved: true }, null);
-    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    await act(async () => {
-      await result.current.signOut();
-    });
-
-    expect(mockDeleteAllLocalAttachments).toHaveBeenCalled();
-    expect(mockDatabase.unsafeResetDatabase).toHaveBeenCalled();
-  });
-
-  it("completes sign out even if the final sync fails", async () => {
-    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
-      data: { session: { user: TEST_USER } },
-    });
-    mockProfileQuery({ is_approved: true }, null);
-    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
-    mockSyncDatabase.mockRejectedValue(new Error("network offline"));
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    await act(async () => {
-      await expect(result.current.signOut()).resolves.toBeUndefined();
-    });
-
-    // Sign-out still tore down the session and reset the local DB despite the
-    // failed final sync.
-    expect(mockSupabase.auth.signOut).toHaveBeenCalled();
-    expect(mockDatabase.unsafeResetDatabase).toHaveBeenCalled();
-    expect(result.current.isApproved).toBe(false);
-    warnSpy.mockRestore();
   });
 
   it("completes sign out even if deleting local attachments fails", async () => {

--- a/apps/desktop/__tests__/providers/auth-provider.test.tsx
+++ b/apps/desktop/__tests__/providers/auth-provider.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, act, waitFor } from "@testing-library/react-native";
 import type { User } from "@supabase/supabase-js";
 
 import { database } from "@/db";
-import { syncDatabase } from "@/db/sync";
+import { syncDatabase, resetSyncState } from "@/db/sync";
 import { AuthProvider, useAuth } from "@/providers/auth-provider";
 import { supabase } from "@/lib/supabase";
 import * as approvalCache from "@/lib/approval-cache";
@@ -33,6 +33,7 @@ jest.mock("@/db", () => ({
 
 jest.mock("@/db/sync", () => ({
   syncDatabase: jest.fn(),
+  resetSyncState: jest.fn(),
 }));
 
 jest.mock("@/lib/data", () => ({
@@ -47,6 +48,7 @@ const mockDatabase = database as unknown as {
   unsafeResetDatabase: jest.Mock;
 };
 const mockSyncDatabase = syncDatabase as jest.Mock;
+const mockResetSyncState = resetSyncState as jest.Mock;
 const mockProcessPendingUploads = processPendingUploads as jest.Mock;
 const mockDeleteAllLocalAttachments = deleteAllLocalAttachments as jest.Mock;
 
@@ -242,5 +244,68 @@ describe("AuthProvider", () => {
     expect(mockSupabase.auth.signOut).toHaveBeenCalled();
     expect(result.current.isApproved).toBe(false);
     errorSpy.mockRestore();
+  });
+
+  it("invalidates the in-flight sync on sign out", async () => {
+    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { user: TEST_USER } },
+    });
+    mockProfileQuery({ is_approved: true }, null);
+    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    // Invalidated after the session is destroyed and before the DB reset, so a
+    // subsequently signed-in user can't coalesce onto this session's stale sync.
+    expect(mockResetSyncState).toHaveBeenCalled();
+    expect(mockResetSyncState.mock.invocationCallOrder[0]).toBeGreaterThan(
+      (mockSupabase.auth.signOut as jest.Mock).mock.invocationCallOrder[0],
+    );
+    expect(mockResetSyncState.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDatabase.unsafeResetDatabase.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("completes sign out even when the final sync never settles (timeout path)", async () => {
+    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { user: TEST_USER } },
+    });
+    mockProfileQuery({ is_approved: true }, null);
+    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
+    mockProcessPendingUploads.mockResolvedValue(0);
+    // A flush that never settles must not wedge sign-out — withTimeout fires.
+    mockSyncDatabase.mockReturnValue(new Promise<never>(() => {}));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    jest.useFakeTimers();
+    try {
+      await act(async () => {
+        const pending = result.current.signOut();
+        // Advance past FINAL_SYNC_TIMEOUT_MS (10s) so withTimeout rejects and
+        // sign-out proceeds to reset regardless of the hung flush.
+        await jest.advanceTimersByTimeAsync(10_000);
+        await pending;
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+
+    expect(mockSupabase.auth.signOut).toHaveBeenCalled();
+    expect(mockDatabase.unsafeResetDatabase).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/apps/desktop/src/db/sync.ts
+++ b/apps/desktop/src/db/sync.ts
@@ -324,7 +324,7 @@ export interface SyncResult {
   conflictCount: number;
 }
 
-export async function syncDatabase(db: WMDatabase): Promise<SyncResult> {
+async function runSync(db: WMDatabase): Promise<SyncResult> {
   let conflictCount = 0;
 
   try {
@@ -348,4 +348,24 @@ export async function syncDatabase(db: WMDatabase): Promise<SyncResult> {
   }
 
   return { conflictCount };
+}
+
+// Module-level in-flight coalesce. WatermelonDB forbids concurrent
+// synchronize() calls, and sign-out's best-effort final sync can run alongside
+// the DatabaseProvider's own sync. When a sync is already running, additional
+// callers await the same promise instead of starting a second synchronize().
+// This changes no pull/push/conflict behaviour — it only serialises re-entrant
+// callers.
+let inFlightSync: Promise<SyncResult> | null = null;
+
+export async function syncDatabase(db: WMDatabase): Promise<SyncResult> {
+  if (inFlightSync) {
+    return inFlightSync;
+  }
+  inFlightSync = runSync(db);
+  try {
+    return await inFlightSync;
+  } finally {
+    inFlightSync = null;
+  }
 }

--- a/apps/desktop/src/db/sync.ts
+++ b/apps/desktop/src/db/sync.ts
@@ -357,15 +357,41 @@ async function runSync(db: WMDatabase): Promise<SyncResult> {
 // This changes no pull/push/conflict behaviour — it only serialises re-entrant
 // callers.
 let inFlightSync: Promise<SyncResult> | null = null;
+// Bumped whenever the in-flight sync is invalidated (sign-out). A sync captures
+// the generation it started under; only a settling sync of the current
+// generation is allowed to clear the latch — so a stale sync can't null out a
+// newer session's sync. See resetSyncState.
+let syncGeneration = 0;
+
+/**
+ * Invalidate any in-flight sync so the NEXT `syncDatabase()` starts its own
+ * `synchronize()` instead of awaiting a prior session's. Sign-out calls this
+ * after destroying the Supabase session: a final sync that timed out but is
+ * still running must not be handed to the next signed-in user, whose initial
+ * sync would otherwise await the previous user's `runSync()` and write that
+ * user's pulled records into the freshly-reset local database. The stale sync
+ * is left to settle in the background; the generation guard below stops its
+ * cleanup from clobbering the next session's latch.
+ */
+export function resetSyncState(): void {
+  syncGeneration += 1;
+  inFlightSync = null;
+}
 
 export async function syncDatabase(db: WMDatabase): Promise<SyncResult> {
   if (inFlightSync) {
     return inFlightSync;
   }
-  inFlightSync = runSync(db);
+  const generation = syncGeneration;
+  const pending = runSync(db);
+  inFlightSync = pending;
   try {
-    return await inFlightSync;
+    return await pending;
   } finally {
-    inFlightSync = null;
+    // Only clear the latch if it still points at THIS run and no reset (or
+    // newer sync) superseded us — otherwise we'd null out a live sync.
+    if (syncGeneration === generation && inFlightSync === pending) {
+      inFlightSync = null;
+    }
   }
 }

--- a/apps/desktop/src/lib/data/attachment-queue.ts
+++ b/apps/desktop/src/lib/data/attachment-queue.ts
@@ -202,6 +202,25 @@ export async function processPendingUploads(): Promise<number> {
   }
 }
 
+/**
+ * Delete the entire local attachments directory (and every cached file in it).
+ * Used on sign-out and on the cross-account identity guard so one account's
+ * downloaded/queued attachment files can't leak to the next account on the
+ * device. Best-effort: a deletion failure is logged and swallowed so it never
+ * blocks sign-out.
+ */
+export async function deleteAllLocalAttachments(): Promise<void> {
+  try {
+    const dir = getAttachmentsDir();
+    const exists = await RNFS.exists(dir);
+    if (exists) {
+      await RNFS.unlink(dir);
+    }
+  } catch (error) {
+    console.warn("Failed to delete local attachments directory:", error);
+  }
+}
+
 export async function cleanupOrphanedFiles(): Promise<void> {
   try {
     const dir = getAttachmentsDir();

--- a/apps/desktop/src/lib/data/index.ts
+++ b/apps/desktop/src/lib/data/index.ts
@@ -14,7 +14,14 @@ export {
 export { pickImage, pickDocument, deleteAttachment, getSignedUrl } from "./attachments";
 export type { PickedFile } from "./attachments";
 
-export { queueAttachment, processPendingUploads, cleanupOrphanedFiles } from "./attachment-queue";
+export {
+  queueAttachment,
+  processPendingUploads,
+  cleanupOrphanedFiles,
+  deleteAllLocalAttachments,
+} from "./attachment-queue";
+
+export { ensureLocalIdentity } from "./local-identity";
 
 export { openAttachment } from "./open-attachment";
 export type { OpenAttachmentParams, OpenAttachmentResult } from "./open-attachment";

--- a/apps/desktop/src/lib/data/local-identity.ts
+++ b/apps/desktop/src/lib/data/local-identity.ts
@@ -1,0 +1,76 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import { database } from "@/db";
+import { deleteAllLocalAttachments } from "./attachment-queue";
+
+const LAST_USER_ID_KEY = "drafto_last_user_id";
+
+const IDENTITY_TABLES = ["notebooks", "notes", "attachments"] as const;
+
+async function getLastUserId(): Promise<string | null> {
+  return AsyncStorage.getItem(LAST_USER_ID_KEY);
+}
+
+async function persistUserId(userId: string): Promise<void> {
+  await AsyncStorage.setItem(LAST_USER_ID_KEY, userId);
+}
+
+async function localDatabaseHasData(): Promise<boolean> {
+  for (const table of IDENTITY_TABLES) {
+    const count = await database.get(table).query().fetchCount();
+    if (count > 0) return true;
+  }
+  return false;
+}
+
+/**
+ * Cross-account safety guard, run before the initial sync for a signed-in user.
+ *
+ * Persists the last signed-in user id. When a session is established for a
+ * *different* user id and the local WatermelonDB still holds the previous
+ * user's records, the local database and cached attachment files are wiped
+ * before any sync can push another user's data or surface it in the UI. This
+ * catches sign-outs that never ran the sign-out-time reset (force-quit,
+ * expired session, reinstall-over-data), and is the backstop for a sign-out
+ * whose own reset failed.
+ *
+ * Best-effort: storage read/write and reset failures are logged and swallowed
+ * so a guard failure never blocks the app from loading. The id is never cleared
+ * on sign-out — only overwritten on the next sign-in — so a different user is
+ * still recognised even when the sign-out-time reset was skipped.
+ */
+export async function ensureLocalIdentity(userId: string): Promise<void> {
+  let lastUserId: string | null;
+  try {
+    lastUserId = await getLastUserId();
+  } catch (error) {
+    // Can't determine the previous identity — do NOT reset, to avoid wiping a
+    // matching user's data on a transient storage error.
+    console.warn("[local-identity] Failed to read last signed-in user id:", error);
+    return;
+  }
+
+  if (lastUserId === userId) {
+    return;
+  }
+
+  // A different user is signing in. Only reset when we know the previous user
+  // differed AND the local database actually holds data — a fresh install
+  // (empty DB) or an unknown previous id (null) must not trigger a wipe.
+  if (lastUserId !== null) {
+    try {
+      if (await localDatabaseHasData()) {
+        await database.write(() => database.unsafeResetDatabase());
+        await deleteAllLocalAttachments();
+      }
+    } catch (error) {
+      console.error("[local-identity] Failed to reset local data on user change:", error);
+    }
+  }
+
+  try {
+    await persistUserId(userId);
+  } catch (error) {
+    console.warn("[local-identity] Failed to persist signed-in user id:", error);
+  }
+}

--- a/apps/desktop/src/lib/data/local-identity.ts
+++ b/apps/desktop/src/lib/data/local-identity.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import { database } from "@/db";
-import { deleteAllLocalAttachments } from "./attachment-queue";
+import { deleteAllLocalAttachments } from "@/lib/data/attachment-queue";
 
 const LAST_USER_ID_KEY = "drafto_last_user_id";
 
@@ -61,8 +61,12 @@ export async function ensureLocalIdentity(userId: string): Promise<void> {
     try {
       if (await localDatabaseHasData()) {
         await database.write(() => database.unsafeResetDatabase());
-        await deleteAllLocalAttachments();
       }
+      // Attachment files live on the filesystem, independent of the local DB.
+      // A prior sign-out may have reset the DB but failed to delete files,
+      // leaving an empty DB with orphaned attachments; always clean them on a
+      // different-user sign-in so that failure can't leak files across accounts.
+      await deleteAllLocalAttachments();
     } catch (error) {
       console.error("[local-identity] Failed to reset local data on user change:", error);
     }
@@ -71,6 +75,9 @@ export async function ensureLocalIdentity(userId: string): Promise<void> {
   try {
     await persistUserId(userId);
   } catch (error) {
-    console.warn("[local-identity] Failed to persist signed-in user id:", error);
+    // Escalated to error (not warn): a failed persist leaves the guard's stored
+    // identity stale, so the next launch for this same user re-triggers a
+    // destructive reset. Surface it rather than swallow it quietly.
+    console.error("[local-identity] Failed to persist signed-in user id:", error);
   }
 }

--- a/apps/desktop/src/providers/auth-provider.tsx
+++ b/apps/desktop/src/providers/auth-provider.tsx
@@ -2,8 +2,44 @@ import { createContext, useContext, useEffect, useState, useCallback } from "rea
 import type { Session, User } from "@supabase/supabase-js";
 
 import { database } from "@/db";
+import { syncDatabase } from "@/db/sync";
 import { getCachedApproval, setCachedApproval, clearCachedApproval } from "@/lib/approval-cache";
+import { deleteAllLocalAttachments, processPendingUploads } from "@/lib/data";
 import { supabase } from "@/lib/supabase";
+
+/** Max time to wait for the pre-sign-out flush before proceeding to reset. */
+const FINAL_SYNC_TIMEOUT_MS = 10_000;
+
+/**
+ * Best-effort flush of unsynced local changes while the session is still valid.
+ * Attachment uploads and metadata sync are independent — an upload failure must
+ * not stop the metadata push.
+ */
+async function flushPendingChanges(): Promise<void> {
+  try {
+    await processPendingUploads();
+  } catch (error) {
+    console.warn("Attachment upload before sign-out failed:", error);
+  }
+  await syncDatabase(database);
+}
+
+/** Rejects if `promise` has not settled within `ms` milliseconds. */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("Operation timed out")), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
 
 interface AuthContextValue {
   user: User | null;
@@ -67,18 +103,38 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signOut = useCallback(async () => {
     const userId = session?.user?.id;
+
+    // Best-effort: flush unsynced local changes while the session is still valid.
+    // A failed, offline, or slow sync must never block sign-out, so it is bounded
+    // by a timeout and its errors are swallowed.
+    try {
+      await withTimeout(flushPendingChanges(), FINAL_SYNC_TIMEOUT_MS);
+    } catch (error) {
+      console.warn("Final sync before sign-out failed or timed out:", error);
+    }
+
     await supabase.auth.signOut();
     setSession(null);
     setIsApproved(false);
     if (userId) {
       await clearCachedApproval(userId);
     }
-    // Wipe the offline cache so a different account/environment starts clean and stale
-    // notes can't carry across logins. Best-effort: a reset failure must not block sign-out.
+
+    // Wipe the offline cache so a different account/environment starts clean and
+    // stale notes can't carry across logins. Best-effort: a reset failure must
+    // not block sign-out.
     try {
       await database.write(() => database.unsafeResetDatabase());
     } catch (error) {
       console.error("Failed to reset local database on sign-out:", error);
+    }
+
+    // Delete locally cached attachment files so they can't leak to the next
+    // account. Best-effort: file-deletion failures must not block sign-out.
+    try {
+      await deleteAllLocalAttachments();
+    } catch (error) {
+      console.error("Failed to delete local attachments on sign-out:", error);
     }
   }, [session?.user?.id]);
 

--- a/apps/desktop/src/providers/auth-provider.tsx
+++ b/apps/desktop/src/providers/auth-provider.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useState, useCallback } from "rea
 import type { Session, User } from "@supabase/supabase-js";
 
 import { database } from "@/db";
-import { syncDatabase } from "@/db/sync";
+import { syncDatabase, resetSyncState } from "@/db/sync";
 import { getCachedApproval, setCachedApproval, clearCachedApproval } from "@/lib/approval-cache";
 import { deleteAllLocalAttachments, processPendingUploads } from "@/lib/data";
 import { supabase } from "@/lib/supabase";
@@ -119,6 +119,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (userId) {
       await clearCachedApproval(userId);
     }
+
+    // Invalidate any in-flight sync (e.g. a final sync that timed out above but
+    // is still running) so the next signed-in user starts a fresh sync instead
+    // of coalescing onto this session's — which could otherwise write this
+    // user's pulled records into the freshly-reset database below.
+    resetSyncState();
 
     // Wipe the offline cache so a different account/environment starts clean and
     // stale notes can't carry across logins. Best-effort: a reset failure must

--- a/apps/desktop/src/providers/database-provider.tsx
+++ b/apps/desktop/src/providers/database-provider.tsx
@@ -7,7 +7,7 @@ import NetInfo from "@react-native-community/netinfo";
 
 import { database } from "@/db";
 import { syncDatabase, SyncNetworkError } from "@/db/sync";
-import { processPendingUploads, cleanupOrphanedFiles } from "@/lib/data";
+import { processPendingUploads, cleanupOrphanedFiles, ensureLocalIdentity } from "@/lib/data";
 import { measureAsync } from "@/lib/performance";
 import { useAuth } from "@/providers/auth-provider";
 
@@ -31,6 +31,7 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const periodicTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const identityReadyRef = useRef(false);
   const [hasPendingChanges, setHasPendingChanges] = useState(false);
   const [pendingChangesCount, setPendingChangesCount] = useState(0);
   const [lastSyncedAt, setLastSyncedAt] = useState<Date | null>(null);
@@ -106,18 +107,30 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
     }
   }, [checkPendingChanges]);
 
-  // Initial sync when user logs in
+  // Initial sync when user logs in. The cross-account identity guard runs first
+  // (and may reset the local DB) so the initial sync — and the periodic /
+  // foreground / reconnect syncs, which wait on identityReadyRef — never push or
+  // surface another user's local data.
   useEffect(() => {
+    let cancelled = false;
     if (user) {
       retryCountRef.current = 0;
-      // Sync first, then clean up orphaned files (cleanup needs complete DB state)
-      sync().then(() => {
-        cleanupOrphanedFiles().catch((cleanupErr) => {
-          console.warn("[DatabaseProvider] Orphaned file cleanup failed:", cleanupErr);
+      identityReadyRef.current = false;
+      ensureLocalIdentity(user.id).finally(() => {
+        if (cancelled) return;
+        identityReadyRef.current = true;
+        // Sync first, then clean up orphaned files (cleanup needs complete DB state)
+        sync().then(() => {
+          cleanupOrphanedFiles().catch((cleanupErr) => {
+            console.warn("[DatabaseProvider] Orphaned file cleanup failed:", cleanupErr);
+          });
         });
       });
+    } else {
+      identityReadyRef.current = false;
     }
     return () => {
+      cancelled = true;
       if (retryTimerRef.current) {
         clearTimeout(retryTimerRef.current);
         retryTimerRef.current = null;
@@ -128,7 +141,7 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
   // Periodic sync for pending changes
   useEffect(() => {
     periodicTimerRef.current = setInterval(async () => {
-      if (!user) return;
+      if (!user || !identityReadyRef.current) return;
       const pending = await hasUnsyncedChanges({ database }).catch(() => false);
       if (pending) {
         sync();
@@ -148,7 +161,7 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
   // (maps to NSApplication.didBecomeActiveNotification)
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (state) => {
-      if (state === "active" && user) {
+      if (state === "active" && user && identityReadyRef.current) {
         sync();
       }
     });
@@ -162,7 +175,7 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
       const isConnected = state.isConnected ?? false;
       if (!isConnected) {
         wasDisconnected = true;
-      } else if (wasDisconnected && user) {
+      } else if (wasDisconnected && user && identityReadyRef.current) {
         wasDisconnected = false;
         retryCountRef.current = 0;
         sync();

--- a/apps/mobile/__tests__/db/sync.test.ts
+++ b/apps/mobile/__tests__/db/sync.test.ts
@@ -1,0 +1,79 @@
+const mockSynchronize = jest.fn().mockResolvedValue(undefined);
+const mockSupabaseFrom = jest.fn();
+const mockSupabaseRpc = jest.fn();
+
+jest.mock("@nozbe/watermelondb/sync", () => ({
+  synchronize: (...args: unknown[]) => mockSynchronize(...args),
+}));
+
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockSupabaseFrom(...args),
+    rpc: (...args: unknown[]) => mockSupabaseRpc(...args),
+  },
+}));
+
+import { syncDatabase, resetSyncState } from "@/db/sync";
+
+// Mirror of apps/desktop/__tests__/db/sync.test.ts's coalescing suite. Guards
+// the module-level in-flight latch and the sign-out invalidation (resetSyncState)
+// that stops a new user coalescing onto the previous session's still-running
+// sync — the cross-account write vector fixed for issue #463.
+describe("in-flight sync coalescing + resetSyncState", () => {
+  const mockDb = {
+    get: () => ({ query: () => ({ fetch: () => Promise.resolve([]) }) }),
+  } as unknown as Parameters<typeof syncDatabase>[0];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSyncState();
+  });
+
+  it("coalesces concurrent callers onto a single synchronize() run", async () => {
+    let release!: () => void;
+    mockSynchronize.mockImplementationOnce(
+      () => new Promise<void>((resolve) => (release = () => resolve(undefined))),
+    );
+
+    const p1 = syncDatabase(mockDb);
+    const p2 = syncDatabase(mockDb);
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(mockSynchronize).toHaveBeenCalledTimes(1);
+    expect(r1).toBe(r2);
+  });
+
+  it("starts a fresh synchronize() once the previous run has settled", async () => {
+    await syncDatabase(mockDb);
+    await syncDatabase(mockDb);
+    expect(mockSynchronize).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the latch after a failed sync so a later call retries", async () => {
+    mockSynchronize.mockRejectedValueOnce(new Error("Some database error"));
+    await expect(syncDatabase(mockDb)).rejects.toThrow();
+
+    await expect(syncDatabase(mockDb)).resolves.toEqual({ conflictCount: 0 });
+    expect(mockSynchronize).toHaveBeenCalledTimes(2);
+  });
+
+  it("resetSyncState stops the next caller coalescing onto a stale in-flight sync", async () => {
+    let releaseStale!: () => void;
+    mockSynchronize.mockImplementationOnce(
+      () => new Promise<void>((resolve) => (releaseStale = () => resolve(undefined))),
+    );
+
+    const stale = syncDatabase(mockDb);
+    resetSyncState();
+
+    const fresh = await syncDatabase(mockDb);
+    expect(mockSynchronize).toHaveBeenCalledTimes(2);
+    expect(fresh).toEqual({ conflictCount: 0 });
+
+    releaseStale();
+    await stale;
+    await syncDatabase(mockDb);
+    expect(mockSynchronize).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/mobile/__tests__/lib/attachment-queue.test.ts
+++ b/apps/mobile/__tests__/lib/attachment-queue.test.ts
@@ -6,6 +6,8 @@ const mockDatabaseGet = jest.fn();
 const mockFileBytes = jest.fn();
 const mockFileDelete = jest.fn();
 const mockFileCopy = jest.fn();
+const mockDirDelete = jest.fn();
+const mockDirExists = jest.fn(() => true);
 
 jest.mock("expo-file-system", () => {
   const mockFile = jest.fn().mockImplementation((...args: unknown[]) => ({
@@ -17,8 +19,11 @@ jest.mock("expo-file-system", () => {
     bytes: mockFileBytes,
   }));
   const mockDirectory = jest.fn().mockImplementation(() => ({
-    exists: true,
+    get exists() {
+      return mockDirExists();
+    },
     create: jest.fn(),
+    delete: mockDirDelete,
     list: jest.fn().mockReturnValue([]),
   }));
   return {
@@ -58,10 +63,11 @@ jest.mock("@/lib/generate-id", () => ({
   generateId: () => "mock-id-123",
 }));
 
-import { processPendingUploads } from "@/lib/data/attachment-queue";
+import { processPendingUploads, deleteAllLocalAttachments } from "@/lib/data/attachment-queue";
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockDirExists.mockReturnValue(true);
 });
 
 describe("processPendingUploads", () => {
@@ -189,5 +195,35 @@ describe("processPendingUploads", () => {
     const result = await processPendingUploads();
 
     expect(result).toEqual({ uploaded: 0, failed: 0 });
+  });
+});
+
+describe("deleteAllLocalAttachments", () => {
+  it("deletes the attachments directory when it exists", async () => {
+    mockDirExists.mockReturnValue(true);
+
+    await deleteAllLocalAttachments();
+
+    expect(mockDirDelete).toHaveBeenCalled();
+  });
+
+  it("does nothing when the attachments directory does not exist", async () => {
+    mockDirExists.mockReturnValue(false);
+
+    await deleteAllLocalAttachments();
+
+    expect(mockDirDelete).not.toHaveBeenCalled();
+  });
+
+  it("swallows deletion errors so sign-out is not blocked", async () => {
+    mockDirExists.mockReturnValue(true);
+    mockDirDelete.mockImplementationOnce(() => {
+      throw new Error("delete failed");
+    });
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(deleteAllLocalAttachments()).resolves.toBeUndefined();
+
+    warnSpy.mockRestore();
   });
 });

--- a/apps/mobile/__tests__/lib/data/local-identity.test.ts
+++ b/apps/mobile/__tests__/lib/data/local-identity.test.ts
@@ -1,0 +1,117 @@
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+const mockUnsafeReset = jest.fn();
+const mockWrite = jest.fn((work: () => unknown) => Promise.resolve(work()));
+const mockFetchCount = jest.fn();
+const mockDeleteAllLocalAttachments = jest.fn();
+
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: (...args: unknown[]) => mockGetItem(...args),
+  setItemAsync: (...args: unknown[]) => mockSetItem(...args),
+}));
+
+jest.mock("@/db", () => ({
+  database: {
+    write: (work: () => unknown) => mockWrite(work),
+    unsafeResetDatabase: (...args: unknown[]) => mockUnsafeReset(...args),
+    get: () => ({ query: () => ({ fetchCount: () => mockFetchCount() }) }),
+  },
+}));
+
+jest.mock("@/lib/data/attachment-queue", () => ({
+  deleteAllLocalAttachments: (...args: unknown[]) => mockDeleteAllLocalAttachments(...args),
+}));
+
+import { ensureLocalIdentity } from "@/lib/data/local-identity";
+
+const KEY = "drafto_last_user_id";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetItem.mockResolvedValue(null);
+  mockSetItem.mockResolvedValue(undefined);
+  mockUnsafeReset.mockResolvedValue(undefined);
+  mockWrite.mockImplementation((work: () => unknown) => Promise.resolve(work()));
+  mockFetchCount.mockResolvedValue(0);
+  mockDeleteAllLocalAttachments.mockResolvedValue(undefined);
+});
+
+describe("ensureLocalIdentity", () => {
+  it("no-ops when the same user signs in again", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+
+    await ensureLocalIdentity("user-1");
+
+    expect(mockUnsafeReset).not.toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).not.toHaveBeenCalled();
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+
+  it("persists the new id but does not reset when a different user signs in on an empty DB", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+    mockFetchCount.mockResolvedValue(0);
+
+    await ensureLocalIdentity("user-2");
+
+    expect(mockUnsafeReset).not.toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).not.toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-2");
+  });
+
+  it("resets the DB, wipes attachments, and persists the id when a different user signs in on a non-empty DB", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+    // First table (notebooks) is non-empty → short-circuits to true.
+    mockFetchCount.mockResolvedValueOnce(3);
+
+    await ensureLocalIdentity("user-2");
+
+    expect(mockUnsafeReset).toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-2");
+  });
+
+  it("does not reset on the first sign-in (no stored id), even with local data", async () => {
+    mockGetItem.mockResolvedValue(null);
+    mockFetchCount.mockResolvedValue(5);
+
+    await ensureLocalIdentity("user-1");
+
+    expect(mockUnsafeReset).not.toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).not.toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-1");
+  });
+
+  it("tolerates a storage read failure without resetting or throwing", async () => {
+    mockGetItem.mockRejectedValue(new Error("keychain locked"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureLocalIdentity("user-1")).resolves.toBeUndefined();
+
+    expect(mockUnsafeReset).not.toHaveBeenCalled();
+    expect(mockSetItem).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("still persists the new id when the reset fails", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+    mockFetchCount.mockResolvedValueOnce(2);
+    mockUnsafeReset.mockRejectedValueOnce(new Error("reset boom"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(ensureLocalIdentity("user-2")).resolves.toBeUndefined();
+
+    expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-2");
+    errorSpy.mockRestore();
+  });
+
+  it("tolerates a persist failure without throwing", async () => {
+    mockGetItem.mockResolvedValue("user-1");
+    mockFetchCount.mockResolvedValue(0);
+    mockSetItem.mockRejectedValue(new Error("write failed"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureLocalIdentity("user-2")).resolves.toBeUndefined();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/mobile/__tests__/lib/data/local-identity.test.ts
+++ b/apps/mobile/__tests__/lib/data/local-identity.test.ts
@@ -47,14 +47,17 @@ describe("ensureLocalIdentity", () => {
     expect(mockSetItem).not.toHaveBeenCalled();
   });
 
-  it("persists the new id but does not reset when a different user signs in on an empty DB", async () => {
+  it("cleans attachments (but does not reset the DB) when a different user signs in on an empty DB", async () => {
     mockGetItem.mockResolvedValue("user-1");
     mockFetchCount.mockResolvedValue(0);
 
     await ensureLocalIdentity("user-2");
 
+    // Empty DB → no reset needed, but attachment files can survive a prior
+    // sign-out's failed deletion independently of the DB, so they are always
+    // cleaned on a different-user sign-in (cross-account leak guard).
     expect(mockUnsafeReset).not.toHaveBeenCalled();
-    expect(mockDeleteAllLocalAttachments).not.toHaveBeenCalled();
+    expect(mockDeleteAllLocalAttachments).toHaveBeenCalled();
     expect(mockSetItem).toHaveBeenCalledWith(KEY, "user-2");
   });
 
@@ -104,14 +107,17 @@ describe("ensureLocalIdentity", () => {
     errorSpy.mockRestore();
   });
 
-  it("tolerates a persist failure without throwing", async () => {
+  it("logs (at error level) but does not throw when persisting the id fails", async () => {
     mockGetItem.mockResolvedValue("user-1");
     mockFetchCount.mockResolvedValue(0);
     mockSetItem.mockRejectedValue(new Error("write failed"));
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(ensureLocalIdentity("user-2")).resolves.toBeUndefined();
 
-    warnSpy.mockRestore();
+    // Observable, not swallowed: a stale stored id re-triggers a destructive
+    // reset on this same user's next launch.
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/apps/mobile/__tests__/providers/auth-provider.test.tsx
+++ b/apps/mobile/__tests__/providers/auth-provider.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, act, waitFor } from "@testing-library/react-native";
 import type { User } from "@supabase/supabase-js";
 
 import { database } from "@/db";
-import { syncDatabase } from "@/db/sync";
+import { syncDatabase, resetSyncState } from "@/db/sync";
 import { AuthProvider, useAuth } from "@/providers/auth-provider";
 import { supabase } from "@/lib/supabase";
 import * as approvalCache from "@/lib/approval-cache";
@@ -33,6 +33,7 @@ jest.mock("@/db", () => ({
 
 jest.mock("@/db/sync", () => ({
   syncDatabase: jest.fn(),
+  resetSyncState: jest.fn(),
 }));
 
 jest.mock("@/lib/data/attachment-queue", () => ({
@@ -47,6 +48,7 @@ const mockDatabase = database as unknown as {
   unsafeResetDatabase: jest.Mock;
 };
 const mockSyncDatabase = syncDatabase as jest.Mock;
+const mockResetSyncState = resetSyncState as jest.Mock;
 const mockProcessPendingUploads = processPendingUploads as jest.Mock;
 const mockDeleteAllLocalAttachments = deleteAllLocalAttachments as jest.Mock;
 
@@ -314,5 +316,68 @@ describe("AuthProvider", () => {
     expect(mockSupabase.auth.signOut).toHaveBeenCalled();
     expect(result.current.isApproved).toBe(false);
     errorSpy.mockRestore();
+  });
+
+  it("invalidates the in-flight sync on sign out", async () => {
+    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { user: TEST_USER } },
+    });
+    mockProfileQuery({ is_approved: true }, null);
+    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    // Invalidated after the session is destroyed and before the DB reset, so a
+    // subsequently signed-in user can't coalesce onto this session's stale sync.
+    expect(mockResetSyncState).toHaveBeenCalled();
+    expect(mockResetSyncState.mock.invocationCallOrder[0]).toBeGreaterThan(
+      (mockSupabase.auth.signOut as jest.Mock).mock.invocationCallOrder[0],
+    );
+    expect(mockResetSyncState.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDatabase.unsafeResetDatabase.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("completes sign out even when the final sync never settles (timeout path)", async () => {
+    (mockSupabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { user: TEST_USER } },
+    });
+    mockProfileQuery({ is_approved: true }, null);
+    (mockSupabase.auth.signOut as jest.Mock).mockResolvedValue({});
+    mockProcessPendingUploads.mockResolvedValue(0);
+    // A flush that never settles must not wedge sign-out — withTimeout fires.
+    mockSyncDatabase.mockReturnValue(new Promise<never>(() => {}));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    jest.useFakeTimers();
+    try {
+      await act(async () => {
+        const pending = result.current.signOut();
+        // Advance past FINAL_SYNC_TIMEOUT_MS (10s) so withTimeout rejects and
+        // sign-out proceeds to reset regardless of the hung flush.
+        await jest.advanceTimersByTimeAsync(10_000);
+        await pending;
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+
+    expect(mockSupabase.auth.signOut).toHaveBeenCalled();
+    expect(mockDatabase.unsafeResetDatabase).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/apps/mobile/src/db/sync.ts
+++ b/apps/mobile/src/db/sync.ts
@@ -263,7 +263,7 @@ export interface SyncResult {
   conflictCount: number;
 }
 
-export async function syncDatabase(db: WMDatabase): Promise<SyncResult> {
+async function runSync(db: WMDatabase): Promise<SyncResult> {
   let conflictCount = 0;
 
   try {
@@ -287,4 +287,24 @@ export async function syncDatabase(db: WMDatabase): Promise<SyncResult> {
   }
 
   return { conflictCount };
+}
+
+// Module-level in-flight coalesce. WatermelonDB forbids concurrent
+// synchronize() calls, and sign-out's best-effort final sync can run alongside
+// the DatabaseProvider's own sync. When a sync is already running, additional
+// callers await the same promise instead of starting a second synchronize().
+// This changes no pull/push/conflict behaviour — it only serialises re-entrant
+// callers.
+let inFlightSync: Promise<SyncResult> | null = null;
+
+export async function syncDatabase(db: WMDatabase): Promise<SyncResult> {
+  if (inFlightSync) {
+    return inFlightSync;
+  }
+  inFlightSync = runSync(db);
+  try {
+    return await inFlightSync;
+  } finally {
+    inFlightSync = null;
+  }
 }

--- a/apps/mobile/src/db/sync.ts
+++ b/apps/mobile/src/db/sync.ts
@@ -296,15 +296,41 @@ async function runSync(db: WMDatabase): Promise<SyncResult> {
 // This changes no pull/push/conflict behaviour — it only serialises re-entrant
 // callers.
 let inFlightSync: Promise<SyncResult> | null = null;
+// Bumped whenever the in-flight sync is invalidated (sign-out). A sync captures
+// the generation it started under; only a settling sync of the current
+// generation is allowed to clear the latch — so a stale sync can't null out a
+// newer session's sync. See resetSyncState.
+let syncGeneration = 0;
+
+/**
+ * Invalidate any in-flight sync so the NEXT `syncDatabase()` starts its own
+ * `synchronize()` instead of awaiting a prior session's. Sign-out calls this
+ * after destroying the Supabase session: a final sync that timed out but is
+ * still running must not be handed to the next signed-in user, whose initial
+ * sync would otherwise await the previous user's `runSync()` and write that
+ * user's pulled records into the freshly-reset local database. The stale sync
+ * is left to settle in the background; the generation guard below stops its
+ * cleanup from clobbering the next session's latch.
+ */
+export function resetSyncState(): void {
+  syncGeneration += 1;
+  inFlightSync = null;
+}
 
 export async function syncDatabase(db: WMDatabase): Promise<SyncResult> {
   if (inFlightSync) {
     return inFlightSync;
   }
-  inFlightSync = runSync(db);
+  const generation = syncGeneration;
+  const pending = runSync(db);
+  inFlightSync = pending;
   try {
-    return await inFlightSync;
+    return await pending;
   } finally {
-    inFlightSync = null;
+    // Only clear the latch if it still points at THIS run and no reset (or
+    // newer sync) superseded us — otherwise we'd null out a live sync.
+    if (syncGeneration === generation && inFlightSync === pending) {
+      inFlightSync = null;
+    }
   }
 }

--- a/apps/mobile/src/lib/data/attachment-queue.ts
+++ b/apps/mobile/src/lib/data/attachment-queue.ts
@@ -204,6 +204,24 @@ export async function processPendingUploads(): Promise<UploadResult> {
   return { uploaded, failed };
 }
 
+/**
+ * Delete the entire local attachments directory (and every cached file in it).
+ * Used on sign-out and on the cross-account identity guard so one account's
+ * downloaded/queued attachment files can't leak to the next account on the
+ * device. Best-effort: a deletion failure is logged and swallowed so it never
+ * blocks sign-out.
+ */
+export async function deleteAllLocalAttachments(): Promise<void> {
+  try {
+    const dir = getAttachmentsDir();
+    if (dir.exists) {
+      dir.delete();
+    }
+  } catch (error) {
+    console.warn("Failed to delete local attachments directory:", error);
+  }
+}
+
 export function cleanupOrphanedFiles(): void {
   try {
     const dir = getAttachmentsDir();

--- a/apps/mobile/src/lib/data/local-identity.ts
+++ b/apps/mobile/src/lib/data/local-identity.ts
@@ -1,0 +1,76 @@
+import * as SecureStore from "expo-secure-store";
+
+import { database } from "@/db";
+import { deleteAllLocalAttachments } from "@/lib/data/attachment-queue";
+
+const LAST_USER_ID_KEY = "drafto_last_user_id";
+
+const IDENTITY_TABLES = ["notebooks", "notes", "attachments"] as const;
+
+async function getLastUserId(): Promise<string | null> {
+  return SecureStore.getItemAsync(LAST_USER_ID_KEY);
+}
+
+async function persistUserId(userId: string): Promise<void> {
+  await SecureStore.setItemAsync(LAST_USER_ID_KEY, userId);
+}
+
+async function localDatabaseHasData(): Promise<boolean> {
+  for (const table of IDENTITY_TABLES) {
+    const count = await database.get(table).query().fetchCount();
+    if (count > 0) return true;
+  }
+  return false;
+}
+
+/**
+ * Cross-account safety guard, run before the initial sync for a signed-in user.
+ *
+ * Persists the last signed-in user id. When a session is established for a
+ * *different* user id and the local WatermelonDB still holds the previous
+ * user's records, the local database and cached attachment files are wiped
+ * before any sync can push another user's data or surface it in the UI. This
+ * catches sign-outs that never ran the sign-out-time reset (force-quit,
+ * expired session, reinstall-over-data), and is the backstop for a sign-out
+ * whose own reset failed.
+ *
+ * Best-effort: storage read/write and reset failures are logged and swallowed
+ * so a guard failure never blocks the app from loading. The id is never cleared
+ * on sign-out — only overwritten on the next sign-in — so a different user is
+ * still recognised even when the sign-out-time reset was skipped.
+ */
+export async function ensureLocalIdentity(userId: string): Promise<void> {
+  let lastUserId: string | null;
+  try {
+    lastUserId = await getLastUserId();
+  } catch (error) {
+    // Can't determine the previous identity — do NOT reset, to avoid wiping a
+    // matching user's data on a transient storage error.
+    console.warn("[local-identity] Failed to read last signed-in user id:", error);
+    return;
+  }
+
+  if (lastUserId === userId) {
+    return;
+  }
+
+  // A different user is signing in. Only reset when we know the previous user
+  // differed AND the local database actually holds data — a fresh install
+  // (empty DB) or an unknown previous id (null) must not trigger a wipe.
+  if (lastUserId !== null) {
+    try {
+      if (await localDatabaseHasData()) {
+        await database.write(() => database.unsafeResetDatabase());
+        await deleteAllLocalAttachments();
+      }
+    } catch (error) {
+      console.error("[local-identity] Failed to reset local data on user change:", error);
+    }
+  }
+
+  try {
+    await persistUserId(userId);
+  } catch (error) {
+    console.warn("[local-identity] Failed to persist signed-in user id:", error);
+  }
+}

--- a/apps/mobile/src/lib/data/local-identity.ts
+++ b/apps/mobile/src/lib/data/local-identity.ts
@@ -61,8 +61,12 @@ export async function ensureLocalIdentity(userId: string): Promise<void> {
     try {
       if (await localDatabaseHasData()) {
         await database.write(() => database.unsafeResetDatabase());
-        await deleteAllLocalAttachments();
       }
+      // Attachment files live on the filesystem, independent of the local DB.
+      // A prior sign-out may have reset the DB but failed to delete files,
+      // leaving an empty DB with orphaned attachments; always clean them on a
+      // different-user sign-in so that failure can't leak files across accounts.
+      await deleteAllLocalAttachments();
     } catch (error) {
       console.error("[local-identity] Failed to reset local data on user change:", error);
     }
@@ -71,6 +75,9 @@ export async function ensureLocalIdentity(userId: string): Promise<void> {
   try {
     await persistUserId(userId);
   } catch (error) {
-    console.warn("[local-identity] Failed to persist signed-in user id:", error);
+    // Escalated to error (not warn): a failed persist leaves the guard's stored
+    // identity stale, so the next launch for this same user re-triggers a
+    // destructive reset. Surface it rather than swallow it quietly.
+    console.error("[local-identity] Failed to persist signed-in user id:", error);
   }
 }

--- a/apps/mobile/src/providers/auth-provider.tsx
+++ b/apps/mobile/src/providers/auth-provider.tsx
@@ -2,8 +2,44 @@ import { createContext, useContext, useEffect, useState, useCallback } from "rea
 import type { Session, User } from "@supabase/supabase-js";
 
 import { database } from "@/db";
+import { syncDatabase } from "@/db/sync";
 import { getCachedApproval, setCachedApproval, clearCachedApproval } from "@/lib/approval-cache";
+import { deleteAllLocalAttachments, processPendingUploads } from "@/lib/data/attachment-queue";
 import { supabase } from "@/lib/supabase";
+
+/** Max time to wait for the pre-sign-out flush before proceeding to reset. */
+const FINAL_SYNC_TIMEOUT_MS = 10_000;
+
+/**
+ * Best-effort flush of unsynced local changes while the session is still valid.
+ * Attachment uploads and metadata sync are independent — an upload failure must
+ * not stop the metadata push.
+ */
+async function flushPendingChanges(): Promise<void> {
+  try {
+    await processPendingUploads();
+  } catch (error) {
+    console.warn("Attachment upload before sign-out failed:", error);
+  }
+  await syncDatabase(database);
+}
+
+/** Rejects if `promise` has not settled within `ms` milliseconds. */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("Operation timed out")), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
 
 interface AuthContextValue {
   user: User | null;
@@ -67,18 +103,38 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signOut = useCallback(async () => {
     const userId = session?.user?.id;
+
+    // Best-effort: flush unsynced local changes while the session is still valid.
+    // A failed, offline, or slow sync must never block sign-out, so it is bounded
+    // by a timeout and its errors are swallowed.
+    try {
+      await withTimeout(flushPendingChanges(), FINAL_SYNC_TIMEOUT_MS);
+    } catch (error) {
+      console.warn("Final sync before sign-out failed or timed out:", error);
+    }
+
     await supabase.auth.signOut();
     setSession(null);
     setIsApproved(false);
     if (userId) {
       await clearCachedApproval(userId);
     }
-    // Wipe the offline cache so a different account/environment starts clean and stale
-    // notes can't carry across logins. Best-effort: a reset failure must not block sign-out.
+
+    // Wipe the offline cache so a different account/environment starts clean and
+    // stale notes can't carry across logins. Best-effort: a reset failure must
+    // not block sign-out.
     try {
       await database.write(() => database.unsafeResetDatabase());
     } catch (error) {
       console.error("Failed to reset local database on sign-out:", error);
+    }
+
+    // Delete locally cached attachment files so they can't leak to the next
+    // account. Best-effort: file-deletion failures must not block sign-out.
+    try {
+      await deleteAllLocalAttachments();
+    } catch (error) {
+      console.error("Failed to delete local attachments on sign-out:", error);
     }
   }, [session?.user?.id]);
 

--- a/apps/mobile/src/providers/auth-provider.tsx
+++ b/apps/mobile/src/providers/auth-provider.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useState, useCallback } from "rea
 import type { Session, User } from "@supabase/supabase-js";
 
 import { database } from "@/db";
-import { syncDatabase } from "@/db/sync";
+import { syncDatabase, resetSyncState } from "@/db/sync";
 import { getCachedApproval, setCachedApproval, clearCachedApproval } from "@/lib/approval-cache";
 import { deleteAllLocalAttachments, processPendingUploads } from "@/lib/data/attachment-queue";
 import { supabase } from "@/lib/supabase";
@@ -119,6 +119,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (userId) {
       await clearCachedApproval(userId);
     }
+
+    // Invalidate any in-flight sync (e.g. a final sync that timed out above but
+    // is still running) so the next signed-in user starts a fresh sync instead
+    // of coalescing onto this session's — which could otherwise write this
+    // user's pulled records into the freshly-reset database below.
+    resetSyncState();
 
     // Wipe the offline cache so a different account/environment starts clean and
     // stale notes can't carry across logins. Best-effort: a reset failure must

--- a/apps/mobile/src/providers/database-provider.tsx
+++ b/apps/mobile/src/providers/database-provider.tsx
@@ -9,6 +9,7 @@ import { database } from "@/db";
 import { syncDatabase, SyncNetworkError } from "@/db/sync";
 import { processPendingUploads } from "@/lib/data/attachment-queue";
 import type { UploadResult } from "@/lib/data/attachment-queue";
+import { ensureLocalIdentity } from "@/lib/data/local-identity";
 import { measureAsync } from "@/lib/performance";
 import { useAuth } from "@/providers/auth-provider";
 import { useToast } from "@/components/toast";
@@ -34,6 +35,7 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const periodicTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const identityReadyRef = useRef(false);
   const [hasPendingChanges, setHasPendingChanges] = useState(false);
   const [pendingChangesCount, setPendingChangesCount] = useState(0);
   const [lastSyncedAt, setLastSyncedAt] = useState<Date | null>(null);
@@ -107,13 +109,25 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
     return uploadResult;
   }, [checkPendingChanges, showToast]);
 
-  // Initial sync when user logs in
+  // Initial sync when user logs in. The cross-account identity guard runs first
+  // (and may reset the local DB) so the initial sync — and the periodic /
+  // foreground / reconnect syncs, which wait on identityReadyRef — never push or
+  // surface another user's local data.
   useEffect(() => {
+    let cancelled = false;
     if (user) {
       retryCountRef.current = 0;
-      sync();
+      identityReadyRef.current = false;
+      ensureLocalIdentity(user.id).finally(() => {
+        if (cancelled) return;
+        identityReadyRef.current = true;
+        sync();
+      });
+    } else {
+      identityReadyRef.current = false;
     }
     return () => {
+      cancelled = true;
       if (retryTimerRef.current) {
         clearTimeout(retryTimerRef.current);
         retryTimerRef.current = null;
@@ -124,7 +138,7 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
   // Periodic sync for pending changes
   useEffect(() => {
     periodicTimerRef.current = setInterval(async () => {
-      if (!user) return;
+      if (!user || !identityReadyRef.current) return;
       const pending = await hasUnsyncedChanges({ database }).catch(() => false);
       if (pending) {
         sync();
@@ -142,7 +156,7 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
   // Sync when app comes to foreground
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (state) => {
-      if (state === "active" && user) {
+      if (state === "active" && user && identityReadyRef.current) {
         sync();
       }
     });
@@ -156,7 +170,7 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
       const isConnected = state.isConnected ?? false;
       if (!isConnected) {
         wasDisconnected = true;
-      } else if (wasDisconnected && user) {
+      } else if (wasDisconnected && user && identityReadyRef.current) {
         wasDisconnected = false;
         retryCountRef.current = 0;
         sync();


### PR DESCRIPTION
<!-- drafto-factory-pr -->

Closes #463

## Summary

Sign-out no longer leaves one account's data on the device for the next account. `signOut()` on both mobile and desktop now attempts a best-effort final sync (attachment uploads + metadata push) **while the session is still valid**, then wipes the local WatermelonDB via `unsafeResetDatabase()` (which also clears the sync checkpoint, so the next sign-in does a full first pull) and deletes the cached attachment files. A new per-platform `lib/data/local-identity.ts` guard persists the last signed-in user id and, before the initial sync, resets the local DB + attachments when a *different* user's session lands on a non-empty local DB — covering sign-outs that never ran the reset (force-quit, expired session, reinstall-over-data). Every step is failure-tolerant and never blocks sign-out. Implements the [approved plan](https://github.com/JakubAnderwald/drafto/issues/463#issuecomment-5030653205).

## Parity report

- mobile — `apps/mobile/src/providers/auth-provider.tsx` (sign-out flush/reset/wipe), `apps/mobile/src/providers/database-provider.tsx` (identity guard + gated sync triggers), `apps/mobile/src/lib/data/attachment-queue.ts` (`deleteAllLocalAttachments`), `apps/mobile/src/lib/data/local-identity.ts` (new, expo-secure-store), `apps/mobile/src/db/sync.ts` (in-flight coalesce) ✅
- desktop — mirrored: `apps/desktop/src/providers/auth-provider.tsx`, `apps/desktop/src/providers/database-provider.tsx`, `apps/desktop/src/lib/data/attachment-queue.ts` (RNFS), `apps/desktop/src/lib/data/local-identity.ts` (new, AsyncStorage), `apps/desktop/src/lib/data/index.ts` (barrel re-export), `apps/desktop/src/db/sync.ts` ✅
- web — out of scope (no WatermelonDB / local replica; documented in the issue's "Out of scope") ➖

## Test plan

- [x] `pnpm --filter @drafto/mobile test` — 136 passed
- [x] `pnpm --filter @drafto/desktop test` — 338 passed
- [x] `pnpm --filter @drafto/mobile typecheck` / `pnpm --filter @drafto/desktop typecheck` — passed
- [x] `pnpm --filter @drafto/mobile lint` (0 errors; pre-existing warnings in untouched `app/_layout.tsx`) / `pnpm --filter @drafto/desktop lint` — passed
- [x] `pnpm format:check` (root) — passed
- n/a `pnpm migration:check` — no schema changes

New/extended tests: extended `apps/mobile/__tests__/providers/auth-provider.test.tsx` and added a mirrored `apps/desktop/__tests__/providers/auth-provider.test.tsx` (final sync ordered before session teardown; attachment deletion invoked; rejected sync / reset / file-deletion still resolve sign-out with the session cleared). New `local-identity` unit tests on both platforms (same-user no-op, empty-DB no-op, reset+wipe+persist on mismatch, first-sign-in no-op, storage/reset/persist-failure tolerance). Extended both `attachment-queue` test files for `deleteAllLocalAttachments`.

## Drift vs. approved plan

Implementation matches the plan's "Files to touch" exactly (7 mobile + 8 desktop files). One minor **test-only addition**: to cover the new `deleteAllLocalAttachments` branches, I extended the two pre-existing attachment-queue test files (`apps/{mobile,desktop}/__tests__/lib/attachment-queue.test.ts`) rather than only the plan's enumerated test files — no new source touched. Per the plan's spec-vs-reality note, PR #548's `unsafeResetDatabase()` reset was already on `main`; this PR delivers the remaining acceptance criteria (final sync, attachment wipe, stale-identity guard, sync coalesce) and left the existing reset in place.

🤖 Generated by the dark factory ([approved plan](https://github.com/JakubAnderwald/drafto/issues/463#issuecomment-5030653205))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards to prevent local data from carrying over between accounts during sign-in.
  * Added cleanup for locally cached attachments during account changes and sign-out.
  * Added a final, time-limited sync before sign-out to preserve pending changes.

* **Bug Fixes**
  * Prevented overlapping sync operations and invalidated stale syncs during account changes.
  * Ensured synchronization waits for account initialization to complete.
  * Sign-out now completes even if synchronization or local cleanup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->