### PR TITLE
chore(deps): stop Dependabot proposing React bumps it cannot land

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,20 @@ updates:
       # which CI cannot verify. Suppress minor + major; patches still flow through the group.
       - dependency-name: "@react-native/*"
         update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      # React (`react`, `react-dom`, `react-test-renderer`) is governed by the root
+      # package.json's `pnpm.overrides`, not by the apps' own declarations — the override is
+      # what forces a single shared React instance across all four workspaces, which
+      # ADR-0027 / #558 established is mandatory (multiple React copies, even at the same
+      # version, break Context/hook identity and render an empty tree with no error).
+      # Dependabot cannot edit `pnpm.overrides`. It can only rewrite pnpm-lock.yaml's
+      # `overrides:` block, so every React bump it opens is one of two useless shapes:
+      # inert (bumps apps/*/package.json while the override silently overrules it, as in
+      # #593) or unmergeable (a lockfile-only override edit that aborts every install with
+      # ERR_PNPM_LOCKFILE_CONFIG_MISMATCH, as in #609 — which also failed the Vercel preview
+      # deployment). Suppress the family entirely; React moves when someone edits
+      # `pnpm.overrides` and regenerates the lockfile as one deliberate step (#441, #610).
+      # This does not freeze React contrary to ADR-0027 §5 — it suppresses a mechanism that
+      # is structurally incapable of moving it, and leaves the deliberate cadence intact.
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "react-test-renderer"

--- a/docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md
+++ b/docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md
@@ -13,6 +13,18 @@
 > Expo SDK again (`.github/dependabot.yml`). References to "RN 0.86" below reflect the state when this
 > ADR was written.
 
+> **Update (2026-08-19)**: Dependabot no longer proposes React bumps at all (`react`, `react-dom`,
+> `react-test-renderer` are in `.github/dependabot.yml`'s ignore list). React's version lives in the
+> root `package.json`'s `pnpm.overrides` — the mechanism that enforces the single shared instance
+> this ADR requires — and Dependabot cannot edit that key. It can only rewrite `pnpm-lock.yaml`'s
+> `overrides:` block, so its React PRs were either inert (bumping `apps/*/package.json` while the
+> override silently overruled them, #593) or unmergeable (a lockfile-only override edit that aborts
+> every install with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` and failed the Vercel preview deployment,
+> #609). This does **not** contradict decision 5 below: 5 forbids freezing React so it silently
+> rots, whereas this suppresses a mechanism structurally incapable of moving it correctly. The
+> deliberate coordinated bump — edit `pnpm.overrides`, regenerate the lockfile, verify — remains the
+> way React moves (#441, #610), and is still the prerequisite for adopting `react-native-macos@0.83`.
+
 ## Context
 
 The macOS desktop app builds on **`react-native-macos`** — Microsoft's macOS fork of React Native.


### PR DESCRIPTION
Follow-up to #610, which fixed the drift but not the mechanism that recreates it.

## The problem

React's version lives in the root `package.json`'s `pnpm.overrides` — the mechanism that forces the single shared React instance [ADR-0027](docs/adr/0027-desktop-react-version-locked-to-react-native-macos.md) / #558 require. **Dependabot cannot edit that key.** It can only rewrite `pnpm-lock.yaml`'s `overrides:` block, so every React PR it opens takes one of two useless shapes:

| shape | what happens | seen in |
|---|---|---|
| **inert** | bumps `apps/*/package.json` while the override silently overrules it — nothing actually moves | #593 |
| **unmergeable** | lockfile-only override edit; aborts every install with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` | #609 |

#609 is the one that generated the failed-preview-deployment email: it took down the Vercel preview *and* all six CI jobs, and could never have been fixed by rebasing or retrying.

Without this rule the exact same PR reappears on the next React patch release.

## The change

Ignore `react`, `react-dom`, `react-test-renderer` by **exact name** — deliberately *not* a `react*` wildcard, which would swallow the `react-native` family that has its own carefully tuned minor/major rules directly above in the same file.

## Why this doesn't contradict ADR-0027 §5

§5 says *"Do not freeze the rnm/React pair from Dependabot permanently; instead upgrade the pair deliberately, together."* That forbids freezing React so it **silently rots**. This suppresses a mechanism **structurally incapable of moving it correctly** — the deliberate cadence §5 asks for is exactly what remains:

> edit `pnpm.overrides` → regenerate the lockfile → verify

which is how React last moved in #441 and #610, and remains the prerequisite for adopting `react-native-macos@0.83`.

Recorded as a dated update note on ADR-0027 rather than a new ADR, matching how the RN-family ignore was recorded there in July. ADR body left otherwise untouched (append-only).

## Verification

| check | result |
|---|---|
| `dependabot.yml` parses | ✅ 14 ignore entries |
| no wildcard leakage into `react-native*` | ✅ exact names only |
| `pnpm format:check` | ✅ |
| scripts tests | ✅ 783/783 |

No code changes — config and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)