### PR TITLE
docs: fix the worktree PR-merge command (needs --method PUT)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ echo "sdk.dir=/Users/jakub/Library/Android/sdk" > apps/mobile/android/local.prop
 **Worktree git gotchas:**
 
 - **Cannot checkout `main`**: In a worktree, `main` is already checked out by the original repo. To create a new branch from latest main, use: `git fetch origin main && git checkout -b <branch> origin/main`
-- **Cannot merge PRs with `--delete-branch`**: `gh pr merge --delete-branch` fails because it tries to switch to `main` locally. Instead use the GitHub API: `gh api repos/{owner}/{repo}/pulls/{number}/merge -f merge_method=squash`
+- **Cannot merge PRs with `--delete-branch`**: `gh pr merge --delete-branch` fails because it tries to switch to `main` locally. Instead use the GitHub API — `--method PUT` is required, because the merge endpoint is a PUT while `gh api` switches to POST as soon as any `-f` field is present, and a POST there returns a bare `404 Not Found`: `gh api --method PUT repos/{owner}/{repo}/pulls/{number}/merge -f merge_method=squash`. Delete the remote branch afterwards with `gh api -X DELETE repos/{owner}/{repo}/git/refs/heads/<branch>`.
 - **Fastlane in worktrees**: Worktrees do not share Ruby gems. Run `bundle install` in the worktree's `apps/mobile/` (or `apps/desktop/`) directory before using Fastlane commands. Also copy `google-play-service-account.json` if needed for store submissions.
 
 ## Parallel Tool Execution


### PR DESCRIPTION
## Problem

CLAUDE.md's worktree gotcha documents this as the way to merge a PR:

```bash
gh api repos/{owner}/{repo}/pulls/{number}/merge -f merge_method=squash
```

That returns a bare `404 Not Found`. The merge endpoint is a **PUT**, but `gh api` switches to POST as soon as any `-f` field is present, so the snippet as written has never worked. Hit while merging #601.

## Fix

Add `--method PUT`, explain why it's needed so nobody drops it again, and record the branch deletion that `--delete-branch` would otherwise have handled.

`scripts/factory-agent.sh:3611` already does this correctly and carries an inline comment saying the endpoint is a PUT, so the factory's release path was never affected — and neither is the `/merge` skill. CLAUDE.md was the only stale copy.

## Verification

```
$ gh api      repos/.../pulls/601/merge -f merge_method=squash   # documented form
gh: Not Found (HTTP 404)
$ gh api -X PUT repos/.../pulls/601/merge -f merge_method=squash   # fixed form
merged=true — Pull Request successfully merged
```

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)